### PR TITLE
Add aliases for carbon.txt importer

### DIFF
--- a/apps/greencheck/tests/carbon-txt-test.toml
+++ b/apps/greencheck/tests/carbon-txt-test.toml
@@ -1,12 +1,14 @@
 [upstream]
 providers = [
-  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/' },
+  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/', aliases = ["www.sys-ten.com", "www.systen.com"]},
   { domain = 'cdn.com', doctype = 'sustainability-page', url = 'https://cdn.com/company/corporate-responsibility/sustainability' },
 ]
 
 [org]
 credentials = [
-  { domain = 'www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/' },
+  { domain = 'www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/', aliases = [
+    "hillbob.de", "hill-bob.de"
+  ] },
   { domain = 'www.hillbob.de', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
   { domain = 'valleytrek.co.uk', doctype = 'sustainability-page', url = 'https://www.alpinetrek.co.uk/climate-neutral/' },
@@ -24,7 +26,7 @@ credentials = [
   { domain = 'hillbob.at', doctype = 'sustainability-page', url = 'https://www.hillbob.at/klimaneutral/' },
   { domain = 'hillbob.at', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/' },
+  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/', aliases = ["hill-bob.ch", "www.hilbob.ch", "www.hill-bob.ch"]},
   { domain = 'hillbob.ch', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
   { domain = 'hillbob.dk', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -91,6 +91,30 @@ class TestCarbonTxtParser:
         assert len(result["upstream"]["providers"]) == 2
         assert len(result["org"]["providers"]) == 14
 
+    def test_check_with_domain_aliases(self, db, carbon_txt_string):
+        """
+        Does 
+        """
+        psr = carbon_txt.CarbonTxtParser()
+        psr.parse_and_import("www.hillbob.de", carbon_txt_string)
+
+        # now check for the domains
+        primary_check = gc_models.GreenDomain.check_for_domain("www.hillbob.de")
+        secondary_check = gc_models.GreenDomain.check_for_domain("valleytrek.co.uk")
+        assert primary_check.green == True
+        assert secondary_check.green == True
+
+        # and the aliases
+        for domain_alias in ["www.sys-ten.com", "www.systen.com"]:
+            check = gc_models.GreenDomain.check_for_domain(domain_alias)
+            assert check.green == True
+
+        for domain_alias in ["hill-bob.ch", "www.hilbob.ch", "www.hill-bob.ch"]:
+            check = gc_models.GreenDomain.check_for_domain(domain_alias)
+            assert check.green == True
+
+
+
     @pytest.mark.skip(reason="pending")
     def test_creation_of_corporate_grouping(self):
         """
@@ -106,3 +130,8 @@ class TestCarbonTxtParser:
         refer to the correct corporate grouping too?
         """
         pass
+
+
+    
+        
+        


### PR DESCRIPTION
This adds alias support for importing with carbon.txt, allowing for aliases like `www.domainname.com` or `domain-name.com`, as alternatives to `domainname.com`.
