### PR TITLE
Update the settings to no longer check for maximum field number size - resolves #224

### DIFF
--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -96,9 +96,13 @@ AUTH_USER_MODEL = "accounts.User"
 
 LOGIN_REDIRECT_URL = "/"
 
-# We need this to account for providers with massive numbers of IP ranges
-# to update. The default limit it too low for django admin!
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
+# We need this to account for some providers that have numbers of IP
+# ranges that are greater than the default limit in django.
+# By setting this to None, we no longer check for the size of the form.
+# This is not ideal, but it at least means some hosting providers can
+# update their info while we rethink how people update IP range info.
+# https://docs.djangoproject.com/en/4.0/ref/settings/#data-upload-max-number-fields
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
This PR introduces a config change to support the massive form submissions that are made in the django admin by some hosting providers, and resolve issue #224.

More specifically, this switches from us using what I thought was a massive number for the total fields that we couldn't ever reach, to not trying to check _at all_, as it turned out that some form submissions far exceeded the limit I had before.

In the long run, we'd have a wizard-style multipart form, or API, but until then this at least makes submissions work again.

### A note on the tests

I wasn't sure if this should have a test, it's changing a config setting, and the code in the django framework doing the checking is here, which is already well tested. Here's the implementation code

https://github.com/django/django/blob/main/django/http/multipartparser.py#L162-L194

The corresponding tests in the django framework are linked below

https://github.com/django/django/blob/main/tests/requests/test_data_upload_settings.py#L154-L217
