### PR TITLE
Update inactive domains when importing

### DIFF
--- a/apps/greencheck/importers/importer_interface.py
+++ b/apps/greencheck/importers/importer_interface.py
@@ -23,8 +23,7 @@ class Importer(Protocol):
 class BaseImporter:
     hosting_provider_id: int
 
-    # @transaction.atomic
-    def process_addresses(cls, list_of_addresses: list):
+    def process_addresses(cls, list_of_updatable_networks: list):
         """
         General function that processes all types of addresses (IPv4, IPv6 and ASN).
 
@@ -34,19 +33,24 @@ class BaseImporter:
 
         Addresses in the list will be set as active, and other addresses in the database
         will be set to inactive.
+        Return: str, success message containing the number of updated networks
         """
-        # TODO: Add docstring
+        # Set temporary counters
         count_ip = 0
         count_asn = 0
 
         try:
-            # Prepare and run ASN update
+            # Prepare: Extract ASN networks
             regex = re.compile("(AS)[0-9]+$")
-            asn_list = list(set(filter(regex.match, list_of_addresses)))
+            asn_list = list(set(filter(regex.match, list_of_updatable_networks)))
+
+            # Run ASN update
             count_asn = cls.update_asn(cls, asn_list)
 
-            # Prepare and run IP update
-            ip_list = list(set(list_of_addresses) - set(asn_list))
+            # Prepare: Extract IP networks
+            ip_list = list(set(list_of_updatable_networks) - set(asn_list))
+
+            # Prepare: Type checking
             ip_list = list(
                 filter(
                     lambda x: isinstance(
@@ -55,93 +59,139 @@ class BaseImporter:
                     ),
                     ip_list,
                 )
-            )  # Type checking
+            )
+
+            # Run IP update
             count_ip = cls.update_ip(cls, ip_list)
 
-            return f"Processing complete. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
+            # Success
+            return """Import complete. Updated {asn} ASN and {ip} IP networks 
+            (v4 and/or v6)""".format(
+                asn=count_asn, ip=count_ip
+            )
         except ValueError:
             logger.exception(
-                "Value has invalid structure. Must be IPv4 or IPv6 with subnetmask (101.102.103.104/27) or AS number (AS123456)."
+                """Value has invalid structure. Must be IPv4 or IPv6 with subnetmask 
+                (x.x.x.x/yy) or AS number (AS123456)."""
             )
-            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
-        except Exception as e:
-            logger.exception("Something really unexpected happened. Aborting")
-            logger.exception(e)
-            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
 
-    def update_asn(cls, active_networks: List[str]) -> int:
+            return """Import aborted as an error occured. Updated {asn} ASN and {ip} IP networks 
+            (v4 and/or v6)""".format(
+                asn=count_asn, ip=count_ip
+            )
+        except Exception as e:
+            logger.exception(
+                "Import aborted. Something unexpected happened."
+            )
+            logger.exception(e)
+            
+            return """Import aborted as an error occured. Updated {asn} ASN and {ip} IP networks 
+            (v4 and/or v6)""".format(
+                asn=count_asn, ip=count_ip
+            )
+
+    def update_asn(cls, active_asn_networks: List[str]) -> int:
         """
         General function that updates a hostingprovider's ASN networks.
-        Under "networks" in this case, it is understood that it needs to have a format 
+        Under "networks" in this case, it is understood that it needs to have a format
         similar to for example: AS12345.
+
         Return: int, number of ASN networks updated in the database
         """
