### PR TITLE
Add handy RIPE check

### DIFF
--- a/apps/theme/templatetags/admin_helpers.py
+++ b/apps/theme/templatetags/admin_helpers.py
@@ -1,9 +1,13 @@
 import urllib
 from django import template
+from django.utils.safestring import mark_safe
 
 import logging
+from apps.greencheck import domain_check
 
 register = template.Library()
+
+checker = domain_check.GreenDomainChecker()
 
 console = logging.StreamHandler()
 logger = logging.getLogger(__name__)
@@ -26,10 +30,21 @@ def make_url(website_string: str) -> str:
     return website_string
 
 
-# def link_to_ripe_stat(website_string: str) -> str:
-#     """
-#     Add link to RIPE checker
-#     """
+@register.simple_tag
+def link_to_ripe_stat(website_string: str) -> str:
+    """
+    Add link to checker at stat.ripe.net for a domain
+    """
 
-#     logger.debug(f"RECIEVED THIS: {str}")
+    url = make_url(website_string)
+    domain = checker.validate_domain(url)
+    resolved_ip = checker.convert_domain_to_ip(domain)
 
+    if resolved_ip:
+        return mark_safe(
+            f"<a"
+            f" target='_blank'"
+            f" href='https://stat.ripe.net/{resolved_ip}'>"
+            f"Check domain against RIPE stats"
+            f"</a>"
+        )

--- a/apps/theme/templatetags/admin_helpers.py
+++ b/apps/theme/templatetags/admin_helpers.py
@@ -1,6 +1,8 @@
 import urllib
 from django import template
+from django.contrib.auth.models import Group
 from django.utils.safestring import mark_safe
+
 
 import logging
 from apps.greencheck import domain_check
@@ -48,3 +50,13 @@ def link_to_ripe_stat(website_string: str) -> str:
             f"Check domain against RIPE stats"
             f"</a>"
         )
+
+
+@register.filter()
+def has_group(user, group_name) -> bool:
+    """
+    Check that a user has a specific group applied, and return
+    either True if so, or False.
+    """
+    group = Group.objects.get(name=group_name)
+    return True if group in user.groups.all() else False

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -36,14 +36,10 @@
 
                                   Visit site
                                 </a>
+                                {% if request.user.is_superuser  %}
+                                    {% link_to_ripe_stat field.field.value %}
+                                {% endif  %}
 
-                                <a
-                                  class="extra_url"
-                                  target="_blank"
-                                  href="{{ field.field.value|make_url }}">
-
-
-                                </a>
 
                             {% endif %}
 

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -36,7 +36,7 @@
 
                                   Visit site
                                 </a>
-                                {% if request.user.is_superuser  %}
+                                {% if request.user|has_group:"admin" %}
                                     {% link_to_ripe_stat field.field.value %}
                                 {% endif  %}
 

--- a/templates/admin/accounts/hostingprovider/hosting_provider_fieldset.html
+++ b/templates/admin/accounts/hostingprovider/hosting_provider_fieldset.html
@@ -36,7 +36,7 @@
                                   Visit site
                                 </a>
 
-                                {% if request.user.is_superuser  %}
+                                {% if request.user|has_group:"admin" %}
                                     {% link_to_ripe_stat field.field.value %}
                                 {% endif  %}
 

--- a/templates/admin/accounts/hostingprovider/hosting_provider_fieldset.html
+++ b/templates/admin/accounts/hostingprovider/hosting_provider_fieldset.html
@@ -36,6 +36,10 @@
                                   Visit site
                                 </a>
 
+                                {% if request.user.is_superuser  %}
+                                    {% link_to_ripe_stat field.field.value %}
+                                {% endif  %}
+
                             {% endif %}
 
                         {% endif %}


### PR DESCRIPTION
For internal staff, this adds a link to check a domain against RIPE's handy stat checker.

This surfaces lots of useful info, including the AS number, the whois data, and the reverse hostname - useful for checking if a state is being served from a content delivery network.