### PR TITLE
Add multiple domain checking

### DIFF
--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -55,14 +55,23 @@ class GreenDomainViewset(viewsets.ReadOnlyModelViewSet):
         Our override for bulk URL lookups, like an index/listing view
         """
         queryset = []
-        urls = self.request.query_params.getlist("urls")
+        urls = None
+
+        get_url_params = self.request.query_params.getlist("urls")
+        if get_url_params:
+            urlstring, *_ = get_url_params
+            urls = urlstring.split(",")
 
         # check for a payload. this takes precedence, to support large requests
         if self.request.data.get("urls"):
-            urls = self.request.data.get("urls")
+            urls = self.request.data.getlist("urls")
 
         if urls is not None:
             queryset = GreenDomain.objects.filter(url__in=urls)
+
+        # import ipdb
+
+        # ipdb.set_trace()
 
         page = self.paginate_queryset(queryset)
         if page is not None:


### PR DESCRIPTION
This PR adds support for checking domains using a comma separated string, of the form a get param like `url=first.greendomain,second.greendomain.org,thirdgreen.co.uk`, or as a POST payload of the form:


```
[
  "first.greendomain",
  "second.greendomain.org",
  "thirdgreen.co.uk"
]
```

The idea here is to allow for simple GET requests like we do in the browser extension, but when we have a large list, we can send a json array of domains as a POST too.