### PR TITLE
Add a safety check for when we get a None result when resolving IPs to ASNs

### DIFF
--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -192,7 +192,7 @@ class GreenDomainChecker:
         if isinstance(asn_result, int):
             return GreencheckASN.objects.filter(asn=asn_result).first()
 
-        if asn_result == "NA":
+        if asn_result == "NA" or asn_result is None:
             logger.info("Received a result we can't match to an ASN. Skipping")
             # we can't process this IP address. Skip it.
             return False

--- a/apps/greencheck/tests/test_domain_checker.py
+++ b/apps/greencheck/tests/test_domain_checker.py
@@ -66,6 +66,18 @@ class TestDomainChecker:
         assert isinstance(res, legacy_workers.SiteCheck)
         assert res.hosting_provider_id == green_asn.hostingprovider.id
 
+    def test_with_green_domain_by_non_resolving_asn(self, green_asn, checker):
+        """
+        Sometimes the service we use for resolving ASNs returns
+        an empty result.
+        """
+        green_asn.save()
+        checker.asn_from_ip = mock.MagicMock(return_value=None)
+
+        res = checker.check_domain("100.113.75.254")
+
+        assert isinstance(res, legacy_workers.SiteCheck)
+
 
 class TestDomainCheckerOrderBySize:
     """


### PR DESCRIPTION
In some cases, the service we rely on to resolve an AS network from an IP address returns an empty result.

This should account for the cases when we have this empty information.