### PR TITLE
WIP - Add preview for carbon.txt file

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -59,6 +59,30 @@ class CheckUrlView(FormView):
         return render(self.request, self.template_name, context)
 
 
+class CarbonTxtCheckForm(forms.Form):
+    """
+    A form to fetch a carbon.txt file at the provided URL, parse it,
+    and show what changes would be made if imported.
+    """
+
+    url = forms.URLField()
+
+
+class CarbonTxtCheckView(FormView):
+    template_name = "accounts/preview_carbon_txt.html"
+    form_class = CarbonTxtCheckForm
+    success_url = "/not/used"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form_url"] = reverse("admin:preview_carbon_txt")
+        return context
+
+    def form_valid(self, form):
+        context = self.get_context_data()
+        return render(self.request, self.template_name, context)
+
+
 class GreenWebAdmin(AdminSite):
     # This is a standard authentication form that allows non-staff users
     login_form = AuthenticationForm
@@ -80,6 +104,11 @@ class GreenWebAdmin(AdminSite):
         patterns = [
             path("try_out/", CheckUrlView.as_view(), name="check_url"),
             path("green-urls", GreenUrlsView.as_view(), name="green_urls"),
+            path(
+                "preview-carbon-txt",
+                CarbonTxtCheckView.as_view(),
+                name="preview_carbon_txt",
+            ),
         ]
         return patterns + urls
 
@@ -95,6 +124,19 @@ class GreenWebAdmin(AdminSite):
                         "name": "Try out a url",
                         "object_name": "greencheck_url",
                         "admin_url": reverse("admin:check_url"),
+                        "view_only": True,
+                    }
+                ],
+            },
+            {
+                "name": "Preview a carbon.txt file",
+                "app_label": "greencheck",
+                "app_url": reverse("admin:preview_carbon_txt"),
+                "models": [
+                    {
+                        "name": "Preview a carbontxt file",
+                        "object_name": "greencheck_url",
+                        "admin_url": reverse("admin:preview_carbon_txt"),
                         "view_only": True,
                     }
                 ],

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -119,9 +119,12 @@ class CarbonTxtParser:
 
         for org in org_creds:
             prov, org_providers = self._create_provider(org, org_providers)
-
+            logger.debug(f"Checking in green domains for {org['domain']}.")
             res = gc_models.GreenDomain.objects.filter(url=org["domain"]).first()
             if not res:
+                logger.debug(
+                    f"No green domain entry found for {org['domain']}. Creating one."
+                )
                 self._create_green_domain_for_provider(org, prov)
 
             org_domains.add(org["domain"])

--- a/apps/theme/templates/accounts/preview_carbon_txt.html
+++ b/apps/theme/templates/accounts/preview_carbon_txt.html
@@ -1,0 +1,25 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+
+{% block pretitle %}
+<h1>Enter the URL of the carbon.txt to see a preview of what it would import</h1>
+{% endblock %}
+
+{% block content %}
+<form action="{{ form_url }}" method="post">
+    {% csrf_token %}
+    {{ form.url.errors }}
+    <label for="{{ form.url.id_for_label }}">Url: </label>
+    {{ form.url }}
+    <input type="submit" value="Submit"
+        style="margin-top: 0px; padding: 6px 15px">
+</form>
+
+{% if parsed_carbon_txt %}
+<div>
+    <h2>Here's where you see what would happen</h2>
+</div>
+{% endif %}
+
+{% endblock content %}


### PR DESCRIPTION
This PR introduces (or will introduce)

- [ ] A preview page so you can see the entities that would be imported from a carbon.txt file if the importer consumed it
- [ ] A preview function for generating a data structure to render in the page


It _might_ introduce a way to trigger an import from this form for staff, but it might make sense to split this into a way to individually accept specific parts of a carbon.txt file, as there is scope for fairly large sets of changes already via a carbon.txt file.