### PR TITLE
Add notifcation support for when new IP Ranges and ASNs are added by member users

### DIFF
--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -116,7 +116,8 @@ class Hostingprovider(models.Model):
         doesn't already have outstanding approvals, notify admins
         to review the IP Range or AS network.
         """
-        logger.info(f"Approval request: {approval_request}")
+        hosting_provider = approval_request.hostingprovider
+        logger.debug(f"Approval request: {approval_request} for {hosting_provider}")
 
         if self.needs_review(approval_request):
             return self.flag_for_review(approval_request)
@@ -127,13 +128,20 @@ class Hostingprovider(models.Model):
         from partners to review, and returns either True if so, or
         false if not.
         """
-        approval_requests = self.greencheckasnapprove_set.filter(status="new")
+        outstanding_asn_approval_reqs = self.greencheckasnapprove_set.filter(
+            status="new"
+        )
+        outstanding_ip_range_approval_reqs = self.greencheckipapprove_set.filter(
+            status="new"
+        )
+        # use list() to evalute the queryset to a datastructure that
+        # we can concatenate easily
+        approval_requests = list(outstanding_asn_approval_reqs) + list(
+            outstanding_ip_range_approval_reqs
+        )
 
         # if the provided approval new, and not seen before?
         # return true if so, otherwise assume this is not new
-        # import ipdb
-
-        # ipdb.set_trace()
         if approval_request is None:
             return False
 

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -17,6 +17,10 @@ from .choices import (
     ClassificationChoice,
     CoolingChoice,
 )
