### PR TITLE
Update flag and notify admin feature

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -436,7 +436,7 @@ class HostingAdmin(admin.ModelAdmin):
 
             # See more:
             # https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#saving-objects-in-the-formset
-            instances = formset.save(commit=False)
+            formset.save(commit=False)
             if formset.new_objects:
                 for new_obj in formset.new_objects:
                     if isinstance(new_obj, HostingProviderNote):
@@ -445,12 +445,13 @@ class HostingAdmin(admin.ModelAdmin):
 
         formset.save()
 
+        # check for any changes in the other forms contained in the formset
         changes_in_related_objects = (
             formset.changed_objects or formset.changed_objects or formset.new_objects
         )
 
-        # we don't want flag the provider for review by internal staff when
-        # our internal staff area already the ones working on it
+        # we don't want to flag the provider for review by internal staff when
+        # our internal staff are the ones working on it
         should_flag_for_review = (
             not form.instance.is_awaiting_review and not request.user.is_admin
         )

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 GREEN_VIA_CARBON_TXT = f"green:{GreenlistChoice.CARBONTXT.value}"
+AWAITING_REVIEW_STRING = "Awaiting Review"
+AWAITING_REVIEW_SLUG = "awaiting-review"
 
 
 class Datacenter(models.Model):
@@ -209,8 +211,9 @@ class Hostingprovider(models.Model):
     def is_awaiting_review(self):
         """
         Convenience check to see if this provider is labelled as
-        awaiting a review by staff."""
-        return "awaiting-review" in self.staff_labels.slugs()
+        awaiting a review by staff.
+        """
+        return AWAITING_REVIEW_SLUG in self.staff_labels.slugs()
 
     def label_as_awaiting_review(self, notify_admins=False):
         """
