### PR TITLE
Add second named queue for slower stats jobs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pipenv run "pytest -m 'not smoke_test' -m 'not dramatiq'"
+          pipenv run pytest
         env:
           PIPENV_DOTENV_LOCATION: .env.test
           DOMAIN_SNAPSHOT_BUCKET: ${{ secrets.TESTING_DOMAIN_SNAPSHOT_BUCKET }}

--- a/apps/greencheck/management/commands/backfill_stats.py
+++ b/apps/greencheck/management/commands/backfill_stats.py
@@ -51,7 +51,7 @@ class StatGenerator:
             inclusive_day_list, query_name=query_name
         )
 
-        jobs = gc_models.DailyStat.create_counts_for_date_range_async(
+        jobs = gc_models.DailyStat.create_jobs_for_date_range_async(
             inclusive_day_list, query_name=query_name
         )
 

--- a/apps/greencheck/tasks.py
+++ b/apps/greencheck/tasks.py
@@ -34,7 +34,7 @@ def process_log(domain):
             return False
 
 
-@dramatiq.actor
+@dramatiq.actor(queue_name="stats")
 def create_stat_async(date_string: str = None, query_name: str = "total_count", *args):
     """
     Accept a date_string, and a query name then execute the query. Used to carry out

--- a/apps/greencheck/tests/models/test_greencheck_stats.py
+++ b/apps/greencheck/tests/models/test_greencheck_stats.py
@@ -3,6 +3,7 @@ import io
 import logging
 from typing import List
 from unittest import mock
+import pytest
 
 import dramatiq
 import faker
@@ -287,6 +288,7 @@ class TestGreencheckStatsGeneration:
 
         assert gc_models.DailyStat.objects.all().count() == 0
 
+    @pytest.mark.flaky
     def test_create_range_for_stats_async(
         self,
         transactional_db,

--- a/apps/greencheck/tests/models/test_greencheck_stats.py
+++ b/apps/greencheck/tests/models/test_greencheck_stats.py
@@ -311,7 +311,7 @@ class TestGreencheckStatsGeneration:
 
         logger.info(f"just this date: { generated_dates[0] }")
 
-        gc_models.DailyStat.create_counts_for_date_range_async(
+        gc_models.DailyStat.create_jobs_for_date_range_async(
             generated_dates, "total_count"
         )
 

--- a/apps/greencheck/tests/views/test_stats_view.py
+++ b/apps/greencheck/tests/views/test_stats_view.py
@@ -2,6 +2,7 @@ import functools
 import logging
 
 import faker
+import pytest
 from dateutil.relativedelta import relativedelta
 from django import urls
 from django.utils import timezone
@@ -185,6 +186,7 @@ class TestDailyStatsView:
         assert len(chart_data["green"]) == 30
         assert len(chart_data["grey"]) == 30
 
+    @pytest.mark.flaky
     @override_flag("greencheck-stats", active=True)
     def test_stat_view_top_domains(
         self, db, client,

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -223,6 +223,9 @@ DRAMATIQ_BROKER = {
     ],
 }
 
+# For some jobs, we want workers dedicated to that queue only
+# this is where we list them.
+DRAMATIQ_EXTRA_QUEUES = {"stats": "stats"}
 
 LOGGING = {
     "version": 1,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,9 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=greenweb.settings.testing
-addopts = --reuse-db --maxfail=0
+addopts = --reuse-db --maxfail=0 -m "not smoke_test and not dramatiq and not flaky"
 python_files = tests.py test_*.py *_tests.py
 markers =
-    only: "Convenience method, so we can run a focussed test in pytest-watch"
-    smoke_test: "Smoke test - for exercising external APIs"
-    object_storage: "Uses object storage"
+    only: Convenience method, so we can run a focussed test in pytest-watch
+    smoke_test: Smoke test - for exercising external APIs
+    object_storage: Uses object storage
+    flaky: Flaky tests that are hard to reproduce a failing result reliably


### PR DESCRIPTION
This PR adds a second queue so it's possible to see the state of long running jobs, of the kind used to generate stats and rankings.