### PR TITLE
WIP - Update our delete function, and tidy up admin view

### DIFF
--- a/apps/greencheck/serializers.py
+++ b/apps/greencheck/serializers.py
@@ -34,11 +34,23 @@ class IPDecimalField(serializers.DecimalField):
 
 
 class UserFilteredPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
+    """
+    A subclass of the normal PrimaryKeyRelatedField, that restricts choices to
+    entities that have a relation back to the authenticated user.
+    """
+
     def get_queryset(self):
+        """
+        This override restricts the possible options we show in an API
+        documentation to just the hostingproviders that are related
+        to the user. We want every IP range to correspond to a hosting
+        provider, but we also want an authenticated user to only be able
+        to update their own provider via the API.
+        """
         request = self.context.get("request", None)
         queryset = super(UserFilteredPrimaryKeyRelatedField, self).get_queryset()
-        if not request or not queryset:
-            return None
+        if not request:
+            return queryset
         return queryset.filter(user=request.user)
 
 

--- a/apps/greencheck/test_api.py
+++ b/apps/greencheck/test_api.py
@@ -106,7 +106,6 @@ class TestIpRangeViewSetList:
         assert ip_range["ip_start"] == green_ip.ip_start
         assert ip_range["ip_end"] == green_ip.ip_end
         assert ip_range["hostingprovider"] == green_ip.hostingprovider.id
-        assert ip_range["active"] == green_ip.active
 
     def test_get_ip_ranges_for_hostingprovider_with_no_active_ones(
         self,
@@ -208,7 +207,6 @@ class TestIpRangeViewSetRetrieve:
         assert response.data["ip_start"] == green_ip.ip_start
         assert response.data["ip_end"] == green_ip.ip_end
         assert response.data["hostingprovider"] == green_ip.hostingprovider.id
-        assert response.data["active"] == green_ip.active
 
 
 class TestIpRangeViewSetCreate:

--- a/apps/greencheck/test_api.py
+++ b/apps/greencheck/test_api.py
@@ -108,6 +108,30 @@ class TestIpRangeViewSetList:
         assert ip_range["hostingprovider"] == green_ip.hostingprovider.id
         assert ip_range["active"] == green_ip.active
 
+    def test_get_ip_ranges_for_hostingprovider_with_no_active_ones(
+        self,
+        hosting_provider: Hostingprovider,
+        sample_hoster_user: User,
+        green_ip: GreencheckIp,
+    ):
+        hosting_provider.save()
+        sample_hoster_user.hostingprovider = hosting_provider
+        sample_hoster_user.save()
+
+        green_ip.active = False
+        green_ip.save()
+
+        rf = APIRequestFactory()
+        url_path = reverse("ip-range-list")
+        request = rf.get(url_path)
+        request.user = sample_hoster_user
+
+        # GET end point for IP Ranges
+        view = IPRangeViewSet.as_view({"get": "list"})
+        response = view(request)
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
     def test_get_ip_ranges_without_auth(
         self, hosting_provider: Hostingprovider, sample_hoster_user: User,
     ):

--- a/apps/greencheck/test_serializers.py
+++ b/apps/greencheck/test_serializers.py
@@ -94,14 +94,12 @@ class TestGreenIpRangeSerialiser:
             "hostingprovider": hosting_provider.id,
             "ip_start": str(ip_addy_start),
             "ip_end": str(ip_addy_end),
-            "active": True,
         }
 
         gipr = GreenIPRangeSerializer(data=sample_json)
         gipr.is_valid()
         data = gipr.save()
 
-        assert data.active == True
         assert data.ip_start == ipaddress.ip_address(ip_addy_start)
         assert data.ip_end == ipaddress.ip_address(ip_addy_end)
         assert data.hostingprovider == hosting_provider
@@ -132,7 +130,6 @@ class TestGreenIpRangeSerialiser:
             "hostingprovider": hosting_provider.id,
             "ip_start": str(ip_addy_start),
             "ip_end": str(ip_addy_end),
-            "active": True,
         }
 
         gipr = GreenIPRangeSerializer(data=sample_json)

--- a/apps/greencheck/test_serializers.py
+++ b/apps/greencheck/test_serializers.py
@@ -46,10 +46,9 @@ class TestGreenIpRangeSerialiser:
         data = gipr.data
         keys = data.keys()
 
-        for key in ["active", "ip_start", "ip_end", "hostingprovider"]:
+        for key in ["ip_start", "ip_end", "hostingprovider"]:
             assert key in keys
 
-        assert data["active"] == True
         assert data["ip_start"] == str(ip_addy_start)
         assert data["ip_end"] == str(ip_addy_end)
         assert data["hostingprovider"] == hosting_provider.id
@@ -74,10 +73,9 @@ class TestGreenIpRangeSerialiser:
         data = gipr.data
         keys = data.keys()
 
-        for key in ["active", "ip_start", "ip_end", "hostingprovider"]:
+        for key in ["ip_start", "ip_end", "hostingprovider"]:
             assert key in keys
 
-        assert data["active"] == True
         assert data["ip_start"] == str(ip_addy_start)
         assert data["ip_end"] == str(ip_addy_end)
         assert data["hostingprovider"] == hosting_provider.id

--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -40,3 +40,12 @@ class IPRangeViewSet(viewsets.ModelViewSet):
                 return provider.greencheckip_set.all()
 
         return []
+
+    def perform_destroy(self, instance):
+        """
+        Overriding this one function means that the rest of
+        our destroy method works as expected.
+        """
+        instance.active = False
+        instance.save()
+

--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -37,7 +37,7 @@ class IPRangeViewSet(viewsets.ModelViewSet):
             provider = self.request.user.hostingprovider
 
             if provider is not None:
-                return provider.greencheckip_set.all()
+                return provider.greencheckip_set.filter(active=True)
 
         return []
 


### PR DESCRIPTION
This PR introduces the following changes:

- we filter the logged in API view now, to only allow IP ranges to be added to hosting providers a user belongs so.
- we have tests that check that our delete function sets an ip range to inactive, but does not delete them (we do this so we can relate historical greenchecks to IP ranges that used to belong to a given hosting provider at the time)
- we remove the `active` property from the API, as it's for internal use.