### PR TITLE
Add nocache option, to avoid waiting for workers

### DIFF
--- a/apps/greencheck/api/legacy_image_view.py
+++ b/apps/greencheck/api/legacy_image_view.py
@@ -142,7 +142,7 @@ def legacy_greencheck_image(request, url):
     if request.GET.get("nocache") == "true":
         sitecheck = checker.perform_full_lookup(domain)
         if sitecheck.green:
-            green_domain = GreenDomain.from_sitecheck(sitecheck)
+            green_domain = GreenDomain.grey_result(sitecheck)
     else:
         green_domain = GreenDomain.objects.filter(url=domain).first()
 

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -399,18 +399,22 @@ class GreenDomain(models.Model):
         )
 
     @classmethod
-    def from_sitecheck(cls, domain):
+    def from_sitecheck(cls, sitecheck):
         """
         Return a grey domain with just the domain name added,
         the time of the and the rest empty.
         """
+        hosting_provider = None
+
+        hosting_provider = Hostingprovider.objects.get(pk=sitecheck.hosting_provider_id)
         return GreenDomain(
-            url=domain,
-            hosted_by=None,
-            hosted_by_id=None,
-            hosted_by_website=None,
-            partner=None,
+            url=sitecheck.url,
+            hosted_by=hosting_provider.name,
+            hosted_by_id=hosting_provider.id,
+            hosted_by_website=hosting_provider.website,
+            partner=hosting_provider.partner,
             modified=timezone.now(),
+            green=True,
         )
 
     class Meta:

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -8,6 +8,7 @@ from django_mysql.models import EnumField
 from django.core import exceptions
 from django.core import validators
 from django.utils.text import capfirst
+from django.utils import timezone
 from django.utils.functional import cached_property
 
 from model_utils.models import TimeStampedModel
@@ -380,6 +381,37 @@ class GreenDomain(models.Model):
 
     def __str__(self):
         return f"{self.url} - {self.modified}"
+
+    # Factories
+    @classmethod
+    def grey_result(cls, domain):
+        """
+        Return a grey domain with just the domain name added,
+        the time of the and the rest empty.
+        """
+        return GreenDomain(
+            url=domain,
+            hosted_by=None,
+            hosted_by_id=None,
+            hosted_by_website=None,
+            partner=None,
+            modified=timezone.now(),
+        )
+
+    @classmethod
+    def from_sitecheck(cls, domain):
+        """
+        Return a grey domain with just the domain name added,
+        the time of the and the rest empty.
+        """
+        return GreenDomain(
+            url=domain,
+            hosted_by=None,
+            hosted_by_id=None,
+            hosted_by_website=None,
+            partner=None,
+            modified=timezone.now(),
+        )
 
     class Meta:
         db_table = "greendomain"

--- a/apps/greencheck/tests/test_legacy_images.py
+++ b/apps/greencheck/tests/test_legacy_images.py
@@ -115,6 +115,31 @@ class TestGreencheckImageView:
 
         assert response.status_code == 200
 
+    def test_download_greencheck_image_green_nocache(
+        self,
+        db,
+        client,
+        hosting_provider_with_sample_user: Hostingprovider,
+        green_ip: GreencheckIp,
+    ):
+        """
+        Check we have support for 'nocache' - this gives us a slow check
+        in return for always returning the results from a network, rather than
+        checking any locally cached result in nginx, redis, or the database.
+        """
+
+        website = green_ip.ip_start
+        url_path = reverse("legacy-greencheck-image", args=[website])
+
+        response = client.get(url_path, {"nocache": "true"})
+
+        with open(f"{website}.png", "wb") as imgfile:
+            imgfile.write(response.content)
+
+        webbrowser.open(f"{website}.png")
+
+        assert response.status_code == 200
+
     @pytest.mark.skip
     def test_redirected_when_browsing_to_greencheck_image(
         self, db, client,

--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -107,6 +107,14 @@ class GreenDomainViewset(viewsets.ReadOnlyModelViewSet):
 
         instance = GreenDomain.objects.filter(url=domain).first()
 
+        # `nocache=true` is the same string used by nginx. Using the same params
+        # means we won't have to worry about nginx caching our request before it
+        # hits an app server
+        if request.GET.get("nocache") == "true":
+            sitecheck = checker.perform_full_lookup(domain)
+            if sitecheck.green:
+                instance = GreenDomain.from_sitecheck(sitecheck)
+
         if not instance:
             try:
                 instance = self.checker.perform_full_lookup(domain)


### PR DESCRIPTION
We have an async worker that updates the caches, because to cope with load, we try to fetch from caches where possible over doing an expensive network lookup.

Normally this works okay, and means we can keep up with load, but in some cases we _do_ want to run a full lookup.

This introduces a `nocache` param to use for images and end results.