### PR TITLE
Remove timezone awareness in admin

### DIFF
--- a/apps/accounts/filters.py
+++ b/apps/accounts/filters.py
@@ -1,7 +1,6 @@
 from django.contrib.admin import SimpleListFilter
 from django_countries.data import COUNTRIES
 from datetime import datetime
-from django.utils import timezone
 
 class YearFilterMixin():
 
@@ -20,9 +19,12 @@ class YearFilterMixin():
         """
 
         year = int(year)
-        tz = timezone.get_current_timezone()
-        start_at = datetime(year=year, month=1, day=1, tzinfo=tz)
-        end_at = datetime(year=year+1, month=1, day=1, tzinfo=tz)
+        # TODO: while we use MySQL and the TIMESTAMP column we
+        # can't use timezone aware dates. Put this back in when
+        # we switch to columns or database tech
+        # tz = timezone.get_current_timezone()
+        start_at = datetime(year=year, month=1, day=1)
+        end_at = datetime(year=year+1, month=1, day=1)
 
         return (start_at, end_at)
 

--- a/apps/accounts/models/user.py
+++ b/apps/accounts/models/user.py
@@ -1,10 +1,11 @@
+import datetime
+
 from django.contrib.auth.models import (
     AbstractBaseUser,
     UserManager,
     PermissionsMixin,
 )
 from django.db import models
-from django.utils import timezone
 from django.core.mail import send_mail
 
 from .hosting import Hostingprovider
@@ -54,7 +55,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             'Unselect this instead of deleting accounts.'
         ),
     )
-    date_joined = models.DateTimeField('date joined')
+    date_joined = models.DateTimeField('date joined', default= datetime.datetime.now)
     EMAIL_FIELD = 'email'
     USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ['email']

--- a/apps/accounts/models/user.py
+++ b/apps/accounts/models/user.py
@@ -54,7 +54,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             'Unselect this instead of deleting accounts.'
         ),
     )
-    date_joined = models.DateTimeField('date joined', default=timezone.now)
+    date_joined = models.DateTimeField('date joined')
     EMAIL_FIELD = 'email'
     USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ['email']

--- a/apps/greencheck/management/commands/update_top_url_list.py
+++ b/apps/greencheck/management/commands/update_top_url_list.py
@@ -3,7 +3,7 @@ from apps.greencheck.models import Greencheck, GreenPresenting, TopUrl, Hostingp
 
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.utils import timezone
+import datetime
 import warnings
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class TopUrlUpdater:
 
             # every 10000 domains processed, log the progress
             if count % 10_000 == 0:
-                now = timezone.now().strftime("%Y-%m-%d - %H-%M-%S")
+                now = datetime.datetime.now().strftime("%Y-%m-%d - %H-%M-%S")
                 logger.info(f"Processed: {count} domains so far. Time: {now}")
 
             try:

--- a/apps/greencheck/test_green_updater.py
+++ b/apps/greencheck/test_green_updater.py
@@ -1,6 +1,5 @@
 import pytest
 
-from django.utils import timezone
 from datetime import datetime
 from apps.greencheck.models import GreenPresenting, Greencheck, TopUrl, Hostingprovider, GreencheckIp
 from apps.greencheck.management.commands.update_top_url_list import TopUrlUpdater


### PR DESCRIPTION
This PR _removes_ timezone awareness, after discovering that because we're using TIMESTAMP in
a few places, and it's not compatible with timezone aware-mode, it's easier to make a change here, than change mahoosive tables. Check the docs here:

> #### TIMESTAMP columns
> 
> If you are using a legacy database that contains TIMESTAMP columns, you must set [USE\_TZ = False](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-USE_TZ) to avoid data corruption. [inspectdb](https://docs.djangoproject.com/en/3.1/ref/django-admin/#django-admin-inspectdb) maps these columns to [DateTimeField](https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.DateTimeField "django.db.models.DateTimeField") and if you enable timezone support, both MySQL and Django will attempt to convert the values from UTC to local time.

Source: [Databases | Django documentation | Django](https://docs.djangoproject.com/en/3.1/ref/databases/#timestamp-columns)

It looks like it might be possible to change these tables later, but they're hundreds of gigabytes in size, so as nasty as it sounds, making this change here feels like the less bad option than exposing users to errors when updating the directory info.
