### PR TITLE
Add release command for make file

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,9 @@
+
+## Installing
+release:
+	sentry-cli releases new -p admin-portal $(shell sentry-cli releases propose-version)
+	sentry-cli releases set-commits --auto $(shell sentry-cli releases propose-version)
+	ansible-playbook ansible/deploy.yml -i ansible/inventories/prod
+	sentry-cli releases finalize $(shell sentry-cli releases propose-version)
+
+.PHONY: release


### PR DESCRIPTION
This PR introduces release tracking, using sentry's CLI, so we can better tell when releases introduce issues and bugs, and alternatively when they fix them

https://docs.sentry.io/cli/