### PR TITLE
Switch to using the more idiomatic get-or-create for updating url information

### DIFF
--- a/apps/greencheck/workers.py
+++ b/apps/greencheck/workers.py
@@ -145,18 +145,15 @@ class SiteCheckLogger:
         Update the caches - namely the green domains table, and if running Redis
         """
 
-        try:
-            green_domain = GreenDomain.objects.get(url=sitecheck.url)
-        except GreenDomain.DoesNotExist:
-            green_domain = GreenDomain(url=sitecheck.url)
-
-        green_domain.hosted_by = hosting_provider.name
-        green_domain.hosted_by_id = sitecheck.hosting_provider_id
-        green_domain.hosted_by_website = hosting_provider.website
-        green_domain.partner = hosting_provider.partner
-        green_domain.modified = sitecheck.checked_at
-        green_domain.green = sitecheck.green
-        green_domain.save()
+        saved_domain, created = GreenDomain.objects.get_or_create(
+            url=sitecheck.url,
+            hosted_by=hosting_provider.name,
+            hosted_by_id=sitecheck.hosting_provider_id,
+            hosted_by_website=hosting_provider.website,
+            partner=hosting_provider.partner,
+            modified=sitecheck.checked_at,
+            green=sitecheck.green,
+        )
 
     def update_redis_domain_cache(self, green_domain: GreenDomain):
         """


### PR DESCRIPTION
This should address the race condition we sometimes see when one process has started a transaction, to create an url or update it, and another process starts trying to update the same domain.