### PR TITLE
Validate IP ranges

### DIFF
--- a/apps/greencheck/admin.py
+++ b/apps/greencheck/admin.py
@@ -8,7 +8,7 @@ from apps.accounts.utils import reverse_admin_name
 
 from . import forms, models
 from .choices import StatusApproval
-from .forms import GreecheckIpApprovalForm, GreencheckIpForm
+from .forms import GreencheckIpApprovalForm, GreencheckIpForm
 from .models import GreencheckIp, GreencheckIpApprove
 
 
@@ -103,7 +103,7 @@ class GreencheckIpInline(admin.TabularInline):
 
 class GreencheckIpApproveInline(admin.TabularInline, ApprovalFieldMixin):
     extra = 0
-    form = GreecheckIpApprovalForm
+    form = GreencheckIpApprovalForm
     model = GreencheckIpApprove
     ordering = (
         "ip_start",
@@ -195,7 +195,6 @@ class GreencheckIpApproveAdmin(admin.ModelAdmin):
     list_display_links = None
     list_filter = [StatusIpFilter]
     readonly_fields = ["link"]
-
     actions = ["approve_selected"]
 
     def get_actions(self, request):

--- a/apps/greencheck/forms.py
+++ b/apps/greencheck/forms.py
@@ -121,7 +121,9 @@ class ImporterCSVForm(forms.Form):
     csv_file = FileField(required=True)
     skip_preview = BooleanField(
         required=False,
-        help_text=("Do not show the preview of what would happen. Save to the import to the database"),
+        help_text=(
+            "Do not show the preview of what would happen. Save to the import to the database"
+        ),
     )
     # replace_with_import = BooleanField(
     #     required=False,
@@ -167,9 +169,9 @@ class ImporterCSVForm(forms.Form):
         if self.importer is None:
             self.initialize_importer()
         logger.info("Skipping preview, running import")
-        
+
         provider = self.cleaned_data["provider"]
-        
+
         self.importer.process_addresses(self.ip_ranges)
         self.processed_ips = self.importer.preview(provider, self.ip_ranges)
         return self.processed_ips
@@ -250,7 +252,7 @@ class GreencheckAsnApprovalForm(ModelForm):
         return super().save(commit=commit)
 
 
-class GreecheckIpApprovalForm(ModelForm):
+class GreencheckIpApprovalForm(ModelForm):
 
     field_order = ("ip_start", "ip_end")
 

--- a/apps/greencheck/tests/test_models.py
+++ b/apps/greencheck/tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from apps.greencheck import choices, models
+from django.core import exceptions
 
 
 @pytest.fixture
@@ -66,6 +67,19 @@ class TestGreenCheckIP:
             hostingprovider=hosting_provider,
         )
         assert gcip.ip_range_length() == range_length
+
+    def test_greencheck_ip_range_validation(self, hosting_provider, db):
+        hosting_provider.save()
+        # given: invalid IP range (ip_start after ip_end)
+        greencheck_ip = models.GreencheckIp.objects.create(
+            active=True,
+            ip_start="127.0.0.2",
+            ip_end="127.0.0.1",
+            hostingprovider=hosting_provider,
+        )
+        # when validating the object, ValidationError is raised
+        with pytest.raises(exceptions.ValidationError):
+            greencheck_ip.full_clean()
 
 
 class TestGreencheckIPApproval:


### PR DESCRIPTION
Closes https://github.com/thegreenwebfoundation/admin-portal/issues/292.

Scope of changes:
- Added model-level validation to `GreencheckIp` and `GreencheckIpApprove` models. Now newly submitted IP ranges (via `ModelForm`s that are using those models) will be automatically validated - tested manually in Django admin
- Added a test for the validation logic
- Changed the order of definition of fields in `GreencheckIp` and `GreencheckIpApprove` models. Thanks to this small change `IP start` is now displayed before `IP end` in the admin panel (hopefully making it more intuitive to input the data)
- Fixed some typos and formatting (in the files that I worked on)