-
-        # Prepare list by extracting AS values
-        active_networks = list(
-            map(int, map(lambda x: x.replace("AS", ""), active_networks))
+        # Prepare list by extracting the "AS" prefix
+        active_asn_networks = list(
+            map(int, map(lambda x: x.replace("AS", ""), active_asn_networks))
         )
+
+        # Set temporary counter
         updated_networks = 0
-        
+
         # Running an atomic transaction.
         # Meaning that if something goes wrong in the process, all changes to the
         # database will be reverted to when the transaction started.
         #
         # This is to avoid having updated half of the networks in the databse and
         # thereafter crashing and being left with a half updated set of networks
-        # connected to a hostingprovider. 
+        # connected to a hostingprovider.
         logger.debug("Running atomic database transaction. Altered AS numbers:")
         with transaction.atomic():
             # Retrieve all ASN entries assosiated with this hosting provider
+            # from the database
             hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
             db_entries = GreencheckASN.objects.select_for_update().filter(
                 hostingprovider=hosting_provider
             )
 
-            # Iterate database entries
+            # Iterate through database entries
+            # Sets:
+            # A = database entries
+            # B = given list of active networks
             for db_entry in db_entries:
-                if db_entry.asn in active_networks:
-                    active_networks.pop(active_networks.index(db_entry.asn))
+                if db_entry.asn in active_asn_networks:
+                    # Update: A ∩ B
+                    # Meaning: Database entry is found in active list
+
+                    # Remove database entry from list of active ASN networks
+                    active_asn_networks.pop(active_asn_networks.index(db_entry.asn))
+
+                    # Make sure to set the database entry to active and save it
                     db_entry.active = True
                     db_entry.save()
 
+                    # Update counter and log
                     updated_networks += 1
                     logger.debug(db_entry)
                 elif db_entry.active:
+                    # Update: A
+                    # Meaning: Only present in datbase with an active status, but not
+                    # in the list of active networks so it must be set to inactive
                     db_entry.active = False
                     db_entry.save()
 
+                    # Update counter and log
                     updated_networks += 1
                     logger.debug(db_entry)
 
-            # Iterate remaining list items (that are not in the database)
-            if active_networks:
-                for asn_network in active_networks:
+            # Update: B
+            # Meaning: Only present in list of active networks, but not in database.
+            # So this must be a new network that needs to be added to the databse.
+            if active_asn_networks:
+                # Only execute if the list still has some remaining items.
+
+                for asn_network in active_asn_networks:
+                    # Create new entry in the database
                     db_entry, created = GreencheckASN.objects.update_or_create(
                         active=True, asn=asn_network, hostingprovider=hosting_provider
                     )
                     db_entry.save()
 
+                    # Update counter and log if creation was successful
                     if created:
+                        updated_networks += 1
                         logger.debug(db_entry)
 
         return updated_networks
 
-    def update_ip(cls, active_networks: List[str]) -> int:
+    def update_ip(cls, active_ip_networks: List[str]) -> int:
         """
         General function that updates a hostingprovider's IPv4 and IPv6 networks.
-        Under "networks" in this case, it is understood that it exists a IP and it's given subnet.
+        Under "networks" in this case, it is understood that it exists a IP and its
+        given subnet.
+
         Return: int, number of IP networks updated in the database
         """
-        updated_networks = 0
-
-        # Convert networks (xxx.xxx.xxx.xxx/yy) to a
-        # start and end ip address
+        # Prepare list by extracting the beginning and ending address of a given
+        # IP network.
+        # This is needed since the database only saves a beginning and ending address
+        # and not a IP with a subnet.
         tmp_list = []
-        for ip_network in active_networks:
+        for ip_network in active_ip_networks:
             network = ipaddress.ip_network(ip_network)
             tmp_list.append((str(network[1]), str(network[-1])))
-        active_networks = list(set(tmp_list))
+        active_ip_networks = list(set(tmp_list))
+
+        # Set temporary counter
+        updated_networks = 0
 
         # Running an atomic transaction.
         # Meaning that if something goes wrong in the process, all changes to the
@@ -149,36 +199,56 @@ class BaseImporter:
         #
         # This is to avoid having updated half of the networks in the databse and
         # thereafter crashing and being left with a half updated set of networks
-        # connected to a hostingprovider. 
+        # connected to a hostingprovider.
         logger.debug("Running atomic database transaction. Altered IP ranges:")
         with transaction.atomic():
-            # Retrieve all IP(v4 and v6) entries assosiated to this hosting provider
+            # Retrieve all IP entries assosiated with this hosting provider
+            # from the database
             hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
             db_entries = GreencheckIp.objects.select_for_update().filter(
                 hostingprovider=hosting_provider
             )
 
-            # Iterate database entries
+            # Iterate through database entries
+            # Sets:
+            # A = database entries
+            # B = given list of active networks
             for db_entry in db_entries:
-                if (db_entry.ip_start, db_entry.ip_end) in active_networks:
-                    active_networks.pop(
-                        active_networks.index((db_entry.ip_start, db_entry.ip_end))
+                if (db_entry.ip_start, db_entry.ip_end) in active_ip_networks:
+                    # Update: A ∩ B
+                    # Meaning: Database entry is found in active list
+
+                    # Remove database entry from list of active IP networks
+                    active_ip_networks.pop(
+                        active_ip_networks.index((db_entry.ip_start, db_entry.ip_end))
                     )
+
+                    # Make sure to set the database entry to active and save it
                     db_entry.active = True
                     db_entry.save()
 
+                    # Update counter and log
                     updated_networks += 1
                     logger.debug(db_entry)
-                elif db_entry.active == True:
+                elif db_entry.active:
+                    # Update: A
+                    # Meaning: Only present in datbase with an active status, but not
+                    # in the list of active networks so it must be set to inactive
                     db_entry.active = False
                     db_entry.save()
 
+                    # Update counter and log
                     updated_networks += 1
                     logger.debug(db_entry)
 
-            # Iterate remaining list items (that are not in the database)
-            if active_networks:
-                for ip_network in active_networks:
+            # Update: B
+            # Meaning: Only present in list of active networks, but not in database.
+            # So this must be a new network that needs to be added to the databse.
+            if active_ip_networks:
+                # Only execute if the list still has some remaining items.
+
+                for ip_network in active_ip_networks:
+                    # Create new entry in the database
                     db_entry, created = GreencheckIp.objects.update_or_create(
                         active=True,
                         ip_start=ip_network[0],
@@ -187,6 +257,7 @@ class BaseImporter:
                     )
                     db_entry.save()
 
+                    # Update counter and log if creation was successful
                     if created:
                         logger.debug(db_entry)
 

--- a/apps/greencheck/importers/importer_interface.py
+++ b/apps/greencheck/importers/importer_interface.py
@@ -30,16 +30,16 @@ class BaseImporter:
         count_asn = 0
 
         try:
-            # Prepare ASN and IP lists
+            # Extract ASN and IP values from the generic list
             regex = re.compile("(AS)[0-9]+$")
             asn_list = list(filter(regex.match, list_of_addresses))
             ip_list = list(set(list_of_addresses) - set(asn_list))
 
-            # Final ASN preparation and run updater
-            asn_list = list(map(lambda x: x.replace("AS", ""), asn_list))
+            # ASN list preperation: formatting
+            asn_list = list(map(int, map(lambda x: x.replace("AS", ""), asn_list)))
             count_asn = cls.update_asn(cls, asn_list)
 
-            # Final IP preparation and run updater
+            # IP list preperation: type checking
             ip_list = list(
                 filter(
                     lambda x: isinstance(
@@ -51,131 +51,107 @@ class BaseImporter:
             )
             count_ip = cls.update_ip(cls, ip_list)
 
-            return f"Processing complete. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            return f"Processing complete. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
         except ValueError:
             logger.exception(
                 "Value has invalid structure. Must be IPv4 or IPv6 with subnetmask (101.102.103.104/27) or AS number (AS123456)."
             )
-            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
         except Exception as e:
             logger.exception("Something really unexpected happened. Aborting")
             logger.exception(e)
-            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (IPv4 and/or IPv6)"
 
-    def update_asn(cls, active_addresses: List[str]):
-        updated_addresses = 0
-        hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
-
-        # Retrieve all ASN entries assosiated to this hosting provider
-        entries = GreencheckASN.objects.select_for_update().filter(
-            hostingprovider=hosting_provider
-        )
+    def update_asn(cls, active_networks: List[int]) -> int:
+        active_networks = list(set(active_networks))  # extract unique values
+        updated_networks = 0
 
         logger.debug("Running atomic database transaction. Altered AS numbers:")
         with transaction.atomic():
+            # Retrieve all ASN entries assosiated with this hosting provider
+            hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
+            entries = GreencheckASN.objects.select_for_update().filter(
+                hostingprovider=hosting_provider
+            )
+
             # Iterate database entries
             for entry in entries:
-                if entry.asn in active_addresses:
+                if entry.asn in active_networks:
+                    active_networks.pop(active_networks.index(entry.asn))
                     entry.active = True
                     entry.save()
 
-                    updated_addresses += 1
+                    updated_networks += 1
                     logger.debug(entry)
                 elif entry.active == True:
                     entry.active = False
                     entry.save()
 
-                    updated_addresses += 1
+                    updated_networks += 1
                     logger.debug(entry)
 
-            # # Iterate remaining list items (that are not in the database)
-            # if active_addresses:
-            #     for address in active_addresses:
-            #         # # TODO: FOLLOWING NEEDS SOME WORK. 
-            #         # OPTION 1
-            #         entry, created = GreencheckASN.objects.update_or_create(
-            #             active=True, asn=address, hostingprovider=hosting_provider
-            #         )
-            #         entry.save()
+            # Iterate remaining list items (that are not in the database)
+            if active_networks:
+                for asn_network in active_networks:
+                    entry, created = GreencheckASN.objects.update_or_create(
+                        active=True, asn=asn_network, hostingprovider=hosting_provider
+                    )
+                    entry.save()
 
-            #         if created:
-            #             logger.debug(entry)
+                    if created:
+                        logger.debug(entry)
 
-            #         # OPTION 2
-            #         entry = GreencheckASN.objects.filter(hostingprovider=hosting_provider, asn=address).first()
-            #         if entry == False:
-            #             entry.active = True
-            #             entry.save()
+        return updated_networks
 
-            #             updated_addresses += 1
-            #             logger.debug(entry)
+    def update_ip(cls, active_networks: List[str]) -> int:
+        updated_networks = 0
 
-        return updated_addresses
-
-    def update_ip(cls, active_addresses: List[str]):
-        updated_addresses = 0
-
-        # Convert list of networks (ip with subnet) to list of
-        # start and end ip addresses.
+        # Convert networks (xxx.xxx.xxx.xxx/yy) to a
+        # start and end ip address
         tmp_list = []
-        for address in active_addresses:
-            network = ipaddress.ip_network(address)
+        for ip_network in active_networks:
+            network = ipaddress.ip_network(ip_network)
             tmp_list.append((str(network[1]), str(network[-1])))
-        active_addresses = tmp_list
-
-        # Retrieve all IP(v4 and v6) entries assosiated to this hosting provider
-        hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
-        entries = GreencheckIp.objects.select_for_update().filter(
-            hostingprovider=hosting_provider
-        )
+        active_networks = list(set(tmp_list))
 
         logger.debug("Running atomic database transaction. Altered IP ranges:")
         with transaction.atomic():
+            # Retrieve all IP(v4 and v6) entries assosiated to this hosting provider
+            hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
+            entries = GreencheckIp.objects.select_for_update().filter(
+                hostingprovider=hosting_provider
+            )
+
             # Iterate database entries
             for entry in entries:
-                if (entry.ip_start, entry.ip_end) in active_addresses:
-                    active_addresses.pop(
-                        active_addresses.index((entry.ip_start, entry.ip_end))
+                if (entry.ip_start, entry.ip_end) in active_networks:
+                    active_networks.pop(
+                        active_networks.index((entry.ip_start, entry.ip_end))
                     )
                     entry.active = True
                     entry.save()
 
-                    updated_addresses += 1
+                    updated_networks += 1
                     logger.debug(entry)
                 elif entry.active == True:
                     entry.active = False
                     entry.save()
 
-                    updated_addresses += 1
+                    updated_networks += 1
                     logger.debug(entry)
 
             # Iterate remaining list items (that are not in the database)
-            # if active_addresses:
-            #     for address in active_addresses:
-                    # # TODO: FOLLOWING NEEDS SOME WORK. 
-                    # # OPTION 1
-                    # entry, created = GreencheckIp.objects.update_or_create(
-                    #     active=True,
-                    #     ip_start=address[0],
-                    #     ip_end=address[1],
-                    #     hostingprovider=hosting_provider,
-                    # )
-                    # entry.save()
+            if active_networks:
+                for ip_network in active_networks:
+                    entry, created = GreencheckIp.objects.update_or_create(
+                        active=True,
+                        ip_start=ip_network[0],
+                        ip_end=ip_network[1],
+                        hostingprovider=hosting_provider,
+                    )
+                    entry.save()
 
-                    # if created:
-                    #     logger.debug(entry)
+            if created:
+                logger.debug(entry)
 
-                    # # OPTION 2
-                    # entry = GreencheckIp.objects.filter(hostingprovider=hosting_provider, 
-                    #     ip_start=address[0],
-                    #     ip_end=address[1]).first()
-                        
-                    # pdb.set_trace()
-                    # if entry.active == False:
-                    #     entry.active = True
-                    #     entry.save()
-
-                    #     updated_addresses += 1
-                    #     logger.debug(entry)
-
-        return updated_addresses
+        return updated_networks

--- a/apps/greencheck/importers/importer_interface.py
+++ b/apps/greencheck/importers/importer_interface.py
@@ -1,13 +1,16 @@
 import ipaddress
 import re
 import logging
+import pdb
 
-from typing import Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable, List
+from django.db import transaction
 
 from apps.greencheck.models import GreencheckIp, GreencheckASN
 from apps.accounts.models import Hostingprovider
 
 logger = logging.getLogger(__name__)
+
 
 @runtime_checkable
 class Importer(Protocol):
@@ -17,67 +20,162 @@ class Importer(Protocol):
     def parse_to_list(cls) -> list:
         raise NotImplementedError
 
-class BaseImporter():
-    hosting_provider_id:int
 
+class BaseImporter:
+    hosting_provider_id: int
+
+    # @transaction.atomic
     def process_addresses(cls, list_of_addresses: list):
-        count_asn = 0
         count_ip = 0
-        
-        # Determine the type of address (IPv4, IPv6 or ASN)for address in list_of_addresses:
+        count_asn = 0
+
         try:
-            for address in list_of_addresses:
-                if re.search("(AS)[0-9]+$", address):
-                    # Address is ASN
-                    cls.save_asn(cls, address)
-                    count_asn += 1
-                elif isinstance(
-                    ipaddress.ip_network(address),
-                    (ipaddress.IPv4Network, ipaddress.IPv6Network),
-                ):
-                    # Address is IPv4 or IPv6
-                    cls.save_ip(cls, address)
-                    count_ip += 1
-            
-            return f"Processing complete. Added {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            # Prepare ASN and IP lists
+            regex = re.compile("(AS)[0-9]+$")
+            asn_list = list(filter(regex.match, list_of_addresses))
+            ip_list = list(set(list_of_addresses) - set(asn_list))
+
+            # Final ASN preparation and run updater
+            asn_list = list(map(lambda x: x.replace("AS", ""), asn_list))
+            count_asn = cls.update_asn(cls, asn_list)
+
+            # Final IP preparation and run updater
+            ip_list = list(
+                filter(
+                    lambda x: isinstance(
+                        ipaddress.ip_network(x),
+                        (ipaddress.IPv4Network, ipaddress.IPv6Network),
+                    ),
+                    ip_list,
+                )
+            )
+            count_ip = cls.update_ip(cls, ip_list)
+
+            return f"Processing complete. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
         except ValueError:
             logger.exception(
                 "Value has invalid structure. Must be IPv4 or IPv6 with subnetmask (101.102.103.104/27) or AS number (AS123456)."
             )
-            return f"An error occurred while adding new entries. Added {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
         except Exception as e:
             logger.exception("Something really unexpected happened. Aborting")
             logger.exception(e)
-            return f"An error occurred while adding new entries. Added {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
+            return f"An error occurred while adding new entries. Updated {count_asn} ASN's and {count_ip} IP's (either IPv4 and/or IPv6)"
 
-    def save_asn(cls, address: str):
-        hoster = Hostingprovider.objects.get(
-            pk=cls.hosting_provider_id
+    def update_asn(cls, active_addresses: List[str]):
+        updated_addresses = 0
+        hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
+
+        # Retrieve all ASN entries assosiated to this hosting provider
+        entries = GreencheckASN.objects.select_for_update().filter(
+            hostingprovider=hosting_provider
         )
 
-        gc_asn, created = GreencheckASN.objects.update_or_create(
-            active=True, asn=int(address.replace("AS", "")), hostingprovider=hoster
+        logger.debug("Running atomic database transaction. Altered AS numbers:")
+        with transaction.atomic():
+            # Iterate database entries
+            for entry in entries:
+                if entry.asn in active_addresses:
+                    entry.active = True
+                    entry.save()
+
+                    updated_addresses += 1
+                    logger.debug(entry)
+                elif entry.active == True:
+                    entry.active = False
+                    entry.save()
+
+                    updated_addresses += 1
+                    logger.debug(entry)
+
+            # # Iterate remaining list items (that are not in the database)
+            # if active_addresses:
+            #     for address in active_addresses:
+            #         # # TODO: FOLLOWING NEEDS SOME WORK. 
+            #         # OPTION 1
+            #         entry, created = GreencheckASN.objects.update_or_create(
+            #             active=True, asn=address, hostingprovider=hosting_provider
+            #         )
+            #         entry.save()
+
+            #         if created:
+            #             logger.debug(entry)
+
+            #         # OPTION 2
+            #         entry = GreencheckASN.objects.filter(hostingprovider=hosting_provider, asn=address).first()
+            #         if entry == False:
+            #             entry.active = True
+            #             entry.save()
+
+            #             updated_addresses += 1
+            #             logger.debug(entry)
+
+        return updated_addresses
+
+    def update_ip(cls, active_addresses: List[str]):
+        updated_addresses = 0
+
+        # Convert list of networks (ip with subnet) to list of
+        # start and end ip addresses.
+        tmp_list = []
+        for address in active_addresses:
+            network = ipaddress.ip_network(address)
+            tmp_list.append((str(network[1]), str(network[-1])))
+        active_addresses = tmp_list
+
+        # Retrieve all IP(v4 and v6) entries assosiated to this hosting provider
+        hosting_provider = Hostingprovider.objects.get(pk=cls.hosting_provider_id)
+        entries = GreencheckIp.objects.select_for_update().filter(
+            hostingprovider=hosting_provider
         )
-        gc_asn.save()  # Save the newly created or updated object
 
-        if created:
-            # Only log and return when a new object was created
-            logger.debug(gc_asn)
-            return gc_asn
+        logger.debug("Running atomic database transaction. Altered IP ranges:")
+        with transaction.atomic():
+            # Iterate database entries
+            for entry in entries:
+                if (entry.ip_start, entry.ip_end) in active_addresses:
+                    active_addresses.pop(
+                        active_addresses.index((entry.ip_start, entry.ip_end))
+                    )
+                    entry.active = True
+                    entry.save()
 
-    def save_ip(cls, address: str):
-        # Convert to IPv4 network with it's respective range
-        network = ipaddress.ip_network(address)
-        hoster = Hostingprovider.objects.get(
-            pk=cls.hosting_provider_id
-        )
+                    updated_addresses += 1
+                    logger.debug(entry)
+                elif entry.active == True:
+                    entry.active = False
+                    entry.save()
 
-        gc_ip, created = GreencheckIp.objects.update_or_create(
-            active=True, ip_start=network[1], ip_end=network[-1], hostingprovider=hoster
-        )
-        gc_ip.save()  # Save the newly created or updated object
+                    updated_addresses += 1
+                    logger.debug(entry)
 
-        if created:
-            # Only log and return when a new object was created
-            logger.debug(gc_ip)
-            return gc_ip
+            # Iterate remaining list items (that are not in the database)
+            # if active_addresses:
+            #     for address in active_addresses:
+                    # # TODO: FOLLOWING NEEDS SOME WORK. 
+                    # # OPTION 1
+                    # entry, created = GreencheckIp.objects.update_or_create(
+                    #     active=True,
+                    #     ip_start=address[0],
+                    #     ip_end=address[1],
+                    #     hostingprovider=hosting_provider,
+                    # )
+                    # entry.save()
+
+                    # if created:
+                    #     logger.debug(entry)
+
+                    # # OPTION 2
+                    # entry = GreencheckIp.objects.filter(hostingprovider=hosting_provider, 
+                    #     ip_start=address[0],
+                    #     ip_end=address[1]).first()
+                        
+                    # pdb.set_trace()
+                    # if entry.active == False:
+                    #     entry.active = True
+                    #     entry.save()
+
+                    #     updated_addresses += 1
+                    #     logger.debug(entry)
+
+        return updated_addresses

--- a/apps/greencheck/tests/test_base_importer.py
+++ b/apps/greencheck/tests/test_base_importer.py
@@ -2,6 +2,7 @@ import pytest
 import pathlib
 import json
 from io import StringIO
+import pdb
 
 from django.core.management import call_command
 from apps.greencheck.importers.importer_interface import BaseImporter
@@ -31,6 +32,15 @@ def hosting_provider():
         website="",
     )
 
+@pytest.fixture
+def asn_list():
+    """
+    Define a list of Autonomous System(AS) Numbers for testing.
+    Return: a list of ASN's
+    """
+
+
+
 
 @pytest.fixture
 def base_importer():
@@ -59,49 +69,49 @@ def sample_data():
 
 @pytest.mark.django_db
 class TestImporterInterface:
-    def test_save_ip(self, hosting_provider, base_importer):
-        """
-        Test saving IPv4 and IPv6 networks to the database
-        """
-        testing_ipv4 = "191.233.8.24/29"
-        testing_ipv6 = "2603:1010:304::140/123"
+    # def test_save_ip(self, hosting_provider, base_importer):
+    #     """
+    #     Test saving IPv4 and IPv6 networks to the database
+    #     """
+    #     testing_ipv4 = "191.233.8.24/29"
+    #     testing_ipv6 = "2603:1010:304::140/123"
 
-        assert (
-            GreencheckIp.objects.all().count() == 0
-        )  # Test: database is empty (for IP)
-        hosting_provider.save()  # Initialize hosting provider in database
+    #     assert (
+    #         GreencheckIp.objects.all().count() == 0
+    #     )  # Test: database is empty (for IP)
+    #     hosting_provider.save()  # Initialize hosting provider in database
 
-        # Import a single IPv4 network
-        BaseImporter.save_ip(base_importer, testing_ipv4)
+    #     # Import a single IPv4 network
+    #     BaseImporter.save_ip(base_importer, testing_ipv4)
 
-        assert (
-            GreencheckIp.objects.all().count() == 1
-        )  # Test: IPv4 is saved after insertion
+    #     assert (
+    #         GreencheckIp.objects.all().count() == 1
+    #     )  # Test: IPv4 is saved after insertion
 
-        # Import a single IPv6 network
-        BaseImporter.save_ip(base_importer, testing_ipv6)
+    #     # Import a single IPv6 network
+    #     BaseImporter.save_ip(base_importer, testing_ipv6)
 
-        assert (
-            GreencheckIp.objects.all().count() == 2
-        )  # Test: IPv6 is saved after insertion
+    #     assert (
+    #         GreencheckIp.objects.all().count() == 2
+    #     )  # Test: IPv6 is saved after insertion
 
-    def test_save_asn(self, hosting_provider, base_importer):
-        """
-        Test saving Autonomous System Numbers (ASN) networks to the database
-        """
-        testing_asn = "AS27407"
+    # def test_save_asn(self, hosting_provider, base_importer):
+    #     """
+    #     Test saving Autonomous System Numbers (ASN) networks to the database
+    #     """
+    #     testing_asn = "AS27407"
 
-        assert (
-            GreencheckASN.objects.all().count() == 0
-        )  # Test: database is empty (for ASN)
-        hosting_provider.save()  # Initialize hosting provider in database
+    #     assert (
+    #         GreencheckASN.objects.all().count() == 0
+    #     )  # Test: database is empty (for ASN)
+    #     hosting_provider.save()  # Initialize hosting provider in database
 
-        # Import a single ASN network
-        BaseImporter.save_asn(base_importer, testing_asn)
+    #     # Import a single ASN network
+    #     BaseImporter.save_asn(base_importer, testing_asn)
 
-        assert (
-            GreencheckASN.objects.all().count() == 1
-        )  # Test: ASN is saved after insertion
+    #     assert (
+    #         GreencheckASN.objects.all().count() == 1
+    #     )  # Test: ASN is saved after insertion
 
     def test_process_addresses(self, hosting_provider, base_importer, sample_data):
         """
@@ -116,8 +126,31 @@ class TestImporterInterface:
         )  # Test: database is empty (for ASN)
         hosting_provider.save()  # Initialize hosting provider in database
 
+        # TODO: This can be replaced by having a some dummy data imported beforehand
+        # ASN dummy database data
+        GreencheckASN.objects.bulk_create([
+            GreencheckASN(hostingprovider=hosting_provider, asn='29154', active=True),
+            GreencheckASN(hostingprovider=hosting_provider, asn='27466', active=False),
+            GreencheckASN(hostingprovider=hosting_provider, asn='270119', active=True),
+            GreencheckASN(hostingprovider=hosting_provider, asn='27566', active=False),
+            GreencheckASN(hostingprovider=hosting_provider, asn='270132', active=True),
+            GreencheckASN(hostingprovider=hosting_provider, asn='230132', active=True),
+        ])
+
+        # IP dummy database data
+        GreencheckIp.objects.bulk_create([
+            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="40.80.168.113", ip_end="40.80.168.119",),
+            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="18.208.0.1", ip_end="18.215.255.255",),
+            GreencheckIp(hostingprovider=hosting_provider, active=True, ip_start="2603:1040:a06:1::141", ip_end="2603:1040:a06:1::15f",),
+            GreencheckIp(hostingprovider=hosting_provider, active=True, ip_start="2603:1020:605::141", ip_end="2603:1020:605::15f",),
+            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="2603:1020:705:1::141", ip_end="2603:1020:705:1::15f",),
+            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="43.81.168.113", ip_end="43.81.168.119",),
+        ])
+
         # Process list of addresses in JSON file
         BaseImporter.process_addresses(base_importer, sample_data)
+
+        all_asn = GreencheckASN.objects.all()
 
         assert (
             GreencheckIp.objects.all().count() == 63

--- a/apps/greencheck/tests/test_base_importer.py
+++ b/apps/greencheck/tests/test_base_importer.py
@@ -1,8 +1,8 @@
+import ipaddress
 import pytest
 import pathlib
 import json
 from io import StringIO
-import pdb
 
 from django.core.management import call_command
 from apps.greencheck.importers.importer_interface import BaseImporter
@@ -32,14 +32,13 @@ def hosting_provider():
         website="",
     )
 
+
 @pytest.fixture
 def asn_list():
     """
     Define a list of Autonomous System(AS) Numbers for testing.
     Return: a list of ASN's
     """
-
-
 
 
 @pytest.fixture
@@ -69,90 +68,269 @@ def sample_data():
 
 @pytest.mark.django_db
 class TestImporterInterface:
-    # def test_save_ip(self, hosting_provider, base_importer):
-    #     """
-    #     Test saving IPv4 and IPv6 networks to the database
-    #     """
-    #     testing_ipv4 = "191.233.8.24/29"
-    #     testing_ipv6 = "2603:1010:304::140/123"
+    def test_update_asn_create(self, hosting_provider, base_importer):
+        """
+        Test creating Autonomous System Numbers (ASN) networks to the database
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        asn_testing_data = ["AS27407", "AS27403", "AS27405"]
+        asn_count = GreencheckASN.objects.all().count()
 
-    #     assert (
-    #         GreencheckIp.objects.all().count() == 0
-    #     )  # Test: database is empty (for IP)
-    #     hosting_provider.save()  # Initialize hosting provider in database
+        # Import a list of ASN networks
+        BaseImporter.update_asn(base_importer, asn_testing_data)
 
-    #     # Import a single IPv4 network
-    #     BaseImporter.save_ip(base_importer, testing_ipv4)
+        assert GreencheckASN.objects.all().count() == asn_count + len(
+            asn_testing_data
+        )  # Test: ASN values are saved after insertion
 
-    #     assert (
-    #         GreencheckIp.objects.all().count() == 1
-    #     )  # Test: IPv4 is saved after insertion
+    def test_update_asn_activate_entry(self, hosting_provider, base_importer):
+        """
+        Test activating a inactive ASN network
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        asn_number = 27407
+        existing_asn = "AS" + str(asn_number)
 
-    #     # Import a single IPv6 network
-    #     BaseImporter.save_ip(base_importer, testing_ipv6)
+        GreencheckASN.objects.create(
+            hostingprovider=hosting_provider,
+            active=False,
+            asn=asn_number,
+        )
+        assert (
+            GreencheckASN.objects.all().count() == 1
+        )  # Test: Check that there is only one entry added to the database
+        assert (
+            GreencheckASN.objects.first().active == False
+        )  # Test: Check that this entry is inactive
 
-    #     assert (
-    #         GreencheckIp.objects.all().count() == 2
-    #     )  # Test: IPv6 is saved after insertion
+        # Import existing ASN network again
+        BaseImporter.update_asn(base_importer, [(existing_asn)])
+        assert (
+            GreencheckASN.objects.first().active == True
+        )  # Test: Check that this entry is activated now
 
-    # def test_save_asn(self, hosting_provider, base_importer):
-    #     """
-    #     Test saving Autonomous System Numbers (ASN) networks to the database
-    #     """
-    #     testing_asn = "AS27407"
+    def test_update_asn_double_insert(self, hosting_provider, base_importer):
+        """
+        Test updating ASN networks twice through the update function
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        asn_count = GreencheckASN.objects.all().count()
 
-    #     assert (
-    #         GreencheckASN.objects.all().count() == 0
-    #     )  # Test: database is empty (for ASN)
-    #     hosting_provider.save()  # Initialize hosting provider in database
+        assert asn_count == 0  # Database is empty
+        asn_testing_data = ["AS27407"]
 
-    #     # Import a single ASN network
-    #     BaseImporter.save_asn(base_importer, testing_asn)
+        # Import a list of new ASN networks
+        BaseImporter.update_asn(base_importer, asn_testing_data)
 
-    #     assert (
-    #         GreencheckASN.objects.all().count() == 1
-    #     )  # Test: ASN is saved after insertion
+        assert GreencheckASN.objects.all().count() == asn_count + len(
+            asn_testing_data
+        )  # Test: ASN values are saved after insertion
+
+        # Since the ASN list is inserted, we can try to update
+        # these values again
+        BaseImporter.update_asn(base_importer, asn_testing_data)
+
+        assert GreencheckASN.objects.all().count() == asn_count + len(
+            asn_testing_data
+        )  # Test: ASN values are updated and no new entry is saved
+
+    def test_update_asn_existing_entries(self, hosting_provider, base_importer):
+        """
+        Test updating already existing ASN networks
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        asn_number = 27407
+        existing_asn = "AS" + str(asn_number)
+
+        GreencheckASN.objects.create(
+            hostingprovider=hosting_provider,
+            active=True,
+            asn=asn_number,
+        )
+        asn_count = GreencheckASN.objects.all().count()
+        assert asn_count == 1  # Test: Database already has an entry
+
+        # Import existing ASN network again
+        BaseImporter.update_asn(base_importer, [(existing_asn)])
+
+        assert (
+            GreencheckASN.objects.all().count() == asn_count
+        )  # Test: ASN value is updated and no new entry is saved
+
+    def test_update_ip_create(self, hosting_provider, base_importer):
+        """
+        Test creating IPv4 and IPv6 networks to the database
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        ip_testing_data = [
+            "191.233.8.24/29",
+            "191.105.2.24/29",
+            "2603:1010:304::140/123",
+            "2253:1310:222::140/123",
+        ]
+        ip_count = GreencheckIp.objects.all().count()
+
+        # Import a list of IP networks
+        BaseImporter.update_ip(base_importer, ip_testing_data)
+
+        assert GreencheckIp.objects.all().count() == ip_count + len(
+            ip_testing_data
+        )  # Test: IPv4 and IPv6 ip addresses are saved after insertion
+
+    def test_update_ip_activate_entry(self, hosting_provider, base_importer):
+        """
+        Test activating an inactive IP network
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        existing_network = "191.105.2.24/29"
+        network = ipaddress.ip_network(existing_network)
+        existing_start_ip = str(network[1])
+        existing_end_ip = str(network[-1])
+
+        GreencheckIp.objects.create(
+            hostingprovider=hosting_provider,
+            active=False,
+            ip_start=existing_start_ip,
+            ip_end=existing_end_ip,
+        )
+        assert (
+            GreencheckIp.objects.all().count() == 1
+        )  # Test: Check that there is only one entry added to the database
+        assert (
+            GreencheckIp.objects.first().active == False
+        )  # Test: Check that this entry is inactive
+
+        # Import existing IP network again
+        BaseImporter.update_ip(base_importer, [(existing_network)])
+        assert (
+            GreencheckIp.objects.first().active == True
+        )  # Test: Check that this entry is activated now
+
+    def test_update_ip_double_insert(self, hosting_provider, base_importer):
+        """
+        Test updating IPv4 and IPv6 networks twice through the update function
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+        ip_testing_data = ["191.105.2.24/29", "2603:1010:304::140/123"]
+
+        ip_count = GreencheckIp.objects.all().count()
+        assert ip_count == 0  # Test: Database is empty
+
+        # Import a list of new IP networks
+        BaseImporter.update_ip(base_importer, ip_testing_data)
+
+        assert GreencheckIp.objects.all().count() == ip_count + len(
+            ip_testing_data
+        )  # Test: IP values are saved after insertion
+
+        # Since the IP list is inserted, we can try to update
+        # these values again
+        BaseImporter.update_ip(base_importer, ip_testing_data)
+
+        assert GreencheckIp.objects.all().count() == ip_count + len(
+            ip_testing_data
+        )  # Test: IP values are updated and no new entry is saved
+
+    def test_update_ip_existing_entries(self, hosting_provider, base_importer):
+        """
+        Test updating already existing IPv4 and IPv6 networks
+        """
+        hosting_provider.save()  # Initialize hosting provider in database
+
+        existing_network = "191.105.2.24/29"
+        network = ipaddress.ip_network(existing_network)
+        existing_start_ip = str(network[1])
+        existing_end_ip = str(network[-1])
+
+        GreencheckIp.objects.create(
+            hostingprovider=hosting_provider,
+            active=True,
+            ip_start=existing_start_ip,
+            ip_end=existing_end_ip,
+        )
+        ip_count = GreencheckIp.objects.all().count()
+        assert ip_count == 1  # Database already has an entry
+
+        # Import existing IP network again
+        BaseImporter.update_ip(base_importer, [(existing_network)])
+
+        assert (
+            GreencheckIp.objects.all().count() == ip_count
+        )  # Test: IP value is updated and no new entry is saved
 
     def test_process_addresses(self, hosting_provider, base_importer, sample_data):
         """
         Test processing addresses(IPv4, IPv6 and/or ASN) to save
         a list with various types of networks
         """
+        hosting_provider.save()  # Initialize hosting provider in database
         assert (
             GreencheckIp.objects.all().count() == 0
         )  # Test: database is empty (for IP)
         assert (
             GreencheckASN.objects.all().count() == 0
         )  # Test: database is empty (for ASN)
-        hosting_provider.save()  # Initialize hosting provider in database
 
-        # TODO: This can be replaced by having a some dummy data imported beforehand
-        # ASN dummy database data
-        GreencheckASN.objects.bulk_create([
-            GreencheckASN(hostingprovider=hosting_provider, asn='29154', active=True),
-            GreencheckASN(hostingprovider=hosting_provider, asn='27466', active=False),
-            GreencheckASN(hostingprovider=hosting_provider, asn='270119', active=True),
-            GreencheckASN(hostingprovider=hosting_provider, asn='27566', active=False),
-            GreencheckASN(hostingprovider=hosting_provider, asn='270132', active=True),
-            GreencheckASN(hostingprovider=hosting_provider, asn='230132', active=True),
-        ])
+        # Insert ASN dummy data
+        GreencheckASN.objects.bulk_create(
+            [
+                # Next records already exist
+                GreencheckASN(
+                    hostingprovider=hosting_provider, asn="29154", active=True
+                ),
+                GreencheckASN(
+                    hostingprovider=hosting_provider, asn="27466", active=False
+                ),
+                GreencheckASN(
+                    hostingprovider=hosting_provider, asn="270119", active=True
+                ),
+                GreencheckASN(
+                    hostingprovider=hosting_provider, asn="27566", active=False
+                ),
+            ]
+        )
 
-        # IP dummy database data
-        GreencheckIp.objects.bulk_create([
-            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="40.80.168.113", ip_end="40.80.168.119",),
-            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="18.208.0.1", ip_end="18.215.255.255",),
-            GreencheckIp(hostingprovider=hosting_provider, active=True, ip_start="2603:1040:a06:1::141", ip_end="2603:1040:a06:1::15f",),
-            GreencheckIp(hostingprovider=hosting_provider, active=True, ip_start="2603:1020:605::141", ip_end="2603:1020:605::15f",),
-            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="2603:1020:705:1::141", ip_end="2603:1020:705:1::15f",),
-            GreencheckIp(hostingprovider=hosting_provider, active=False, ip_start="43.81.168.113", ip_end="43.81.168.119",),
-        ])
+        # Insert IP dummy data
+        GreencheckIp.objects.bulk_create(
+            [
+                # Next records already exist
+                GreencheckIp(
+                    hostingprovider=hosting_provider,
+                    active=False,
+                    ip_start="40.80.168.113",
+                    ip_end="40.80.168.119",
+                ),
+                GreencheckIp(
+                    hostingprovider=hosting_provider,
+                    active=False,
+                    ip_start="18.208.0.1",
+                    ip_end="18.215.255.255",
+                ),
+                GreencheckIp(
+                    hostingprovider=hosting_provider,
+                    active=True,
+                    ip_start="2603:1040:a06:1::141",
+                    ip_end="2603:1040:a06:1::15f",
+                ),
+                GreencheckIp(
+                    hostingprovider=hosting_provider,
+                    active=True,
+                    ip_start="2603:1020:605::141",
+                    ip_end="2603:1020:605::15f",
+                ),
+                GreencheckIp(
+                    hostingprovider=hosting_provider,
+                    active=False,
+                    ip_start="2603:1020:705:1::141",
+                    ip_end="2603:1020:705:1::15f",
+                ),
+            ]
+        )
 
         # Process list of addresses in JSON file
         BaseImporter.process_addresses(base_importer, sample_data)
 
-        all_asn = GreencheckASN.objects.all()
-
         assert (
             GreencheckIp.objects.all().count() == 63
             and GreencheckASN.objects.all().count() == 5
-        )  # Test: list of IPv4,IPv6 and ASN is saved after insertion
+        )  # Test: list of IPv4, IPv6 and ASN is saved after insertion


### PR DESCRIPTION
Records were only set to active and never back to inactive if they did not appear in the list given by the hosting provider.
In addition to this change I also improved the following:
- Database atomicity. Making it possible to roll back a database transaction if it goes wrong.
- More comprehensive testing

[See this issue for more info](https://github.com/thegreenwebfoundation/admin-portal/issues/260).