### PR TITLE
Add test for visiting admin page as logged in user

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -427,7 +427,16 @@ class HostingAdmin(admin.ModelAdmin):
         is_admin = request.user.groups.filter(name="admin").exists()
 
         if not is_admin:
-            inlines.remove(HostingProviderNoteInline)
+            # they're not an admin, remove HostingProviderNoteInline
+            # from the list so we don't show it
+            admin_inlines = (
+                GreencheckAsnApproveInline,
+                GreencheckIpApproveInline,
+                HostingProviderNoteInline,
+            )
+            for inline in admin_inlines:
+                if inline in inlines:
+                    inlines.remove(inline)
 
         return inlines
 

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.models import Group
+from django.contrib.auth.models import Permission
+from conftest import sample_hoster_user
+from django import urls
+
+import pytest
+
+
+class TestHostingProviderAdminInlineRendering:
+    """Test that we can visit new provider pages"""
+
+    def test_add_new_provider(
+        self, db, client, sample_hoster_user, default_user_groups
+    ):
+        """
+        Sign in, and visit new hosting provider page.
+
+        Simulate the journey for a new user creating an hosting
+        provider in the admin.
+        """
+        sample_hoster_user.save()
+
+        _, hp = default_user_groups
+
+        client.force_login(sample_hoster_user)
+
+        new_provider_url = urls.reverse("greenweb_admin:accounts_hostingprovider_add")
+        resp = client.get(new_provider_url)
+        assert resp.status_code == 200

--- a/apps/theme/templatetags/admin_helpers.py
+++ b/apps/theme/templatetags/admin_helpers.py
@@ -56,5 +56,9 @@ def has_group(user, group_name) -> bool:
     Check that a user has a specific group applied, and return
     either True if so, or False.
     """
-    group = Group.objects.get(name=group_name)
-    return True if group in user.groups.all() else False
+    group = Group.objects.filter(name=group_name)
+
+    if not group:
+        return False
+
+    return True if group[0] in user.groups.all() else False


### PR DESCRIPTION
This is a fix for #181 - previously we were not checking if a class was in an array before removing it, which caused a crash when visiting the new hosting provider page.