### PR TITLE
Add the missing symlink for media uploads

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -43,6 +43,13 @@
         dest: "{{ project_root }}/current/.env"
         state: link
 
+    - name: Link ./media to shared ./media directory
+      file:
+        src: "{{ project_root }}/shared/media"
+        dest: "{{ project_root }}/current/media"
+        state: link
+
+
     - name: install pipenv and mariadb libraries for python
       apt:
         pkg:


### PR DESCRIPTION
Previously we didn't need this, as we didn't really upload any files
from users.

This adds the symlink so access to uploaded files persists between deploys (!)