### PR TITLE
Add checks for API error responses for browser extension multi checks

### DIFF
--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -148,9 +148,14 @@ def greencheck_multi(request, url_list: str):
     Return a JSON object for the multichecks, like the API
     """
     urls = None
+
     try:
         urls = json.loads(url_list)
     except Exception:
+        urls = []
+
+    # fallback if the url list is not usable
+    if urls is None:
         urls = []
 
     green_matches = GreenDomain.objects.filter(url__in=urls)

--- a/apps/greencheck/tests/test_legacy_images.py
+++ b/apps/greencheck/tests/test_legacy_images.py
@@ -156,35 +156,3 @@ class TestGreencheckImageView:
 
         assert response.status_code == 302
 
-
-class TestGreencheckMultiView:
-    def test_multi_check(
-        self,
-        db,
-        client,
-        hosting_provider_with_sample_user: Hostingprovider,
-        green_ip: GreencheckIp,
-    ):
-
-        #
-        # add our green domains
-        setup_domains(
-            ["www.facebook.com", "twitter.com", "www.youtube.com"],
-            hosting_provider_with_sample_user,
-            green_ip,
-        )
-
-        # fmt: off
-        urls_string = '["www.acethinker.com","download.acethinker.com","www.avangatenetwork.com","www.facebook.com","twitter.com","www.youtube.com","acethinker.com"]' # noqa
-        # urls_string = '[%22docs.google.com%22,%22accounts.google.com%22,%22www.google.com%22,%22myaccount.google.com%22,%22policies.google.com%22]'
-        # fmt: on
-
-        # urls = json.loads(parse.unquote(urls_string))
-        urls = json.loads(urls_string)
-
-        response = client.get(reverse("legacy-greencheck-multi", args=[urls_string]))
-        returned_domains = response.data.keys()
-        for url in urls:
-            assert url in returned_domains
-
-        assert response.status_code == 200

--- a/apps/greencheck/tests/test_legacy_v2_api.py
+++ b/apps/greencheck/tests/test_legacy_v2_api.py
@@ -1,0 +1,53 @@
+# import webbrowser
+import json
+
+from django.urls import reverse
+
+from ..models import GreencheckIp, Hostingprovider
+from . import setup_domains
+
+
+class TestGreencheckMultiView:
+    def test_multi_check(
+        self,
+        db,
+        client,
+        hosting_provider_with_sample_user: Hostingprovider,
+        green_ip: GreencheckIp,
+    ):
+
+        #
+        # add our green domains
+        setup_domains(
+            ["www.facebook.com", "twitter.com", "www.youtube.com"],
+            hosting_provider_with_sample_user,
+            green_ip,
+        )
+
+        # fmt: off
+        urls_string = '["www.acethinker.com","download.acethinker.com","www.avangatenetwork.com","www.facebook.com","twitter.com","www.youtube.com","acethinker.com"]' # noqa
+        # urls_string = '[%22docs.google.com%22,%22accounts.google.com%22,%22www.google.com%22,%22myaccount.google.com%22,%22policies.google.com%22]' # noqa
+        # fmt: on
+
+        # urls = json.loads(parse.unquote(urls_string))
+        urls = json.loads(urls_string)
+
+        response = client.get(reverse("legacy-greencheck-multi", args=[urls_string]))
+        returned_domains = response.data.keys()
+        for url in urls:
+            assert url in returned_domains
+
+        assert response.status_code == 200
+
+    def test_multi_check_with_null_value(
+        self,
+        db,
+        client,
+        hosting_provider_with_sample_user: Hostingprovider,
+        green_ip: GreencheckIp,
+    ):
+
+        urls_string = "null"
+
+        response = client.get(reverse("legacy-greencheck-multi", args=[urls_string]))
+        assert response.status_code == 200


### PR DESCRIPTION
We get 500's when the browser extensions send a multi-url request. 

this stops the 500s happening.