### PR TITLE
Add the missing step to generate our JS bundle

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -74,6 +74,11 @@
       args:
         chdir: "{{ project_root }}/current"
 
+  - name: build javascript bundle with rollup, using the local config file
+      shell: "npx rollup --config"
+      args:
+        chdir: "{{ project_root }}/current/apps/theme/static_src"
+
     - name: collect static files for django
       shell: "pipenv run ./manage.py collectstatic --no-input"
       args:


### PR DESCRIPTION
This PR adds the missing step for generating bundles using rollup, before running collectstatic.

This should resolve the issue where link to non-existent js bundle