### PR TITLE
Sort providers by partners first, then alphabetically by name

### DIFF
--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -62,7 +62,7 @@ def fetch_providers_for_country(country_code):
     """
     Return all the country providers that should be visible
     as a list, with partners listed first, then in
-    alphetical order.
+    alphabetical order.
     """
     # we need to order by partner, then alphabetical
     # order. Because the django ORM doesn't natively support
@@ -73,14 +73,16 @@ def fetch_providers_for_country(country_code):
     # values, we need to use multiple excludes
     partner_providers = (
         Hostingprovider.objects.filter(country=country_code, showonwebsite=True)
-        .exclude(partner__in=["", "None", None])
+        .filter(partner__isnull=False)
+        .exclude(partner__in=["", "None"])
         .order_by("name")
     )
-    regular_providers = (
-        Hostingprovider.objects.filter(country=country_code, showonwebsite=True)
-        .filter(partner__in=["", "None", None])
-        .order_by("name")
+    all_providers = Hostingprovider.objects.filter(
+        country=country_code, showonwebsite=True
     )
+
+    regular_providers = all_providers.exclude(id__in=partner_providers).order_by("name")
+
     # destructure the providers to build a new list,
     # with partner providers first, then regular providers
     providers = [*partner_providers, *regular_providers]
@@ -210,4 +212,3 @@ def greencheck_multi(request, url_list: str):
             result_dict[url] = result
 
     return response.Response(result_dict)
-

--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -69,16 +69,17 @@ def fetch_providers_for_country(country_code):
     # group by, and because we have hundreds of hosters for each
     # country, at a maximum we can get away with doing it in memory
 
+    all_providers = Hostingprovider.objects.filter(
+        country=country_code, showonwebsite=True
+    )
+
     # because historically we have had a mix of empty strings and null
     # values, we need to use multiple excludes
     partner_providers = (
-        Hostingprovider.objects.filter(country=country_code, showonwebsite=True)
+        all_providers.filter(country=country_code, showonwebsite=True)
         .filter(partner__isnull=False)
         .exclude(partner__in=["", "None"])
         .order_by("name")
-    )
-    all_providers = Hostingprovider.objects.filter(
-        country=country_code, showonwebsite=True
     )
 
     regular_providers = all_providers.exclude(id__in=partner_providers).order_by("name")

--- a/apps/greencheck/tests/test_legacy_v2_api.py
+++ b/apps/greencheck/tests/test_legacy_v2_api.py
@@ -64,20 +64,23 @@ class TestDirectoryListingView:
     def test_list_directory_order_grouped(self, db, hosting_provider_factory):
 
         # given: 9 providers, out of which 3 are partners
-        created_providers = []
+        partners = []
+        nonpartners = []
+        # For legacy reasons, the non-partner providers can be represented either:
+        # - with empty string
+        # - or None.
+        # The factory fixture creates non-partner and partner providers in a way
+        # that avoids those objects to be already sorted, to create a more
+        # realistic testing scenario.
         for _ in range(3):
             p1 = hosting_provider_factory.create(partner="", showonwebsite=True)
             p2 = hosting_provider_factory.create(partner="Partner", showonwebsite=True)
             p3 = hosting_provider_factory.create(partner=None, showonwebsite=True)
-            created_providers.extend([p1, p2, p3])
+            partners.append(p2)
+            nonpartners.extend([p1, p3])
 
-        sorted_partners = sorted(
-            [p for p in created_providers if p.partner], key=lambda x: x.name
-        )
-        sorted_nonpartners = sorted(
-            [p for p in created_providers if p not in sorted_partners],
-            key=lambda x: x.name,
-        )
+        sorted_partners = sorted(partners, key=lambda x: x.name)
+        sorted_nonpartners = sorted(nonpartners, key=lambda x: x.name)
 
         # when: requesting all providers
         res = legacy_views.fetch_providers_for_country("US")

--- a/apps/greencheck/tests/test_legacy_v2_api.py
+++ b/apps/greencheck/tests/test_legacy_v2_api.py
@@ -62,49 +62,32 @@ class TestDirectoryListingView:
     """
 
     def test_list_directory_order_grouped(self, db, hosting_provider_factory):
-        for _ in range(3):
-            hosting_provider_factory.create(partner="Partner", showonwebsite=True)
 
+        # given: 9 providers, out of which 3 are partners
+        created_providers = []
         for _ in range(3):
-            hosting_provider_factory.create(partner="", showonwebsite=True)
+            p1 = hosting_provider_factory.create(partner="", showonwebsite=True)
+            p2 = hosting_provider_factory.create(partner="Partner", showonwebsite=True)
+            p3 = hosting_provider_factory.create(partner=None, showonwebsite=True)
+            created_providers.extend([p1, p2, p3])
 
+        sorted_partners = sorted(
+            [p for p in created_providers if p.partner], key=lambda x: x.name
+        )
+        sorted_nonpartners = sorted(
+            [p for p in created_providers if p not in sorted_partners],
+            key=lambda x: x.name,
+        )
+
+        # when: requesting all providers
         res = legacy_views.fetch_providers_for_country("US")
 
-        # Are the first three entries the partners and also the same order?
-        partners_in_response = res[:3]
-        reg_providers_in_response = res[3:]
-
-        partners_in_db = (
-            ac_models.Hostingprovider.objects.filter(partner="Partner")
-            .order_by("name")
-            .values("name", "partner")
-        )
-
-        reg_providers_in_db = (
-            ac_models.Hostingprovider.objects.filter(partner="")
-            .order_by("name")
-            .values("name", "partner")
-        )
-
-        # Are the first entries partners, and also in ascending order?
+        # then: first 3 items in the response are partners, sorted alphabetically by name
         for index in range(3):
-            res_name = partners_in_response[index]["naam"]
-            res_partner = partners_in_response[index]["partner"]
+            assert res[index]["naam"] == sorted_partners[index].name
+            assert res[index]["partner"] == sorted_partners[index].partner
 
-            db_name = partners_in_db[index]["name"]
-            db_partner = partners_in_db[index]["partner"]
-
-            assert res_name == db_name
-            assert res_partner == db_partner
-
-        # Are the second entries not partners, but also in ascending order?
-        for index in range(3):
-            res_name = reg_providers_in_response[index]["naam"]
-            res_partner = reg_providers_in_response[index]["partner"]
-
-            db_name = reg_providers_in_db[index]["name"]
-            db_partner = reg_providers_in_db[index]["partner"]
-
-            assert res_name == db_name
-            assert res_partner == db_partner
-
+        # then: remaining items are sorted alphabetically by name
+        for index in range(6):
+            assert res[index + 3]["naam"] == sorted_nonpartners[index].name
+            assert res[index + 3]["partner"] == sorted_nonpartners[index].partner


### PR DESCRIPTION
Closes https://github.com/thegreenwebfoundation/admin-portal/issues/266.

The root cause of the bug seems to be `NULL` value comparison in SQL. The field lookup `partner__in=[1, 2, 3]` [in Django translates to](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#in) the SQL query: `SELECT ... WHERE partner IN (1, 2, 3);`. This is problematic because in SQL NULL values are not comparable:
```
> SELECT 1 WHERE NULL IN ("", NULL);
Empty set (0.00 sec)
```

The QuerySet lookup was changed to [`isnull`](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#isnull), which is handled like this in SQL:
```
> SELECT 1 WHERE NULL IS NULL;
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set (0.00 sec)
```
I also fixed the test, it failed to catch this bug before because the data that was used for the test didn't use NULL values, just empty strings.

This is fix should be enough to resolve the issue, but I suggest that we look into cleaning the data, so that we don't get bitten in the future by different presentations of non-partner providers in the database.