### PR TITLE
Hide archived providers by default in admin views

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -429,7 +429,9 @@ class HostingAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request, *args, **kwargs):
         qs = super().get_queryset(request, *args, **kwargs)
-        qs = qs.filter(archived=False)
+        if "archived" not in request.GET:
+            qs = qs.filter(archived=False)
+
         qs = qs.prefetch_related(
             "hostingprovider_certificates",
             "datacenter",

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -429,6 +429,7 @@ class HostingAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request, *args, **kwargs):
         qs = super().get_queryset(request, *args, **kwargs)
+        qs = qs.filter(archived=False)
         qs = qs.prefetch_related(
             "hostingprovider_certificates",
             "datacenter",

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -343,7 +343,7 @@ class TestHostingProviderAdmin:
     @pytest.mark.parametrize(
         "archived", ((True, 0), (False, 1),),
     )
-    def test_archived_users_hidden_by_default(
+    def test_archived_providers_are_hidden_by_default(
         self, db, client, hosting_provider_with_sample_user, archived
     ):
         """Test that by default, archived users to not show up in our listings."""
@@ -354,6 +354,27 @@ class TestHostingProviderAdmin:
 
         admin_url = urls.reverse("greenweb_admin:accounts_hostingprovider_changelist")
         resp = client.get(admin_url, follow=True)
+
+        assert len(resp.context["results"]) == archived[1]
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        "archived", ((True, 1), (False, 0),),
+    )
+    def test_archived_providers_hidden_by_seen_with_override_params(
+        self, db, client, hosting_provider_with_sample_user, archived
+    ):
+        """
+        If we really need to see archived users, we can with a
+        special GET param, to override our view
+        """
+
+        hosting_provider_with_sample_user.archived = archived[0]
+        hosting_provider_with_sample_user.save()
+        client.force_login(hosting_provider_with_sample_user.user_set.first())
+
+        admin_url = urls.reverse("greenweb_admin:accounts_hostingprovider_changelist")
+        resp = client.get(admin_url, {"archived": True}, follow=True)
 
         assert len(resp.context["results"]) == archived[1]
         assert resp.status_code == 200

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -340,3 +340,21 @@ class TestHostingProviderAdmin:
         assert len(labels) == 1
         assert labels[0].name == "welcome-email sent"
 
+    @pytest.mark.parametrize(
+        "archived", ((True, 0), (False, 1),),
+    )
+    def test_archived_users_hidden_by_default(
+        self, db, client, hosting_provider_with_sample_user, archived
+    ):
+        """Test that by default, archived users to not show up in our listings."""
+
+        hosting_provider_with_sample_user.archived = archived[0]
+        hosting_provider_with_sample_user.save()
+        client.force_login(hosting_provider_with_sample_user.user_set.first())
+
+        admin_url = urls.reverse("greenweb_admin:accounts_hostingprovider_changelist")
+        resp = client.get(admin_url, follow=True)
+
+        assert len(resp.context["results"]) == archived[1]
+        assert resp.status_code == 200
+


### PR DESCRIPTION
This PR changes the behaviour of the django admin, to filter out archived providers in our the admin views.

### Background

As much as possible, we don't delete old hosting providers, but we _do_ archive them.

This has an unfortunate side effect of showing archived providers in our provider list in admin views, which is confusing - you need to look for an "archived" checkbox as well as checking for the "show on site" checkbox.

This updates the listing to only ever show non-archived providers in the normal admin view.

If need be, there is still an override available - you can add `?archived=True` as a GET param in an url. This is helpful if you accidentally mark a provider as archived, and need to find it again.

```
# show the filtered view
https://admin.thegreenwebfoundation.org/admin/accounts/hostingprovider/

# include the archived ones as well.
https://admin.thegreenwebfoundation.org/admin/accounts/hostingprovider/
```
