### PR TITLE
Catch domain submissions that trigger UnicodeError

### DIFF
--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -134,12 +134,16 @@ class GreenDomainViewset(viewsets.ReadOnlyModelViewSet):
             except socket.gaierror:
                 process_log.send(domain)
                 return self.legacy_grey_response(domain)
+            except UnicodeError:
+                return self.legacy_grey_response(domain)
 
         if not instance:
             try:
                 instance = self.checker.perform_full_lookup(domain)
             except socket.gaierror:
                 process_log.send(domain)
+                return self.legacy_grey_response(domain)
+            except UnicodeError:
                 return self.legacy_grey_response(domain)
 
         # log_the_check asynchronously


### PR DESCRIPTION
We're getting some bad domain submissions that trigger a 500.

This catches the common errors, serving a non 500 result.

Were probably better serving a 400 Bad Request, but I think this is at least consistent with the old API.