### PR TITLE
Introduce checking via carbon.txt

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -68,6 +68,8 @@ django-taggit-serializer = "*"
 # https://github.com/yourlabs/django-autocomplete-light/issues/1248
 django-autocomplete-light = "==3.8.2"
 markdown = "*"
+toml = "*"
+python-dateutil = "*"
 
 [pipenv]
 # Needed for `black`. See https://github.com/microsoft/vscode-python/pull/5967.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "44c608ee256cb76af31dcb6fc88d854e6af201ec3595b62e5cabab1887327683"
+            "sha256": "83fb81738ef95f0cbb5cde3f793b50f1e9144298ccd355c0929ce483cd7c743a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -51,19 +51,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:63b9846c26e0905f4e9e39d6b59f152330c53a926d693439161c43dcf9779365",
-                "sha256:a9232185d8e7e2fd2b166c0ebee5d7b1f787fdb3093f33bbf5aa932c08f0ccac"
+                "sha256:9b6679e3c54f8c32c09872948450ece87473cbc830cfd6c84dad58eb014329ba",
+                "sha256:caa96b7c2be2168b6efc25ab1fb61c996174bcfbcab21b5f642608185daa6403"
             ],
             "index": "pypi",
-            "version": "==1.18.42"
+            "version": "==1.18.43"
         },
         "botocore": {
             "hashes": [
-                "sha256:0952d1200968365b440045efe8e45bbae38cf603fee12bcfc3d7b5f963cbfa18",
-                "sha256:6de4fec4ee10987e4dea96f289553c2f45109fcaafcb74a5baee1221926e1306"
+                "sha256:b74d0a5fe0f7b73fa4b5670eaa9ff456b0bce70966d478dcd631c91458916eb6",
+                "sha256:de7bf9c9098578d386b785b5b6eab954acccd3f79fe3e2eb971da608c967082b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.42"
+            "version": "==1.21.43"
         },
         "brotli": {
             "hashes": [
@@ -184,11 +184,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
-                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
+                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
+                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.4"
+            "version": "==2.0.5"
         },
         "click": {
             "hashes": [
@@ -793,7 +793,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.8.2"
         },
         "python-slugify": {
@@ -1007,6 +1007,14 @@
             "index": "pypi",
             "version": "==0.12.6"
         },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "index": "pypi",
+            "version": "==0.10.2"
+        },
         "unicodecsv": {
             "hashes": [
                 "sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc"
@@ -1060,11 +1068,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c",
-                "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"
+                "sha256:dcc06f6165f415220013801642bd6c9808a02967070919c4b746c6864c205471",
+                "sha256:fe81f80c0b35264acb5653302ffbd935d394f1775c5e4487df745bf9c2442708"
             ],
             "markers": "python_version ~= '3.6'",
-            "version": "==2.7.3"
+            "version": "==2.8.0"
         },
         "attrs": {
             "hashes": [
@@ -1098,11 +1106,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
-                "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
+                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
+                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.4"
+            "version": "==2.0.5"
         },
         "click": {
             "hashes": [
@@ -1245,11 +1253,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:6714c153433086681b26e5c95ee314ee0fcd45ec05f2426097543dd4c70789a6",
-                "sha256:810859626d19e62a2a13aa4a08d59ada131f0522431eec163b09b6df147a25b9"
+                "sha256:0e41f73deb8233210b728c98b926284d3a7f51c001793e8b61f4382561971011",
+                "sha256:d4492b0f84d67e76a86ce1712ec7d38ecb92f91c0ca0ac0a9f2a0c3227ab9eb2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.12.1"
+            "version": "==8.13.2"
         },
         "flake8": {
             "hashes": [
@@ -1261,11 +1269,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:25eb0cfca5efdfcc3dba52ba61e415882ca0ac410bff9557d730d078608d77b4",
-                "sha256:48e618e1c279ffa6a2c3be4625628f3ebd8e91732d7f4af64039a0377776cfcd"
+                "sha256:0729766a5969bcde9d01a625c7dc3f64705efa7cb47e567504eacfebc08e4d3c",
+                "sha256:92810e59f01ed25a18589d92fd38c931a4c8509134c7a9d18ed1b6c3a8464f5e"
             ],
             "index": "pypi",
-            "version": "==6.21.1"
+            "version": "==6.21.4"
         },
         "idna": {
             "hashes": [
@@ -1516,11 +1524,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:6758cce3ddbab60c52b57dcc07f0c5d779e5daf0cf50f6faacbef1d3ea62d2a1",
-                "sha256:e178e96b6ba171f8ef51fbce9ca30931e6acbea4a155074d80cc081596c9e852"
+                "sha256:315fc81fad20d495f374d8fde685e442d4b6e3b275a5940fc212ae0484cb2eb6",
+                "sha256:87ed31da38248b9cc34869516af89f58d3bb1898736674c5759ca99092b382aa"
             ],
             "index": "pypi",
-            "version": "==2.10.2"
+            "version": "==2.11.0"
         },
         "pylint-django": {
             "hashes": [
@@ -1598,7 +1606,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.8.2"
         },
         "pytz": {
@@ -1721,7 +1729,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -1746,6 +1754,7 @@
                 "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
                 "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
+            "markers": "python_version < '3.10'",
             "version": "==3.10.0.2"
         },
         "urllib3": {

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -26,6 +26,8 @@ from apps.greencheck.choices import StatusApproval
 
 logger = logging.getLogger(__name__)
 
+GREEN_VIA_CARBON_TXT = "green:carbontxt"
+
 
 class Datacenter(models.Model):
     country = CountryField(db_column="countrydomain")
@@ -219,6 +221,14 @@ class Hostingprovider(models.Model):
             return True
 
         return False
+
+    def counts_as_green(self):
+        """
+        A convenience check, provide a simple to let us avoid
+        needing to implement the logic for determining
+        if a provider counts as green in multiple places
+        """
+        return GREEN_VIA_CARBON_TXT in self.staff_labels.names()
 
     def outstanding_approval_requests(self):
         """

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -22,11 +22,12 @@ from .choices import (
     ClassificationChoice,
     PartnerChoice,
 )
-from apps.greencheck.choices import StatusApproval
+from apps.greencheck.choices import StatusApproval, GreenlistChoice
 
 logger = logging.getLogger(__name__)
 
-GREEN_VIA_CARBON_TXT = "green:carbontxt"
+
+GREEN_VIA_CARBON_TXT = f"green:{GreenlistChoice.CARBONTXT.value}"
 
 
 class Datacenter(models.Model):

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -8,6 +8,7 @@ from dateutil import relativedelta
 
 from django.utils import timezone
 from ..accounts import models as ac_models
+from . import models as gc_models
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,18 @@ class CarbonTxtParser:
                 )
                 logger.info(f"New supporting doc {doc} for {prov}")
 
+            res = gc_models.GreenDomain.objects.filter(url=provider["domain"]).first()
+            if not res:
+                gc_models.GreenDomain.objects.create(
+                    url=provider["domain"],
+                    hosted_by=prov.name,
+                    hosted_by_id=prov.id,
+                    hosted_by_website=prov.website,
+                    partner=prov.partner,
+                    modified=timezone.now(),
+                    green=True,
+                )
+
         # given a parsed carbon.txt object,  fetch the listed organisation
         org_domains = set()
 
@@ -99,6 +112,18 @@ class CarbonTxtParser:
                         valid_to=timezone.now() + relativedelta.relativedelta(years=1),
                     )
                     logger.info(f"New supporting doc {doc} for {prov}")
+
+            res = gc_models.GreenDomain.objects.filter(url=org["domain"]).first()
+            if not res:
+                gc_models.GreenDomain.objects.create(
+                    url=org["domain"],
+                    hosted_by=prov.name,
+                    hosted_by_id=prov.id,
+                    hosted_by_website=prov.website,
+                    partner=prov.partner,
+                    modified=timezone.now(),
+                    green=True,
+                )
 
             org_domains.add(org["domain"])
 

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -3,6 +3,8 @@ from typing import Dict, Set, List
 import toml
 import rich
 import logging
+import requests
+from urllib import parse
 
 from dateutil import relativedelta
 
@@ -126,3 +128,15 @@ class CarbonTxtParser:
             "upstream": {"providers": [*upstream_providers]},
             "org": {"providers": [*org_providers]},
         }
+
+    def import_from_url(self, url: str):
+        """
+        Try to fetch a carbon.txt file at a given url, and
+        if successful, import the carbon.text file
+        """
+        res = requests.get(url)
+        domain = parse.urlparse(url).netloc
+        carbon_txt_string = res.content.decode("utf-8")
+
+        return self.parse_and_import(domain, carbon_txt_string)
+

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -80,6 +80,8 @@ class CarbonTxtParser:
             modified=timezone.now(),
             green=True,
         )
+        # mark it as green using our label
+        provider.staff_labels.add(ac_models.GREEN_VIA_CARBON_TXT)
 
     def parse_and_import(self, domain: str = None, carbon_txt: str = None) -> Dict:
         """

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -27,13 +27,17 @@ class CarbonTxtParser:
         """
         Create a hosting provider from the provider dict passed
         in, and return a dict of the created hosting provider, and
-        updated provider set
+        updated provider set.
+
+        The provider matching the domain already exists, add the supporting evidence
+        without creating a new provider.
         """
         prov, created = ac_models.Hostingprovider.objects.get_or_create(
             website=provider_dict["domain"]
         )
         if not prov.name:
             prov.name = provider_dict["domain"]
+            prov.save()
         if prov not in provider_set:
             provider_set.add(prov)
         SupportingDoc = ac_models.HostingProviderSupportingDocument
@@ -112,8 +116,7 @@ class CarbonTxtParser:
         org_domains = set()
 
         for org in org_creds:
-            if org["domain"] not in org_domains:
-                prov, org_providers = self._create_provider(org, org_providers)
+            prov, org_providers = self._create_provider(org, org_providers)
 
             res = gc_models.GreenDomain.objects.filter(url=org["domain"]).first()
             if not res:
@@ -128,6 +131,17 @@ class CarbonTxtParser:
             "upstream": {"providers": [*upstream_providers]},
             "org": {"providers": [*org_providers]},
         }
+
+    def parse_and_preview(self, url: str, carbon_txt: str = None) -> Dict:
+        """
+        Parses a carbon.txt string and returns a preview of the objects that would be created if it was imported.
+
+        Used to show a preview for an administrator to approve
+        before running an import.
+
+        """
+        # not implemented
+        pass
 
     def import_from_url(self, url: str):
         """

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -1,0 +1,111 @@
+from typing import Dict
+import toml
+import rich
+import logging
+
+from dateutil import relativedelta
+
+
+from django.utils import timezone
+from ..accounts import models as ac_models
+
+logger = logging.getLogger(__name__)
+
+
+class CarbonTxtParser:
+    """
+    A parser for reading carbon.txt files and turning them into domain objects
+    we can use for updating information about provider organisations in
+    the green web database.
+    """
+
+    def parse_and_import(self, domain: str = None, carbon_txt: str = None) -> Dict:
+        """
+        Accept a domain representing where the carbon.txt file
+        comes form, and a string containing the carbon.txt
+        contents, and import the organisations listed, returning
+        the providers
+        """
+        # what we need
+
+        # parse a carbon.txt file, plus where it is fetched from
+        # (request, DNS lookup) and return a set of providers and
+        # pieces of supporting evidence
+        parsed_txt = toml.loads(carbon_txt)
+        upstream_providers = set()
+        org_providers = set()
+
+        providers = parsed_txt["upstream"]["providers"]
+        org_creds = parsed_txt["org"]["credentials"]
+
+        # given a parsed carbon.txt object,
+        # fetch the upstream providers
+        for provider in providers:
+            prov, created = ac_models.Hostingprovider.objects.get_or_create(
+                website=provider["domain"]
+            )
+            if not prov.name:
+                prov.name = provider["domain"]
+            if prov not in upstream_providers:
+                upstream_providers.add(prov)
+            SupportingDoc = ac_models.HostingProviderSupportingDocument
+
+            found_docs = SupportingDoc.objects.filter(
+                hostingprovider=prov, url=provider["url"]
+            )
+            doc = None
+
+            if found_docs:
+                doc = found_docs[0]
+
+            if not found_docs:
+                title = f"{provider['domain']} - {provider['doctype']}"
+                doc = SupportingDoc.objects.create(
+                    url=provider["url"],
+                    hostingprovider=prov,
+                    title=title,
+                    valid_from=timezone.now(),
+                    valid_to=timezone.now() + relativedelta.relativedelta(years=1),
+                )
+                logger.info(f"New supporting doc {doc} for {prov}")
+
+        # given a parsed carbon.txt object,  fetch the listed organisation
+        org_domains = set()
+
+        for org in org_creds:
+            if org["domain"] not in org_domains:
+                prov, created = ac_models.Hostingprovider.objects.get_or_create(
+                    website=org["domain"]
+                )
+                if not prov.name:
+                    prov.name = org["domain"]
+                org_providers.add(prov)
+
+                found_docs = SupportingDoc.objects.filter(
+                    hostingprovider=prov, url=provider["url"]
+                )
+                doc = None
+
+                if found_docs:
+                    doc = found_docs[0]
+
+                if not found_docs:
+                    title = f"{org['domain']} - {org['doctype']}"
+                    doc = SupportingDoc.objects.create(
+                        url=org["url"],
+                        hostingprovider=prov,
+                        title=title,
+                        valid_from=timezone.now(),
+                        valid_to=timezone.now() + relativedelta.relativedelta(years=1),
+                    )
+                    logger.info(f"New supporting doc {doc} for {prov}")
+
+            org_domains.add(org["domain"])
+
+        # we return the entities that we would query
+        # for further information that should have been added
+        # during parsing
+        return {
+            "upstream": {"providers": [*upstream_providers]},
+            "org": {"providers": [*org_providers]},
+        }

--- a/apps/greencheck/choices.py
+++ b/apps/greencheck/choices.py
@@ -8,11 +8,13 @@ class GreenlistChoice(models.TextChoices):
     its result.
     """
 
-    ASN = "as", _("as")
-    IP = "ip", _("ip")
-    NONE = "none", _("none")
+    # source order matters here, because migrations are
+    # generated based on the order of these for building MySQL ENUMS
     URL = "url", _("url")
     WHOIS = "whois", _("whois")
+    IP = "ip", _("ip")
+    NONE = "none", _("none")
+    ASN = "as", _("as")
     CARBONTXT = "carbontxt", _("carbon.txt")
 
 

--- a/apps/greencheck/choices.py
+++ b/apps/greencheck/choices.py
@@ -13,6 +13,7 @@ class GreenlistChoice(models.TextChoices):
     NONE = "none", _("none")
     URL = "url", _("url")
     WHOIS = "whois", _("whois")
+    CARBONTXT = "carbontxt", _("carbon.txt")
 
 
 class CheckedOptions(models.TextChoices):

--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -25,6 +25,7 @@ import urllib
 import tld
 
 from .models import GreenDomain, SiteCheck
+from .choices import GreenlistChoice
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class GreenDomainChecker:
             data=True,
             green=True,
             hosting_provider_id=ip_match.hostingprovider.id,
-            match_type="ip",
+            match_type=GreenlistChoice.IP.value,
             match_ip_range=ip_match.id,
             cached=False,
             checked_at=timezone.now(),
@@ -119,7 +120,7 @@ class GreenDomainChecker:
             data=True,
             green=True,
             hosting_provider_id=matching_asn.hostingprovider.id,
-            match_type="as",
+            match_type=GreenlistChoice.ASN.value,
             match_ip_range=matching_asn.id,
             cached=False,
             checked_at=timezone.now(),
@@ -166,7 +167,7 @@ class GreenDomainChecker:
             data=True,
             green=True,
             hosting_provider_id=matching_green_domain.hosted_by_id,
-            match_type="carbontxt",
+            match_type=GreenlistChoice.CARBONTXT.value,
             match_ip_range=None,
             cached=False,
             checked_at=timezone.now(),

--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -135,7 +135,7 @@ class GreenDomainChecker:
             data=False,
             green=False,
             hosting_provider_id=None,
-            match_type="ip",
+            match_type=GreenlistChoice.IP.value,
             match_ip_range=None,
             cached=False,
             checked_at=timezone.now(),
@@ -167,7 +167,12 @@ class GreenDomainChecker:
             data=True,
             green=True,
             hosting_provider_id=matching_green_domain.hosted_by_id,
-            match_type=GreenlistChoice.CARBONTXT.value,
+            # NOTE: we use WHOIS for now, as a way to decouple
+            # an expensive and risky migration from the rest of
+            # this carbon.txt work. See this issue for more:
+            # https://github.com/thegreenwebfoundation/admin-portal/issues/198
+            # match_type=GreenlistChoice.CARBONTXT.value,
+            match_type=GreenlistChoice.WHOIS.value,
             match_ip_range=None,
             cached=False,
             checked_at=timezone.now(),

--- a/apps/greencheck/management/commands/import_from_carbon_txt_url.py
+++ b/apps/greencheck/management/commands/import_from_carbon_txt_url.py
@@ -1,0 +1,42 @@
+import logging
+from django.core.management.base import BaseCommand
+
+from ... import models as gc_models
+from ... import carbon_txt
+
+logger = logging.getLogger(__name__)
+# console = logging.StreamHandler()
+# logger.addHandler(console)
+# logger.setLevel(logging.DEBUG)
+
+
+class Command(BaseCommand):
+
+    help = (
+        "Fetch a carbon.txt file from the URL provided and import the providers "
+        "with any supporting evidence associated."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "url",
+            type=str,
+            help="The fully qualified URL to download the carbon.txt file from",
+        )
+
+    def handle(self, *args, **options):
+        """
+        """
+        import_url = options["url"]
+        parser = carbon_txt.CarbonTxtParser()
+        res = parser.import_from_url(import_url)
+        self.stdout.write(f"OK. Import successful. Imported the following providers:")
+
+        flattened_provider_list = [
+            *res["upstream"]["providers"],
+            *res["org"]["providers"],
+        ]
+
+        for provider in flattened_provider_list:
+            self.stdout.write(f"Imported {provider}")
+

--- a/apps/greencheck/models/checks.py
+++ b/apps/greencheck/models/checks.py
@@ -404,6 +404,10 @@ class TopUrl(models.Model):
 
 
 class GreenDomain(models.Model):
+    """
+    The model we use for quick lookups against a domain.
+
+    """
 
     url = models.CharField(max_length=255)
     hosted_by_id = models.IntegerField()

--- a/apps/greencheck/tests/carbon-txt-test.toml
+++ b/apps/greencheck/tests/carbon-txt-test.toml
@@ -1,0 +1,51 @@
+[upstream]
+providers = [
+  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/' },
+  { domain = 'cdn.com', doctype = 'sustainability-page', url = 'https://cdn.com/company/corporate-responsibility/sustainability' },
+]
+
+[org]
+credentials = [
+  { domain = 'www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/' },
+  { domain = 'www.hillbob.de', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'valleytrek.co.uk', doctype = 'sustainability-page', url = 'https://www.alpinetrek.co.uk/climate-neutral/' },
+  { domain = 'valleytrek.co.uk', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.nl', doctype = 'sustainability-page', url = 'https://www.hillbob.nl/klimaatneutraliteit/' },
+  { domain = 'hillbob.nl', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'alpine.fr', doctype = 'sustainability-page', url = 'https://www.alpine.fr/carbone-neutre/' },
+  { domain = 'alpine.fr', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.eu', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.eu', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.at', doctype = 'sustainability-page', url = 'https://www.hillbob.at/klimaneutral/' },
+  { domain = 'hillbob.at', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/' },
+  { domain = 'hillbob.ch', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.dk', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.dk', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.se', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.se', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.no', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.no', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.fi', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.fi', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.it', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.it', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hillbob.es', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hillbob.es', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+  { domain = 'hbcdn.com', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },
+  { domain = 'hbcdn.com', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+
+]

--- a/apps/greencheck/tests/management/test_import_carbon_txt.py
+++ b/apps/greencheck/tests/management/test_import_carbon_txt.py
@@ -2,8 +2,15 @@ import logging
 import pytest
 import io
 from django.core import management
+from django.urls import reverse
 
+import dramatiq
+import rich
+from dramatiq.brokers import stub
 from ....accounts import models as ac_models
+from ... import models as gc_models
+from ... import workers
+from ... import domain_check
 
 
 logger = logging.getLogger(__name__)
@@ -36,3 +43,30 @@ class TestImportFromCarbonTxt:
         for name in names:
             assert name in out.getvalue()
 
+    @pytest.mark.only
+    def test_import_from_url_then_check_against_api(self, db, client):
+        """
+        Sanity check to make sure we don't override the imported
+        information with our async lookup process.
+        """
+        out = io.StringIO()
+        # broker.declare_queue("default")
+
+        url = "bergfreunde.it"
+
+        # run an import
+        management.call_command(
+            "import_from_carbon_txt_url",
+            "https://www.bergfreunde.it/carbon.txt",
+            stdout=out,
+        )
+
+        checker = domain_check.GreenDomainChecker()
+        sitecheck = checker.check_domain(url)
+
+        # we use the sitecheck status to keep the GreenDomain
+        # table up to date, and our async workers update the status in the Greendomain table after each check.
+        # Checking the status here saves us needing to have all
+        # the async checking infra with workers, and brokers in our
+        # test
+        assert sitecheck.green

--- a/apps/greencheck/tests/management/test_import_carbon_txt.py
+++ b/apps/greencheck/tests/management/test_import_carbon_txt.py
@@ -1,0 +1,38 @@
+import logging
+import pytest
+import io
+from django.core import management
+
+from ....accounts import models as ac_models
+
+
+logger = logging.getLogger(__name__)
+console = logging.StreamHandler()
+# logger.setLevel(logging.DEBUG)
+# logger.addHandler(console)
+
+FIRST_OF_JAN = "2020-01-01"
+
+
+class TestImportFromCarbonTxt:
+    @pytest.mark.only
+    def test_import_from_url(self, db):
+        """
+        Check we can run an import from the command line
+        """
+        out = io.StringIO()
+        management.call_command(
+            "import_from_carbon_txt_url",
+            "https://www.bergfreunde.it/carbon.txt",
+            stdout=out,
+        )
+
+        providers = ac_models.Hostingprovider.objects.all()
+        assert len(providers) == 16
+        assert "OK" in out.getvalue()
+
+        # do we name the providers we have imported?
+        names = [prov.name for prov in providers]
+        for name in names:
+            assert name in out.getvalue()
+

--- a/apps/greencheck/tests/management/test_import_carbon_txt.py
+++ b/apps/greencheck/tests/management/test_import_carbon_txt.py
@@ -1,24 +1,13 @@
-import logging
-import pytest
 import io
-from django.core import management
-from django.urls import reverse
+import logging
 
-import dramatiq
-import rich
-from dramatiq.brokers import stub
+import pytest
+from django.core import management
+
 from ....accounts import models as ac_models
-from ... import models as gc_models
-from ... import workers
 from ... import domain_check
 
-
 logger = logging.getLogger(__name__)
-console = logging.StreamHandler()
-# logger.setLevel(logging.DEBUG)
-# logger.addHandler(console)
-
-FIRST_OF_JAN = "2020-01-01"
 
 
 class TestImportFromCarbonTxt:
@@ -50,8 +39,6 @@ class TestImportFromCarbonTxt:
         information with our async lookup process.
         """
         out = io.StringIO()
-        # broker.declare_queue("default")
-
         url = "bergfreunde.it"
 
         # run an import
@@ -65,7 +52,8 @@ class TestImportFromCarbonTxt:
         sitecheck = checker.check_domain(url)
 
         # we use the sitecheck status to keep the GreenDomain
-        # table up to date, and our async workers update the status in the Greendomain table after each check.
+        # table up to date, and our async workers update the status
+        # in the Greendomain table after each check.
         # Checking the status here saves us needing to have all
         # the async checking infra with workers, and brokers in our
         # test

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -68,7 +68,6 @@ class TestCarbonTxtParser:
         assert res.green == True
         assert res.hosted_by_id == provider.id
 
-    @pytest.mark.only
     def test_check_with_alternative_domain(self, db, carbon_txt_string):
         """
         Does a check against the domain return a positive result?
@@ -84,11 +83,9 @@ class TestCarbonTxtParser:
         assert res.green == True
         assert res.hosted_by_id == provider.id
 
-    @pytest.mark.only
     def test_import_from_remote_carbon_text_file(self, db):
         psr = carbon_txt.CarbonTxtParser()
-        result = psr.import_from_url("https://www.domain.com.it/carbon.txt")
-
+        result = psr.import_from_url("https://www.bergfreunde.de/carbon.txt")
         providers = ac_models.Hostingprovider.objects.all()
         assert len(providers) == 16
         assert len(result["upstream"]["providers"]) == 2

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -87,7 +87,7 @@ class TestCarbonTxtParser:
     @pytest.mark.only
     def test_import_from_remote_carbon_text_file(self, db):
         psr = carbon_txt.CarbonTxtParser()
-        result = psr.import_from_url("https://www.bergfreunde.it/carbon.txt")
+        result = psr.import_from_url("https://www.domain.com.it/carbon.txt")
 
         providers = ac_models.Hostingprovider.objects.all()
         assert len(providers) == 16

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -1,0 +1,78 @@
+import ipdb
+import pytest
+import pathlib
+
+
+from .. import carbon_txt
+from ...accounts import models as ac_models
+
+
+class TestCarbonTxtParser:
+    """
+    First tests to check that we can parse the carbon.txt file
+    """
+
+    @pytest.mark.only
+    def test_parse_basic_provider(self, db):
+        """
+        Has this created the necessary organisations?
+        i.e. one hosting provider and the two upstream providers?
+        And do they have the supporting info?
+        """
+        pth = pathlib.Path(__file__)
+
+        carbon_txt_path = pth.parent / "carbon-txt-test.toml"
+
+        carbon_txt_string = None
+        with open(carbon_txt_path) as carb_file:
+            carbon_txt_string = carb_file.read()
+
+        psr = carbon_txt.CarbonTxtParser()
+
+        result = psr.parse_and_import("www.bergfreunde.de", carbon_txt_string)
+
+        # do we have the 16 providers listed now?
+        providers = ac_models.Hostingprovider.objects.all()
+        assert len(providers) == 16
+        assert len(result["upstream"]["providers"]) == 2
+        assert len(result["org"]["providers"]) == 14
+
+        # do the providers have any supporting evidence
+        upstream_providers = result["org"]["providers"]
+        org_providers = result["org"]["providers"]
+
+        for prov in [*upstream_providers, *org_providers]:
+            # is there at least one piece of supporting evidence
+            # from the carbon txt file?
+            assert prov.supporting_documents.all()
+
+    @pytest.mark.skip(reason="pending")
+    def test_check_after_parsing_provider_txt_file(self):
+        """
+        Does a check against the domain return a positive result?
+        """
+        pass
+
+    @pytest.mark.skip(reason="pending")
+    def test_check_with_alternative_domain(self):
+        """
+        Does a check against the domain return a positive result?
+        """
+        pass
+
+    @pytest.mark.skip(reason="pending")
+    def test_creation_of_corporate_grouping(self):
+        """
+        Does parsing create the necessary corporate grouping from a
+        carbon.txt file?
+        """
+        pass
+
+    @pytest.mark.skip(reason="pending")
+    def test_referencing_corporate_grouping(self):
+        """
+        After parsing a carbon.txt file, can checking an alternative domain
+        areer able to refer to the corporate grouping from the alternative domain
+        too?
+        """
+        pass

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -62,7 +62,6 @@ class TestCarbonTxtParser:
 
         # now check for the domains
         res = gc_models.GreenDomain.check_for_domain("www.hillbob.de")
-        rich.inspect(res)
         provider = ac_models.Hostingprovider.objects.get(id=res.hosted_by_id)
 
         # do we have a green result?
@@ -79,12 +78,21 @@ class TestCarbonTxtParser:
 
         # now check for the domains
         res = gc_models.GreenDomain.check_for_domain("valleytrek.co.uk")
-        rich.inspect(res)
         provider = ac_models.Hostingprovider.objects.get(id=res.hosted_by_id)
 
         # do we have a green result?
         assert res.green == True
         assert res.hosted_by_id == provider.id
+
+    @pytest.mark.only
+    def test_import_from_remote_carbon_text_file(self, db):
+        psr = carbon_txt.CarbonTxtParser()
+        result = psr.import_from_url("https://www.bergfreunde.it/carbon.txt")
+
+        providers = ac_models.Hostingprovider.objects.all()
+        assert len(providers) == 16
+        assert len(result["upstream"]["providers"]) == 2
+        assert len(result["org"]["providers"]) == 14
 
     @pytest.mark.skip(reason="pending")
     def test_creation_of_corporate_grouping(self):
@@ -98,7 +106,6 @@ class TestCarbonTxtParser:
     def test_referencing_corporate_grouping(self):
         """
         After parsing a carbon.txt file, can checking an alternative domain
-        areer able to refer to the corporate grouping from the alternative domain
-        too?
+        refer to the correct corporate grouping too?
         """
         pass


### PR DESCRIPTION
This PR introduces the first parser and importer for carbon.txt.

More specifically, this PR introduces:

- **A CarbonTxt parsing and importing class** - it fetches a carbon.txt file at a given URL, written in TOML, and then converts the entities into the corresponding domain objects inside this codebase - namely "providers" and "supporting documentary evidence" for any green claims. This lets us expose this information in lookups against our existing greencheck API.
- **A django managemeent command** to import information from a given URL. This largely uses the importer above, and should be something that can be run idempotently against a domain, for cronjobs the like.
- **Updates to the domain checker**, to account for the existing of information provided via carbon.txt rather than using the IP based lookup approach we had before. Without making these updates when we run an async check, we end up overwiting information returned by the IP/ASN based lookups.
- **General tidyups elsewhere** - I've updated the order for the choices that feed into the SQL that generated ENUM types for MySQL. I've done this as a safeguard after reading up a bit on how we'd add an 'extra checked by carbon.txt' type value in the massive greencheck tables. I've split this potentially scary data migration step into a separate issue, so we can at least get this shipped, as I think the two can be delivered separately, and it would be really good to have this actually get shipped. See #198  for more.



