### PR TITLE
Re-arrange workers, and add checks for common logger errors

### DIFF
--- a/apps/greencheck/legacy_workers.py
+++ b/apps/greencheck/legacy_workers.py
@@ -1,7 +1,9 @@
 import phpserialize
 
 from django.utils import dateparse
-from .workers import SiteCheck, SiteCheckLogger
+from .workers import SiteCheckLogger
+from .models import SiteCheck
+
 
 import logging
 

--- a/apps/greencheck/models.py
+++ b/apps/greencheck/models.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import decimal
 import ipaddress
 import logging
@@ -34,6 +35,25 @@ logger = logging.getLogger(__name__)
 # wait for reply on these.
 - greenenergy - also an old table
 """
+
+
+@dataclass
+class SiteCheck:
+    """
+    A representation of the Sitecheck object from the PHP app.
+    We use it as a basis for logging to the Greencheck, but also maintaining
+    our green_domains tables.
+    """
+
+    url: str
+    ip: str
+    data: bool
+    green: bool
+    hosting_provider_id: int
+    checked_at: str
+    match_type: str
+    match_ip_range: int
+    cached: bool
 
 
 class IpAddressField(Field):

--- a/apps/greencheck/tests/__init__.py
+++ b/apps/greencheck/tests/__init__.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 from typing import List
-from apps.greencheck.models import GreencheckIp, Hostingprovider, GreenDomain
-from apps.greencheck.legacy_workers import SiteCheck, LegacySiteCheckLogger
+from apps.greencheck.models import GreencheckIp, Hostingprovider, GreenDomain, SiteCheck
+from apps.greencheck.legacy_workers import LegacySiteCheckLogger
 
 
 def create_greendomain(hosting_provider, sitecheck):

--- a/apps/greencheck/tests/test_green_domain_dump.py
+++ b/apps/greencheck/tests/test_green_domain_dump.py
@@ -10,8 +10,7 @@ from django.core.management import call_command, CommandError
 from django.utils import timezone
 from sqlite_utils import Database
 
-from ..models import Hostingprovider
-from ..legacy_workers import SiteCheck
+from ..models import Hostingprovider, SiteCheck
 from ..management.commands.dump_green_domains import GreenDomainExporter
 from ..models import GreencheckIp
 


### PR DESCRIPTION
This PR addresses two main causes of errors brought by our worker processes - when an api call to look up the 'localhost' domain is sent, and when we see a domain that points to an IP address that can't be resolved to a AS number using the Cymru IP to ASN service.