### PR TITLE
Add more extensive info for trying out urls in admin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -39,6 +39,7 @@ db-to-sqlite = "*"
 sqlite-utils = "*"
 google-cloud-storage = "*"
 sentry-sdk = "*"
+ipwhois = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "76bfe413af4d8805feeda7e0bda01a254fa70f4eac7431908214217379c82322"
+            "sha256": "54ac8529872d717af5a1bf0394b9cd371f186307828cb89e9f8f40941b402585"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -163,11 +163,11 @@
                 "bcrypt"
             ],
             "hashes": [
-                "sha256:65e2387e6bde531d3bb803244a2b74e0253550a9612c64a60c8c5be267b30f50",
-                "sha256:b51c9c548d5c3b3ccbb133d0bebc992e8ec3f14899bce8936e6fdda6b23a1881"
+                "sha256:69897097095f336d5aeef45b4103dceae51c00afa6d3ae198a2a18e519791b7a",
+                "sha256:6ecd229e1815d4fc5240fc98f1cca78c41e7a8cd3e3f2eefadc4735031077916"
             ],
             "index": "pypi",
-            "version": "==2.2.11"
+            "version": "==2.2.12"
         },
         "django-anymail": {
             "extras": [
@@ -244,6 +244,13 @@
             "index": "pypi",
             "version": "==1.0.3"
         },
+        "dnspython": {
+            "hashes": [
+                "sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01",
+                "sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d"
+            ],
+            "version": "==1.16.0"
+        },
         "google-api-core": {
             "hashes": [
                 "sha256:859f7392676761f2b160c6ee030c3422135ada4458f0948c5690a6a7c8d86294",
@@ -253,10 +260,10 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:4fddaf62bcfc3b9cc1bb2062130937a25ebe781b8eb15beec217c160b8cabb68",
-                "sha256:ec172006e626bb90f6069e9358c373bc991a15da6cc55276986d9ecd29235b15"
+                "sha256:016924388770b7e66c7e9ade1c4c3144ee88812d79697fd6c0dad9abdfcda2fd",
+                "sha256:01d686448f57d3bc027726474faa1aa650ba333bedb392e06938b0add8ec8d3a"
             ],
-            "version": "==1.11.3"
+            "version": "==1.12.0"
         },
         "google-cloud-core": {
             "hashes": [
@@ -300,6 +307,14 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "ipwhois": {
+            "hashes": [
+                "sha256:1f01f7cf4b4d667df6859e9f52d0971aac830d1e602946b4c02f477a393cb585",
+                "sha256:904efbd8d5fbb3319fc7e3aa33923fdd272bb81fd5a04bd56fd9125be6437a71"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
         },
         "mysqlclient": {
             "hashes": [
@@ -413,9 +428,10 @@
         },
         "tabulate": {
             "hashes": [
-                "sha256:5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8"
+                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
+                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
             ],
-            "version": "==0.8.6"
+            "version": "==0.8.7"
         },
         "urllib3": {
             "hashes": [
@@ -447,10 +463,10 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:3e4192eaec0758b99722f0b0666d5fbfaa713054d92e8de5b58ba84ec5ce696f",
-                "sha256:c8f49dd3b42edcc51d09dd2eea8a92b3cfc987ff7e6486be734b4d0cbfd5d315"
+                "sha256:8036f90603c54e93521e5777b2b9a39ba1bad05773fcf2d208f0299d1df58ce5",
+                "sha256:9ca8b952a0a9afa61d30aa6d3d9b570bb3fd6bafcf7ec9e6bed43b936133db1c"
             ],
-            "version": "==3.2.5"
+            "version": "==3.2.7"
         },
         "astroid": {
             "hashes": [
@@ -612,11 +628,11 @@
                 "bcrypt"
             ],
             "hashes": [
-                "sha256:65e2387e6bde531d3bb803244a2b74e0253550a9612c64a60c8c5be267b30f50",
-                "sha256:b51c9c548d5c3b3ccbb133d0bebc992e8ec3f14899bce8936e6fdda6b23a1881"
+                "sha256:69897097095f336d5aeef45b4103dceae51c00afa6d3ae198a2a18e519791b7a",
+                "sha256:6ecd229e1815d4fc5240fc98f1cca78c41e7a8cd3e3f2eefadc4735031077916"
             ],
             "index": "pypi",
-            "version": "==2.2.11"
+            "version": "==2.2.12"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -649,11 +665,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
-                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.5.0"
+            "version": "==1.6.0"
         },
         "ipdb": {
             "hashes": [
@@ -783,10 +799,10 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:859e1b205b6cf6a51fa57fa34202e45365cf58f8338f0ee9f4e84a4165b37d5b",
-                "sha256:ebe6b1b08c888b84c50d7f93dee21a09af39860144ff6130aadbd61ae8d29783"
+                "sha256:563d1a4140b63ff9dd587bda9557cffb2fe73650205ab6f4383092fb882e7dc8",
+                "sha256:df7e9e63aea609b1da3a65641ceaf5bc7d05e0a04de5bd45d05dbeffbabf9e04"
             ],
-            "version": "==3.0.4"
+            "version": "==3.0.5"
         },
         "ptyprocess": {
             "hashes": [
@@ -877,11 +893,11 @@
         },
         "pytest-django": {
             "hashes": [
-                "sha256:456fa6854d04ee625d6bbb8b38ca2259e7040a6f93333bfe8bc8159b7e987203",
-                "sha256:489b904f695f9fb880ce591cf5a4979880afb467763b1f180c07574554bdfd26"
+                "sha256:64f99d565dd9497af412fcab2989fe40982c1282d4118ff422b407f3f7275ca5",
+                "sha256:664e5f42242e5e182519388f01b9f25d824a9feb7cd17d8f863c8d776f38baf9"
             ],
             "index": "pypi",
-            "version": "==3.8.0"
+            "version": "==3.9.0"
         },
         "pytest-watch": {
             "hashes": [
@@ -913,9 +929,10 @@
         },
         "tabulate": {
             "hashes": [
-                "sha256:5470cc6687a091c7042cee89b2946d9235fe9f6d49c193a4ae2ac7bf386737c8"
+                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
+                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
             ],
-            "version": "==0.8.6"
+            "version": "==0.8.7"
         },
         "terminaltables": {
             "hashes": [
@@ -965,18 +982,18 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
-                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
+                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
             ],
-            "version": "==0.1.8"
+            "version": "==0.1.9"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
-                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.0.1"
         },
         "wrapt": {
             "hashes": [

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -1,37 +1,31 @@
+import json
 import re
-from urllib.parse import urlparse
 import socket
-from ipwhois import IPWhois
+from urllib.parse import urlparse
 
+import requests
+from django import forms
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.exceptions import ValidationError
-from django.urls import path
-from django.urls import reverse
-from django.shortcuts import render
 from django.core.validators import URLValidator
-
-
-import json
-
-import requests
-from requests.exceptions import HTTPError
-
+from django.shortcuts import render
+from django.urls import path, reverse
 from django.views.generic.edit import FormView
-from django import forms
+from ipwhois import IPWhois
+from requests.exceptions import HTTPError
 
 from apps.greencheck.views import GreenUrlsView
 
-
-URL_RE = re.compile(r'https?:\/\/(.*)')
-BASE_URL = 'https://api.thegreenwebfoundation.org/greencheck'
+URL_RE = re.compile(r"https?:\/\/(.*)")
+BASE_URL = "https://api.thegreenwebfoundation.org/greencheck"
 
 
 class CheckUrlForm(forms.Form):
     url = forms.URLField()
 
     def clean_url(self):
-        url = self.cleaned_data['url']
+        url = self.cleaned_data["url"]
         url_check = URLValidator()
         # if this is valid, nothing should be raised
         url_check(url)
@@ -39,39 +33,37 @@ class CheckUrlForm(forms.Form):
 
 
 class CheckUrlView(FormView):
-    template_name = 'try_out.html'
+    template_name = "try_out.html"
     form_class = CheckUrlForm
-    success_url = '/not/used'
+    success_url = "/not/used"
 
     def greencheck(self, domain):
-        resp = requests.get(f'{BASE_URL}/{domain}')
+        resp = requests.get(f"{BASE_URL}/{domain}")
         resp.raise_for_status()
         return resp.json()
 
     def whois_check(self, domain):
         ip_address = socket.gethostbyname(domain)
-
         obj = IPWhois(ip_address)
         return obj.lookup_rdap(depth=1)
-        # import ipdb ; ipdb.set_trace()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['form_url'] = reverse('admin:check_url')
+        context["form_url"] = reverse("admin:check_url")
         return context
 
     def form_valid(self, form):
-        url = form.data.get('url')
+        url = form.data.get("url")
         domain = urlparse(url).netloc
 
         greencheck = self.greencheck(domain)
         whois_check = self.whois_check(domain)
-        green = greencheck.get('green')
+        green = greencheck.get("green")
         context = self.get_context_data()
 
-        context['green_status'] = 'green' if green else 'gray'
-        context['whois_check'] = whois_check
-        context['greencheck'] = greencheck
+        context["green_status"] = "green" if green else "gray"
+        context["whois_check"] = whois_check
+        context["greencheck"] = greencheck
 
         return render(self.request, self.template_name, context)
 
@@ -79,11 +71,11 @@ class CheckUrlView(FormView):
 class GreenWebAdmin(AdminSite):
     # This is a standard authentication form that allows non-staff users
     login_form = AuthenticationForm
-    index_template = 'admin_index.html'
-    site_header = 'The Green Web Foundation Administration Site'
-    index_title = 'The Green Web Foundation Administration Site'
-    login_template = 'login.html'
-    logout_template = 'logout.html'
+    index_template = "admin_index.html"
+    site_header = "The Green Web Foundation Administration Site"
+    index_title = "The Green Web Foundation Administration Site"
+    login_template = "login.html"
+    logout_template = "logout.html"
 
     def has_permission(self, request):
         """
@@ -95,8 +87,8 @@ class GreenWebAdmin(AdminSite):
     def get_urls(self):
         urls = super().get_urls()
         patterns = [
-            path('try_out/', CheckUrlView.as_view(), name='check_url'),
-            path('green-urls', GreenUrlsView.as_view(), name='green_urls'),
+            path("try_out/", CheckUrlView.as_view(), name="check_url"),
+            path("green-urls", GreenUrlsView.as_view(), name="green_urls"),
         ]
         return patterns + urls
 
@@ -106,12 +98,12 @@ class GreenWebAdmin(AdminSite):
             {
                 "name": "Try out greencheck",
                 "app_label": "greencheck",
-                "app_url": reverse('admin:check_url'),
+                "app_url": reverse("admin:check_url"),
                 "models": [
                     {
                         "name": "Try out a url",
                         "object_name": "greencheck_url",
-                        "admin_url": reverse('admin:check_url'),
+                        "admin_url": reverse("admin:check_url"),
                         "view_only": True,
                     }
                 ],
@@ -119,18 +111,18 @@ class GreenWebAdmin(AdminSite):
             {
                 "name": "Download data dump",
                 "app_label": "greencheck",
-                "app_url": reverse('admin:check_url'),
+                "app_url": reverse("admin:check_url"),
                 "models": [
                     {
                         "name": "Download data dump",
                         "object_name": "greencheck_url",
-                        "admin_url": reverse('admin:green_urls'),
+                        "admin_url": reverse("admin:green_urls"),
                         "view_only": True,
                     }
                 ],
-            }
+            },
         ]
         return app_list
 
 
-greenweb_admin = GreenWebAdmin(name='greenweb_admin')
+greenweb_admin = GreenWebAdmin(name="greenweb_admin")

--- a/apps/accounts/test_tryout_view.py
+++ b/apps/accounts/test_tryout_view.py
@@ -1,0 +1,31 @@
+import pytest
+import ipaddress
+import json
+from django.urls import reverse
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.django_db
+class TestTryout:
+
+    @pytest.mark.only
+    def test_tryout_performs_lookup(self, client, hosting_user):
+        """
+        Check that we use the provided library lookup the IP address
+        for the provided url, and use ipwhois to fetch info
+        """
+        res = client.force_login(hosting_user)
+        res2 = client.get(reverse('admin:check_url'))
+
+        res3 = client.post(reverse('admin:check_url'), {
+                "url": "http://thegreenwebfoundation.org"
+        })
+        logger.info(f"greencheck: {res3.context.get('greencheck')}")
+        logger.info(f"whois_check: {res3.context.get('whois_check')}")
+
+        whois_check = res3.context.get('whois_check')
+
+        assert 'green_status' in res3.context
+        assert whois_check

--- a/apps/accounts/tests.py
+++ b/apps/accounts/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/apps/greencheck/tests.py
+++ b/apps/greencheck/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,24 @@ import pytest
 
 from apps.accounts.models import Hostingprovider
 from apps.greencheck.models import GreencheckIp
+from apps.accounts.models import User
+
+
+@pytest.fixture
+def hosting_user(hosting_provider):
+
+    hosting_provider.save()
+
+    user = User(
+        username='joe_bloggs',
+        email='joe.bloggs@greening.digital',
+        # for tests to pass, we NEED a hosting provider
+        # this can't be right.
+        hostingprovider=hosting_provider
+    )
+    user.save()
+
+    return user
 
 
 @pytest.fixture

--- a/greenweb/settings/testing.py
+++ b/greenweb/settings/testing.py
@@ -1,5 +1,19 @@
 import socket
 from .common import * # noqa
 
+import logging
+
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+logger = logging.getLogger(__name__)
+
 INTERNAL_IPS = ['127.0.0.1']
 ALLOWED_HOSTS.extend(['127.0.0.1', 'localhost'])
+
+
+# In testing, using whitenoise here doesn't really help us, so we
+# switch back to the default instead.
+# This is recommended by Django maintainers, and referred to in
+# the whitenoise docs
+# https://docs.djangoproject.com/en/3.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=greenweb.settings.testing
-addopts = --reuse-db --nomigrations --maxfail=1 --cov=apps
+addopts = --reuse-db --nomigrations --maxfail=1
+addopts = --reuse-db --nomigrations --maxfail=1 --cov=apps --ds=greenweb.settings.testing
 python_files = tests.py test_*.py *_tests.py
 markers =
     only: "Convenience method, so we can run a focussed test in pytest-watch"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-addopts = --reuse-db --nomigrations --maxfail=1
 addopts = --reuse-db --nomigrations --maxfail=1 --cov=apps --ds=greenweb.settings.testing
 python_files = tests.py test_*.py *_tests.py
 markers =


### PR DESCRIPTION
This PR addresses #66, introducing similar functionality to the url tryout feature on the older admin view.

### TODO

- [x] show full info returned from API request, including hosting org and last check
- [x] present whois info for a given domain for troubleshooting
- [x] refactor existing form to avoid making multiple requests to the TGWF API on a single page load
- [ ] _maybe_ incorporate green trace 'hops' view when looking up a domain