@@ -221,11 +224,12 @@ class Hostingprovider(models.Model):
         the added label
         """
 
+        # we already have the label, do nothing an return early
         if self.is_awaiting_review:
             return None
 
         # otherwise, we add the label
-        self.staff_labels.add("Awaiting Review")
+        self.staff_labels.add(AWAITING_REVIEW_STRING)
 
         if notify_admins:
             link_path = reverse(
@@ -247,7 +251,7 @@ class Hostingprovider(models.Model):
                 email_text,
                 email_html,
             )
-        return self.staff_labels.get(name="Awaiting Review")
+        return self.staff_labels.get(name=AWAITING_REVIEW_STRING)
 
     def mark_as_pending_review(self, approval_request):
         """

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -205,9 +205,53 @@ class Hostingprovider(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def is_awaiting_review(self):
+        """
+        Convenience check to see if this provider is labelled as
+        awaiting a review by staff."""
+        return "awaiting-review" in self.staff_labels.slugs()
+
+    def label_as_awaiting_review(self, notify_admins=False):
+        """
+        Mark this hosting provider as in need of review by staff.
+        Sends an notification email if the provider previously
+        did not have this label.
+        Returns None if we have a label already, otherwise returns
+        the added label
+        """
+
+        if self.is_awaiting_review:
+            return None
+
+        # otherwise, we add the label
+        self.staff_labels.add("Awaiting Review")
+
+        if notify_admins:
+            link_path = reverse(
+                "greenweb_admin:accounts_hostingprovider_change", args=[self.id]
+            )
+            link_url = f"{settings.SITE_URL}{link_path}"
+
+            email_text = render_to_string(
+                "emails/provider-awaiting-review.txt",
+                context={"provider": self.name, "link_url": link_url},
+            )
+            email_html = render_to_string(
+                "emails/provider-awaiting-review.html",
+                context={"provider": self.name, "link_url": link_url},
+            )
+
+            self.notify_admins(
+                f"TGWF: {self.name} has been updated and is awaiting review",
+                email_text,
+                email_html,
+            )
+        return self.staff_labels.get(name="Awaiting Review")
+
     def mark_as_pending_review(self, approval_request):
         """
-        Accept an approval request, and if the hosting provider
+        Accept an IP / ASN approval request, and if the hosting provider
         doesn't already have outstanding approvals, notify admins
         to review the IP Range or AS network. Returns true if
         marking it as pending trigger action, otherwise false.
@@ -215,10 +259,9 @@ class Hostingprovider(models.Model):
         hosting_provider = approval_request.hostingprovider
         logger.debug(f"Approval request: {approval_request} for {hosting_provider}")
 
-        approval_requests = self.outstanding_approval_requests()
-
-        if approval_request not in approval_requests:
-            self.flag_for_review(approval_request)
+        if not self.is_awaiting_review():
+            self.label_as_awaiting_review()
+            self.request_network_review_from_admins(approval_request)
             return True
 
         return False
@@ -250,39 +293,47 @@ class Hostingprovider(models.Model):
         )
         return approval_requests
 
-    def flag_for_review(self, approval_request):
+    def notify_admins(self, subject: str, email_txt: str, email_html: str = None):
         """
-        Mark this hosting provider as in need of review by admins.
+        Send an email to the admins with the provided subject, email content.
+        If an html version email_html is provided, the html variant is provided.
+        """
+
+        msg = AnymailMessage(
+            subject=subject, body=email_txt, to=["support@thegreenwebfoundation.org"],
+        )
+
+        if email_html:
+            msg.attach_alternative(email_html, "text/html")
+        msg.send()
+
+    def request_network_review_from_admins(self, approval_request):
+        """
+        Mark the approval request for this  hosting provider as
+        in need of review by admins.
         Sends an notification via email to admins.
         """
 
         #  notify_admin_via_email(approval_request)
-        provider = approval_request.hostingprovider
         link_path = reverse(
-            "greenweb_admin:accounts_hostingprovider_change", args=[provider.id]
+            "greenweb_admin:accounts_hostingprovider_change", args=[self.id]
         )
         link_url = f"{settings.SITE_URL}{link_path}"
         ctx = {
             "approval_request": approval_request,
-            "provider": provider,
+            "provider": self,
             "link_url": link_url,
         }
         notification_subject = (
-            f"TGWF: {approval_request.hostingprovider} - "
-            "has been updated and needs a review"
+            f"TGWF: {self.name} - " "has been updated and needs a review"
         )
 
         notification_email_copy = render_to_string("flag_for_review_text.txt", ctx)
         notification_email_html = render_to_string("flag_for_review_text.html", ctx)
 
-        msg = AnymailMessage(
-            subject=notification_subject,
-            body=notification_email_copy,
-            to=["support@thegreenwebfoundation.org"],
+        self.notify_admins(
+            notification_subject, notification_email_copy, notification_email_html
         )
-
-        msg.attach_alternative(notification_email_html, "text/html")
-        msg.send()
 
     class Meta:
         # managed = False

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -259,7 +259,7 @@ class Hostingprovider(models.Model):
         hosting_provider = approval_request.hostingprovider
         logger.debug(f"Approval request: {approval_request} for {hosting_provider}")
 
-        if not self.is_awaiting_review():
+        if not self.is_awaiting_review:
             self.label_as_awaiting_review()
             self.request_network_review_from_admins(approval_request)
             return True

--- a/apps/accounts/models/user.py
+++ b/apps/accounts/models/user.py
@@ -77,8 +77,14 @@ class User(AbstractBaseUser, PermissionsMixin):
             models.Index(fields=["email_canonical"], name="email_canonical"),
         ]
 
+    # Properties
+
     def __str__(self):
         return self.username
+
+    @property
+    def is_admin(self):
+        return self.groups.filter(name="admin").exists()
 
     def get_absolute_url(self):
         return reverse("user_edit", args=[str(self.id)])

--- a/apps/accounts/templates/emails/provider-awaiting-review.html
+++ b/apps/accounts/templates/emails/provider-awaiting-review.html
@@ -1,0 +1,7 @@
+<p>Hello there.</p>
+
+<p>{{ provider }} has just updated their organisation profile. It is now awaiting review from staff.<p>
+
+<p>You can do so at the link below:</p>
+
+<p><a href="{{ link_url }}">{{ link_url }}</a></p>

--- a/apps/accounts/templates/emails/provider-awaiting-review.txt
+++ b/apps/accounts/templates/emails/provider-awaiting-review.txt
@@ -1,0 +1,7 @@
+Hello there.
+
+{{ provider }} has just updated their organisation profile. It is now awaiting review from staff.
+
+You can do so at the link below:
+
+{{ link_url }}

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -22,7 +22,7 @@ class TestHostingProviderAdminInlineRendering:
         """
         Sign in, and visit new hosting provider page.
 
-        Simulate the journey for a new user creating an hosting
+        Simulate the journey for a new user creating a hosting
         provider in the admin.
         """
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+from ipaddress import ip_address
 import pathlib
 
 import pytest
@@ -36,15 +37,15 @@ def provider_groups():
 @pytest.fixture
 def sample_hoster_user(provider_groups):
     """A user created when they register"""
-    u = UserFactory.build(username="joebloggs", email="joe@example.com")
-    u.set_password("topSekrit")
-    u.save()
+    user = UserFactory.build(username="joebloggs", email="joe@example.com")
+    user.set_password("topSekrit")
+    user.save()
 
-    u.groups.add(*provider_groups)
+    user.groups.add(*provider_groups)
     [grp.save() for grp in provider_groups]
-    u.save()
+    user.save()
 
-    return u
+    return user
 
 
 @pytest.fixture
@@ -54,20 +55,20 @@ def greenweb_staff_user():
     of internal green web staff, who are paid to maintain
     the database
     """
-    u = UserFactory.build(username="greenweb_staff", email="staff@greenweb.org")
-    u.set_password("topSekrit")
+    user = UserFactory.build(username="greenweb_staff", email="staff@greenweb.org")
+    user.set_password("topSekrit")
 
     # give them an id so we can set up many to many relationships with groups
-    u.save()
+    user.save()
 
     groups = auth_models.Group.objects.filter(
         name__in=["admin", "datacenter", "hostingprovider"]
     )
 
-    u.groups.add(*groups)
+    user.groups.add(*groups)
     [grp.save() for grp in groups]
-    u.save()
-    return u
+    user.save()
+    return user
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR introduces a few new changes

- **new notification emails for admins** - we send different emails now, and listen for more than just an IP / ASN approval request
- **updated flagging mechanism**  - we add a flag to the user that is visible in the admin, allowing us to see providers that need review
- **updated change detection mechanism** - we use the formset change detection APIs, to listen to changes made by non-admins that are made to the hosting provider, as all as any of the related items they have