### PR TITLE
Add extensions for python development in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,7 +32,7 @@ tasks:
       npx rollup --config
       cd ../../../
       pipenv run ./manage.py collectstatic --no-input
-      
+
     command: ls
 
   - name: rabbitmq
@@ -80,3 +80,8 @@ ports:
     # debugging ports in vscode
   - port: 30000-50000
     onOpen: ignore
+
+vscode:
+  extensions:
+    - ms-python.python
+    - eamodio.gitlens


### PR DESCRIPTION
This PR introduces the use of pre-installed VS code extensions, so we automatically can benefit from:

- using black for formatting by default
- flake8 for catching common linting issues, rather than needing to bring them up in code review
- isort for easier to read module import orders

More below:

https://www.gitpod.io/docs/ides-and-editors/vscode-extensions