### PR TITLE
Ca add migrate cmd

### DIFF
--- a/ansible/inventories/prod
+++ b/ansible/inventories/prod
@@ -1,2 +1,2 @@
 [prod]
-thegreenwebfoundation.org project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" tgwf_stage="prod" tgwf_domain_name=admin gunicorn_port=9002
+server.thegreenwebfoundation.org project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" tgwf_stage="prod" tgwf_domain_name=admin gunicorn_port=9002

--- a/ansible/inventories/staging
+++ b/ansible/inventories/staging
@@ -1,2 +1,2 @@
 [staging]
-thegreenwebfoundation.org tgwf_stage="staging" tgwf_domain_name=staging-admin project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" gunicorn_port=9003
+server.thegreenwebfoundation.org tgwf_stage="staging" tgwf_domain_name=staging-admin project_root="/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org" gunicorn_port=9003

--- a/ansible/migrate.yml
+++ b/ansible/migrate.yml
@@ -1,0 +1,12 @@
+---
+  - name: Deploy the TGWF django admin
+    hosts:
+      - all
+    remote_user: "deploy"
+    become: no
+
+    tasks:
+      - name: run migration
+        shell: "pipenv run ./manage.py migrate"
+        args:
+          chdir: "{{ project_root }}/current"

--- a/apps/accounts/models/test_models.py
+++ b/apps/accounts/models/test_models.py
@@ -3,6 +3,8 @@ import pytest
 from apps.accounts.models import Datacenter
 from apps.accounts.models.choices import ModelType
 
+# TODO these hit the database, when they probably don't need to, and this will make tests slow. If we can test that these objects are valid another way we should - maybe checking at the field level, or form level.
+
 class TestDatacenter:
 
     @pytest.mark.parametrize("accounting_model", ("groeneenergie","mixed","compensatie",))
@@ -24,8 +26,6 @@ class TestHostingProvider:
     @pytest.mark.parametrize("accounting_model", ("groeneenergie","mixed","compensatie",))
     def test_accepted_ways_to_model(self, datacenter, db, sample_hoster_user, accounting_model, hosting_provider):
 
-
-        # import ipdb ; ipdb.set_trace()
         hosting_provider.save()
         sample_hoster_user.hostingprovider = hosting_provider
         sample_hoster_user.save()


### PR DESCRIPTION
This adds a migration command with ansible, to avoid the need to sign in to run this management task in future.

Since adding the extra caching layer, it also adds the new server names