### PR TITLE
Remove reference to removed polyfill

### DIFF
--- a/templates/swagger-ui.html
+++ b/templates/swagger-ui.html
@@ -18,7 +18,6 @@
     <script src="{% static 'drf-yasg/swagger-ui-dist/swagger-ui-standalone-preset.js' %}"></script>
     <script src="{% static 'drf-yasg/insQ.min.js' %}"></script>
     <script src="{% static 'drf-yasg/immutable.min.js' %}"></script>
-    <script src="{% static 'drf-yasg/url-polyfill.min.js' %}"></script>
     <script src="{% static 'greencheck/js/swagger-custom-init.js' %}"></script>
 
 {% endblock %}


### PR DESCRIPTION
This should resolve #290, where a reference to a now removed file was causing an embarassing crash.