### PR TITLE
Make sure we're using constants in forms

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -275,7 +275,7 @@ class HostingAdmin(admin.ModelAdmin):
         obj.status = action
         obj.save()
 
-        if action == StatusApproval.approved:
+        if action == StatusApproval.APPROVED:
             GreencheckASN.objects.create(
                 active=True, hostingprovider=obj.hostingprovider, asn=obj.asn
             )
@@ -291,7 +291,7 @@ class HostingAdmin(admin.ModelAdmin):
         obj.status = action
         obj.save()
 
-        if action == StatusApproval.approved:
+        if action == StatusApproval.APPROVED:
             GreencheckIp.objects.create(
                 active=True,
                 hostingprovider=obj.hostingprovider,

--- a/apps/greencheck/admin.py
+++ b/apps/greencheck/admin.py
@@ -26,12 +26,12 @@ class ApprovalFieldMixin:
         approve_url = reverse_admin_name(
             Hostingprovider,
             name=name,
-            params={"action": StatusApproval.approved, "approval_id": obj.pk},
+            params={"action": StatusApproval.APPROVED, "approval_id": obj.pk},
         )
         reject_url = reverse_admin_name(
             Hostingprovider,
             name=name,
-            params={"action": StatusApproval.removed, "approval_id": obj.pk},
+            params={"action": StatusApproval.REMOVED, "approval_id": obj.pk},
         )
 
         approve = f'<a href="{approve_url}">Approve</a>'
@@ -39,9 +39,9 @@ class ApprovalFieldMixin:
         link = f"{approve} / {reject}"
         action_taken = any(
             [
-                obj.status == StatusApproval.deleted,
-                obj.status == StatusApproval.removed,
-                obj.status == StatusApproval.approved,
+                obj.status == StatusApproval.DELETED,
+                obj.status == StatusApproval.REMOVED,
+                obj.status == StatusApproval.APPROVED,
             ]
         )
         if action_taken:

--- a/apps/greencheck/forms.py
+++ b/apps/greencheck/forms.py
@@ -28,8 +28,8 @@ class ApprovalMixin:
             hosting_provider = self.instance.hostingprovider
 
             # changed here represents an
-            action = ActionChoice.update if self.changed else ActionChoice.new
-            status = StatusApproval.update if self.changed else StatusApproval.new
+            action = ActionChoice.UPDATE if self.changed else ActionChoice.NEW
+            status = StatusApproval.UPDATE if self.changed else StatusApproval.NEW
             kwargs = {
                 "action": action,
                 "status": status,


### PR DESCRIPTION
I saw an error in Sentry caused by some of the django choices still using the lower case options i.e. `action = ActionChoice.update` instead of `action = ActionChoice.UPDATE`.

This fixes the outstanding ones.