### PR TITLE
Match cache key to invalidate stale data

### DIFF
--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -120,7 +120,7 @@ class GreenDomainViewset(viewsets.ReadOnlyModelViewSet):
 
         # try our cache first before hitting the database
         if not skip_cache:
-            cache_hit = redis_cache.get(f"domains:{domain}")
+            cache_hit = redis_cache.get(f"domain:{domain}")
             if cache_hit:
                 process_log.send(domain)
                 return response.Response(json.loads(cache_hit))


### PR DESCRIPTION
Re:  Issue #170

Appears that there was a mismatch between the key get and key delete.