### PR TITLE
Add rabbit and redis as docker containers for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -42,6 +42,7 @@ tasks:
       docker run  
       --rm  
       --name green-redis 
+      -p 6379:6379
       redis:6
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,7 +38,7 @@ tasks:
       rabbitmq:3
 
   - name: redis
-    command: |
+    command: >
       docker run  
       --rm  
       --name green-redis 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,21 +21,28 @@ github:
 
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - name: set up supporting services
-    init: |
-      # we use rabbit for our queue
-      sudo service rabbitmq-server start
-      # redis is our cache
-      sudo service redis-server start
-      gp sync-done backing-services
-
   - name: set up python dependencies and database
     init: |
       cp ./.env.gitpod ./.env
       mysqladmin create greencheck
-      gp sync-await backing-services
       pipenv install --dev
     command: pipenv run ./manage.py
+
+  - name: rabbitmq
+    command: >
+      docker run 
+      --hostname green-rabbit 
+      -p 5672:5672 
+      --rm  
+      --name green-rabbit 
+      rabbitmq:3
+
+  - name: redis
+    command: |
+      docker run  
+      --rm  
+      --name green-redis 
+      redis:6
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:

--- a/scripts/test-rabbitmq.connection.py
+++ b/scripts/test-rabbitmq.connection.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import pika
+import logging
+
+# create our logger
+logger = logging.getLogger(__name__)
+
+# make sure have the logger set to level to 
+# accept the logging statements
+logger.setLevel(logging.DEBUG)
+
+# create a handler for our logs, so we can see them 
+console = logging.StreamHandler()
+# add the handler, so logs are shared as stream to STDOUT
+logger.addHandler(console)
+
+connection = pika.BlockingConnection(
+    pika.URLParameters("amqp://guest:guest@localhost:5672")
+)
+
+# we need a channel to sent things to 
+channel = connection.channel()
+channel.queue_declare(queue="hello")
+
+channel.basic_publish(exchange="", routing_key="hello", body="Hello World!")
+
+logger.info(" [x] Sent 'Hello World!'")
+connection.close()


### PR DESCRIPTION
This PR sets up the environment for using RabbitMQ and Redis as 'black box' external services running on the normal exposed ports, by using docker, rather than installing them as part of this development image.

This should make it easier to run the tests in a development environment without needing to know too much about the internals of either service.