+from apps.greencheck.choices import (
+    StatusApproval,
+    ActionChoice,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,10 +133,10 @@ class Hostingprovider(models.Model):
         false if not.
         """
         outstanding_asn_approval_reqs = self.greencheckasnapprove_set.filter(
-            status="new"
+            status__in=[StatusApproval.new, StatusApproval.update]
         )
         outstanding_ip_range_approval_reqs = self.greencheckipapprove_set.filter(
-            status="new"
+            status__in=[StatusApproval.new, StatusApproval.update]
         )
         # use list() to evalute the queryset to a datastructure that
         # we can concatenate easily

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -248,6 +248,12 @@ class GreencheckASN(TimeStampedModel):
 
 
 class GreencheckASNapprove(TimeStampedModel):
+    """
+    A greencheck ASN approve is a request, to register an AS Network
+    with a given hosting provider. Once approved, associates the AS
+    with the provider.
+    """
+
     action = models.TextField(choices=ActionChoice.choices)
     asn = models.IntegerField()
     hostingprovider = models.ForeignKey(
@@ -263,7 +269,7 @@ class GreencheckASNapprove(TimeStampedModel):
         verbose_name = "Greencheck ASN Submissions"
 
     def __str__(self):
-        return f"Status: {self.status} Action: {self.action}"
+        return f"ASN: {self.asn} - Status: {self.status} Action: {self.action}"
 
 
 # class Tld(models.Model):

--- a/apps/greencheck/templates/flag_for_review_text.html
+++ b/apps/greencheck/templates/flag_for_review_text.html
@@ -1,0 +1,11 @@
+<p>Hello there.</p>
+
+<p>{{ provider }} has just updated their organisation profile. It is now awaiting review from staff.<p>
+
+<p>In need of review:</p>
+
+<p>- <a href="{{ link_url }}">{{ approval_request }}</a></p>
+
+<p>You can update this at the link below:</p>
+
+<p><a href="{{ link_url }}">{{ link_url }}</a></p>

--- a/apps/greencheck/templates/flag_for_review_text.txt
+++ b/apps/greencheck/templates/flag_for_review_text.txt
@@ -1,0 +1,11 @@
+Hello there.
+
+{{ provider  }} has just updated their organisation profile is now awaiting review from staff.
+
+In need of review:
+
+- {{ approval_request }}
+
+You can update this at:
+
+{% url 'greenweb_admin:accounts_hostingprovider_change' provider.id %}

--- a/apps/greencheck/templates/flag_for_review_text.txt
+++ b/apps/greencheck/templates/flag_for_review_text.txt
@@ -6,6 +6,6 @@ In need of review:
 
 - {{ approval_request }}
 
-You can update this at:
+You can update this at the link below
 
-{% url 'greenweb_admin:accounts_hostingprovider_change' provider.id %}
+{{ link_url }}

--- a/apps/greencheck/tests/test_models.py
+++ b/apps/greencheck/tests/test_models.py
@@ -2,16 +2,119 @@ import pytest
 
 import ipaddress
 
-from apps.greencheck.models import GreencheckIp
+from apps.greencheck import models
+from apps.greencheck import forms
+from apps.greencheck import choices
+
+
+@pytest.fixture
+def green_asn_approval_request(hosting_provider_with_sample_user):
+    hosting_provider = hosting_provider_with_sample_user
+    return models.GreencheckASNapprove(
+        action=choices.ActionChoice.new,
+        status=choices.ActionChoice.new,
+        hostingprovider=hosting_provider,
+        asn=12345,
+    )
 
 
 class TestGreenCheckIP:
     def test_greencheckip_has_start_and_end(self, hosting_provider, db):
         hosting_provider.save()
-        gcip = GreencheckIp.objects.create(
+        gcip = models.GreencheckIp.objects.create(
             active=True,
             ip_start="127.0.0.1",
             ip_end="120.0.0.1",
             hostingprovider=hosting_provider,
         )
         gcip.save()
+
+
+class TestHostingProviderASNApprovalNeedsReview:
+    """
+    We want to know when a hosting provider has an outstanding ASN that needs review.
+    """
+
+    def test_hosting_provider_is_pending_with_new_ASN(
+        self, db, hosting_provider_with_sample_user, green_asn_approval_request
+    ):
+        """
+        When a hosting provider has a ASN approval waiting a response,
+        a hosting provider should count as in a 'needs review' state.
+        """
+
+        # when we pass nothing in we expect a false response
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        # we call this with the new request before persisting it
+        # to database. this simulates its use in forms or serailisers
+        assert hosting_provider_with_sample_user.needs_review(
+            green_asn_approval_request
+        )
+
+        # once a request has been persisted, we still want future `needs_review
+        # checks to count as True.
+        green_asn_approval_request.save()
+        assert hosting_provider_with_sample_user.needs_review()
+
+
+class TestHostingProviderSendsNotification:
+    def test_hosting_provider_notifications_sent_when_review_needed(
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_asn_approval_request,
+        mailoutbox,
+    ):
+        """
+        When a hosting provider counts as in need of review, we only want to send an email
+        if we are tranisitioning from a state of having no claims to review to having claims to review.
+        We do this, because we don't want to deluge admins with unnecessary notifications.
+        """
+
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_asn_approval_request
+        )
+
+        assert len(mailoutbox) == 1
+
+        msg, *_ = mailoutbox
+        assert hosting_provider_with_sample_user.name in msg.subject
+
+    def test_hosting_provider_does_not_send_duplicate_notifications(
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_asn_approval_request,
+        mailoutbox,
+    ):
+        """
+            When a hosting provider counts as in need of review, we only want to send
+            an email if we are tranisitioning from a state of having no claims
+            to review, to a state of having claims to review.
+            We do this because we don't want to deluge admins with unnecessary
+            notifications.
+            """
+
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_asn_approval_request
+        )
+
+        # after a successful API or form submission, we save the approval request
+        # so save it here to represent it
+        green_asn_approval_request.save()
+
+        # call this again, to simulate multiple claims being made
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_asn_approval_request
+        )
+
+        assert len(mailoutbox) == 1
+
+        msg, *_ = mailoutbox
+        assert hosting_provider_with_sample_user.name in msg.subject
+

--- a/apps/greencheck/tests/test_models.py
+++ b/apps/greencheck/tests/test_models.py
@@ -8,6 +8,17 @@ from apps.greencheck import choices
 
 
 @pytest.fixture
+def green_ip_range_approval_request(green_ip):
+    return models.GreencheckIpApprove(
+        action=choices.ActionChoice.new,
+        status=choices.ActionChoice.new,
+        hostingprovider=green_ip.hostingprovider,
+        ip_end=green_ip.ip_end,
+        ip_start=green_ip.ip_start,
+    )
+
+
+@pytest.fixture
 def green_asn_approval_request(hosting_provider_with_sample_user):
     hosting_provider = hosting_provider_with_sample_user
     return models.GreencheckASNapprove(
@@ -57,9 +68,27 @@ class TestHostingProviderASNApprovalNeedsReview:
         green_asn_approval_request.save()
         assert hosting_provider_with_sample_user.needs_review()
 
+    def test_hosting_provider_is_pending_with_new_IRange(
+        self, db, hosting_provider_with_sample_user, green_ip_range_approval_request
+    ):
+
+        # when we pass nothing in we expect a false response
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        # we call this with the new request before persisting it
+        # to database. this simulates its use in forms or serailisers
+        assert hosting_provider_with_sample_user.needs_review(
+            green_ip_range_approval_request
+        )
+
+        # once a request has been persisted, we still want future `needs_review
+        # checks to count as True.
+        green_ip_range_approval_request.save()
+        assert hosting_provider_with_sample_user.needs_review()
+
 
 class TestHostingProviderSendsNotification:
-    def test_hosting_provider_notifications_sent_when_review_needed(
+    def test_hosting_provider_notifications_sent_when_review_needed_for_asn(
         self,
         db,
         hosting_provider_with_sample_user,
@@ -67,9 +96,11 @@ class TestHostingProviderSendsNotification:
         mailoutbox,
     ):
         """
-        When a hosting provider counts as in need of review, we only want to send an email
-        if we are tranisitioning from a state of having no claims to review to having claims to review.
-        We do this, because we don't want to deluge admins with unnecessary notifications.
+        When a hosting provider counts as in need of review, we only want to send an
+        email if we are tranisitioning from a state of having no claims to
+        review to having claims to review.
+        We do this, because we don't want to deluge admins with unnecessary
+        notifications.
         """
 
         assert not hosting_provider_with_sample_user.needs_review()
@@ -83,7 +114,29 @@ class TestHostingProviderSendsNotification:
         msg, *_ = mailoutbox
         assert hosting_provider_with_sample_user.name in msg.subject
 
-    def test_hosting_provider_does_not_send_duplicate_notifications(
+    def test_hosting_provider_notifications_sent_when_review_needed_for_ip_range(
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_ip_range_approval_request,
+        mailoutbox,
+    ):
+        """
+        As above, but with an IP Range. We can't pass fixtures in as parameters in tests
+        """
+
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_ip_range_approval_request
+        )
+
+        assert len(mailoutbox) == 1
+
+        msg, *_ = mailoutbox
+        assert hosting_provider_with_sample_user.name in msg.subject
+
+    def test_hosting_provider_does_not_send_duplicate_notifications_for_asn(
         self,
         db,
         hosting_provider_with_sample_user,
@@ -111,6 +164,41 @@ class TestHostingProviderSendsNotification:
         # call this again, to simulate multiple claims being made
         hosting_provider_with_sample_user.mark_as_pending_review(
             green_asn_approval_request
+        )
+
+        assert len(mailoutbox) == 1
+
+        msg, *_ = mailoutbox
+        assert hosting_provider_with_sample_user.name in msg.subject
+
+    def test_hosting_provider_does_not_send_duplicate_notifications_for_ip_range(
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_ip_range_approval_request,
+        mailoutbox,
+    ):
+        """
+            When a hosting provider counts as in need of review, we only want to send
+            an email if we are tranisitioning from a state of having no claims
+            to review, to a state of having claims to review.
+            We do this because we don't want to deluge admins with unnecessary
+            notifications.
+            """
+
+        assert not hosting_provider_with_sample_user.needs_review()
+
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_ip_range_approval_request
+        )
+
+        # after a successful API or form submission, we save the approval request
+        # so save it here to represent it
+        green_ip_range_approval_request.save()
+
+        # call this again, to simulate multiple claims being made
+        hosting_provider_with_sample_user.mark_as_pending_review(
+            green_ip_range_approval_request
         )
 
         assert len(mailoutbox) == 1

--- a/apps/greencheck/tests/test_models.py
+++ b/apps/greencheck/tests/test_models.py
@@ -46,13 +46,29 @@ class TestHostingProviderASNApprovalNeedsReview:
     We want to know when a hosting provider has an outstanding ASN that needs review.
     """
 
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_is_pending_with_new_ASN(
-        self, db, hosting_provider_with_sample_user, green_asn_approval_request
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_asn_approval_request,
+        status,
+        action,
     ):
         """
         When a hosting provider has a ASN approval waiting a response,
         a hosting provider should count as in a 'needs review' state.
         """
+        green_asn_approval_request.status = status
+        green_asn_approval_request.action = action
 
         # when we pass nothing in we expect a false response
         assert not hosting_provider_with_sample_user.needs_review()
@@ -68,10 +84,25 @@ class TestHostingProviderASNApprovalNeedsReview:
         green_asn_approval_request.save()
         assert hosting_provider_with_sample_user.needs_review()
 
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_is_pending_with_new_IRange(
-        self, db, hosting_provider_with_sample_user, green_ip_range_approval_request
+        self,
+        db,
+        hosting_provider_with_sample_user,
+        green_ip_range_approval_request,
+        status,
+        action,
     ):
-
+        green_ip_range_approval_request.status = status
+        green_ip_range_approval_request.action = action
         # when we pass nothing in we expect a false response
         assert not hosting_provider_with_sample_user.needs_review()
 
@@ -88,12 +119,23 @@ class TestHostingProviderASNApprovalNeedsReview:
 
 
 class TestHostingProviderSendsNotification:
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_notifications_sent_when_review_needed_for_asn(
         self,
         db,
         hosting_provider_with_sample_user,
         green_asn_approval_request,
         mailoutbox,
+        status,
+        action,
     ):
         """
         When a hosting provider counts as in need of review, we only want to send an
@@ -102,6 +144,8 @@ class TestHostingProviderSendsNotification:
         We do this, because we don't want to deluge admins with unnecessary
         notifications.
         """
+        green_asn_approval_request.status = status
+        green_asn_approval_request.action = action
 
         assert not hosting_provider_with_sample_user.needs_review()
 
@@ -114,16 +158,29 @@ class TestHostingProviderSendsNotification:
         msg, *_ = mailoutbox
         assert hosting_provider_with_sample_user.name in msg.subject
 
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_notifications_sent_when_review_needed_for_ip_range(
         self,
         db,
         hosting_provider_with_sample_user,
         green_ip_range_approval_request,
         mailoutbox,
+        status,
+        action,
     ):
         """
         As above, but with an IP Range. We can't pass fixtures in as parameters in tests
         """
+        green_ip_range_approval_request.status = status
+        green_ip_range_approval_request.action = action
 
         assert not hosting_provider_with_sample_user.needs_review()
 
@@ -136,12 +193,23 @@ class TestHostingProviderSendsNotification:
         msg, *_ = mailoutbox
         assert hosting_provider_with_sample_user.name in msg.subject
 
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_does_not_send_duplicate_notifications_for_asn(
         self,
         db,
         hosting_provider_with_sample_user,
         green_asn_approval_request,
         mailoutbox,
+        status,
+        action,
     ):
         """
             When a hosting provider counts as in need of review, we only want to send
@@ -149,7 +217,9 @@ class TestHostingProviderSendsNotification:
             to review, to a state of having claims to review.
             We do this because we don't want to deluge admins with unnecessary
             notifications.
-            """
+        """
+        green_asn_approval_request.status = status
+        green_asn_approval_request.action = action
 
         assert not hosting_provider_with_sample_user.needs_review()
 
@@ -171,12 +241,23 @@ class TestHostingProviderSendsNotification:
         msg, *_ = mailoutbox
         assert hosting_provider_with_sample_user.name in msg.subject
 
+    @pytest.mark.parametrize(
+        "action,status",
+        [
+            (choices.ActionChoice.new, choices.StatusApproval.new),
+            (choices.ActionChoice.update, choices.StatusApproval.update),
+            (choices.ActionChoice.new, choices.StatusApproval.update),
+            (choices.ActionChoice.update, choices.StatusApproval.new),
+        ],
+    )
     def test_hosting_provider_does_not_send_duplicate_notifications_for_ip_range(
         self,
         db,
         hosting_provider_with_sample_user,
         green_ip_range_approval_request,
         mailoutbox,
+        action,
+        status,
     ):
         """
             When a hosting provider counts as in need of review, we only want to send
@@ -186,6 +267,8 @@ class TestHostingProviderSendsNotification:
             notifications.
             """
 
+        green_ip_range_approval_request.status = status
+        green_ip_range_approval_request.action = action
         assert not hosting_provider_with_sample_user.needs_review()
 
         hosting_provider_with_sample_user.mark_as_pending_review(

--- a/apps/greencheck/tests/test_models.py
+++ b/apps/greencheck/tests/test_models.py
@@ -71,18 +71,22 @@ class TestHostingProviderASNApprovalNeedsReview:
         green_asn_approval_request.action = action
 
         # when we pass nothing in we expect a false response
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         # we call this with the new request before persisting it
-        # to database. this simulates its use in forms or serailisers
-        assert hosting_provider_with_sample_user.needs_review(
+        # to database. this simulates its use in forms or serialisers
+        assert hosting_provider_with_sample_user.mark_as_pending_review(
             green_asn_approval_request
         )
 
-        # once a request has been persisted, we still want future `needs_review
-        # checks to count as True.
+        # once a request has been persisted, we still want to be able to see if
+        # there are outstanding_approval_requests, even if we are no longer sending
+        # more notifications
         green_asn_approval_request.save()
-        assert hosting_provider_with_sample_user.needs_review()
+        assert hosting_provider_with_sample_user.outstanding_approval_requests()
+        assert not hosting_provider_with_sample_user.mark_as_pending_review(
+            green_asn_approval_request
+        )
 
     @pytest.mark.parametrize(
         "action,status",
@@ -93,7 +97,7 @@ class TestHostingProviderASNApprovalNeedsReview:
             (choices.ActionChoice.update, choices.StatusApproval.new),
         ],
     )
-    def test_hosting_provider_is_pending_with_new_IRange(
+    def test_hosting_provider_is_pending_with_new_ip_range(
         self,
         db,
         hosting_provider_with_sample_user,
@@ -104,18 +108,24 @@ class TestHostingProviderASNApprovalNeedsReview:
         green_ip_range_approval_request.status = status
         green_ip_range_approval_request.action = action
         # when we pass nothing in we expect a false response
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         # we call this with the new request before persisting it
         # to database. this simulates its use in forms or serailisers
-        assert hosting_provider_with_sample_user.needs_review(
+        assert hosting_provider_with_sample_user.mark_as_pending_review(
             green_ip_range_approval_request
         )
 
         # once a request has been persisted, we still want future `needs_review
         # checks to count as True.
+        # once a request has been persisted, we still want to be able to see if
+        # there are outstanding_approval_requests, even if we are no longer sending
+        # more notifications
         green_ip_range_approval_request.save()
-        assert hosting_provider_with_sample_user.needs_review()
+        assert hosting_provider_with_sample_user.outstanding_approval_requests()
+        assert not hosting_provider_with_sample_user.mark_as_pending_review(
+            green_ip_range_approval_request
+        )
 
 
 class TestHostingProviderSendsNotification:
@@ -147,7 +157,7 @@ class TestHostingProviderSendsNotification:
         green_asn_approval_request.status = status
         green_asn_approval_request.action = action
 
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         hosting_provider_with_sample_user.mark_as_pending_review(
             green_asn_approval_request
@@ -182,7 +192,7 @@ class TestHostingProviderSendsNotification:
         green_ip_range_approval_request.status = status
         green_ip_range_approval_request.action = action
 
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         hosting_provider_with_sample_user.mark_as_pending_review(
             green_ip_range_approval_request
@@ -221,7 +231,7 @@ class TestHostingProviderSendsNotification:
         green_asn_approval_request.status = status
         green_asn_approval_request.action = action
 
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         hosting_provider_with_sample_user.mark_as_pending_review(
             green_asn_approval_request
@@ -269,7 +279,7 @@ class TestHostingProviderSendsNotification:
 
         green_ip_range_approval_request.status = status
         green_ip_range_approval_request.action = action
-        assert not hosting_provider_with_sample_user.needs_review()
+        assert not hosting_provider_with_sample_user.outstanding_approval_requests()
 
         hosting_provider_with_sample_user.mark_as_pending_review(
             green_ip_range_approval_request

--- a/conftest.py
+++ b/conftest.py
@@ -72,6 +72,18 @@ def hosting_provider_aws():
 
 
 @pytest.fixture
+def hosting_provider_with_sample_user(hosting_provider, sample_hoster_user):
+    """
+    Return a hosting provider that's been persisted to the database,
+    and has a user associated with it
+    """
+    hosting_provider.save()
+    sample_hoster_user.hostingprovider = hosting_provider
+    sample_hoster_user.save()
+    return hosting_provider
+
+
+@pytest.fixture
 def datacenter():
 
     return Datacenter(

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -212,3 +212,5 @@ LOGGING = {
         }
     },
 }
+
+SITE_URL = "https://admin.thegreenwebfoundation.org"

--- a/greenweb/settings/development.py
+++ b/greenweb/settings/development.py
@@ -15,3 +15,9 @@ INSTALLED_APPS.insert(0, "whitenoise.runserver_nostatic")
 MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# mailhog
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "localhost"
+EMAIL_PORT = 1025
+SITE_URL = "http://localhost:9000"


### PR DESCRIPTION
This PR introduces a notification system, in which emails are send to a support address when members update IP range or ASNs relating to their hosting provider.

This should make it easier to respond to member requests quickly, when they come in. We have some basic logic to avoid sending duplicate alerts - once a hosting provider has outstanding IP range or ASN requests no further emails are sent.

We have a basic email template in text and html, but there is no real styling applied- just links back to the hosting provider are provided.
