### PR TITLE
Update how we show datacentres - fixes #317

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -960,14 +960,12 @@ class DatacenterAdmin(admin.ModelAdmin):
             datacentre = self.model.objects.get(id=object_id)
             associated_providers_count = datacentre.hostingproviders.all().count()
 
-            if associated_providers_count > 1000:
-                extra_context["associated_providers_count"] = associated_providers_count
-                extra_context["associated_providers"] = []
-            else:
+            if associated_providers_count:
                 extra_context["associated_providers_count"] = associated_providers_count
                 extra_context[
                     "associated_providers"
                 ] = datacentre.hostingproviders.all()
+                extra_context["dc_has_providers"] = True
 
         return super().change_view(
             request,

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -149,7 +149,9 @@ class CustomUserAdmin(UserAdmin):
         # what we show for internal staff
         staff_fieldsets = (
             "Permissions",
-            {"fields": ("is_active", "is_staff", "groups"),},
+            {
+                "fields": ("is_active", "is_staff", "groups"),
+            },
         )
 
         # our usual set of forms to show for users
@@ -202,8 +204,7 @@ class HostingProviderSupportingDocumentInline(admin.StackedInline):
 
 
 class HostingProviderNoteInline(admin.StackedInline):
-    """
-    """
+    """ """
 
     extra = 1
     model = HostingProviderNote
@@ -323,10 +324,8 @@ class HostingAdmin(admin.ModelAdmin):
             messages.add_message(
                 request,
                 messages.WARNING,
-                (
-                    "No user exists for this host, so you will need to "
-                    "add an email manually"
-                ),
+                "No user exists for this host, so you will need to "
+                "add an email manually",
             )
 
         context = dj_template.Context({"host": obj, "recipient": user})
@@ -402,12 +401,16 @@ class HostingAdmin(admin.ModelAdmin):
             if valid and skip_preview:
                 # not doing preview. Run the import
                 completed_importer = form.save()
-        
+
                 context = {
                     "ip_ranges": completed_importer,
                     "provider": provider,
                 }
-                return render(request, "import_csv_results.html", context,)
+                return render(
+                    request,
+                    "import_csv_results.html",
+                    context,
+                )
 
             if valid:
                 # the save default we don't save the contents
@@ -418,7 +421,11 @@ class HostingAdmin(admin.ModelAdmin):
                     "ip_ranges": ip_ranges,
                     "provider": provider,
                 }
-                return render(request, "import_csv_preview.html", context,)
+                return render(
+                    request,
+                    "import_csv_preview.html",
+                    context,
+                )
 
             # otherwise fallback to showing the form with errors,
             # ready for another attempted submission
@@ -429,7 +436,11 @@ class HostingAdmin(admin.ModelAdmin):
                 "provider": provider,
             }
 
-            return render(request, "import_csv_preview.html", context,)
+            return render(
+                request,
+                "import_csv_preview.html",
+                context,
+            )
 
         return redirect("greenweb_admin:accounts_hostingprovider_change", provider.id)
 
@@ -653,7 +664,12 @@ class HostingAdmin(admin.ModelAdmin):
                 "Hostingprovider info",
                 {
                     "fields": (
-                        ("name", "website",), "country", "services",
+                        (
+                            "name",
+                            "website",
+                        ),
+                        "country",
+                        "services",
                     )
                 },
             )
@@ -663,11 +679,15 @@ class HostingAdmin(admin.ModelAdmin):
             "Admin only",
             {
                 "fields": (
-                    ("archived", "showonwebsite", "customer",),
+                    (
+                        "archived",
+                        "showonwebsite",
+                        "customer",
+                    ),
                     ("partner", "model"),
                     ("staff_labels",),
                     ("email_template", "preview_email_button"),
-                    ("start_csv_import_button"),
+                    "start_csv_import_button",
                 )
             },
         )
@@ -732,7 +752,9 @@ class HostingAdmin(admin.ModelAdmin):
     @mark_safe
     def send_button(self, obj):
         url = reverse_admin_name(
-            Hostingprovider, name="send_email", kwargs={"provider": obj.pk},
+            Hostingprovider,
+            name="send_email",
+            kwargs={"provider": obj.pk},
         )
         link = f'<a href="{url}" class="sendEmail">Send email</a>'
         return link
@@ -742,7 +764,9 @@ class HostingAdmin(admin.ModelAdmin):
     @mark_safe
     def preview_email_button(self, obj):
         url = reverse_admin_name(
-            Hostingprovider, name="preview_email", kwargs={"provider": obj.pk},
+            Hostingprovider,
+            name="preview_email",
+            kwargs={"provider": obj.pk},
         )
         link = f'<a href="{url}" class="sendEmail">Compose message</a>'
         return link
@@ -756,13 +780,15 @@ class HostingAdmin(admin.ModelAdmin):
         of IP ranges.
         """
         url = reverse_admin_name(
-            Hostingprovider, name="start_import_from_csv", kwargs={"provider": obj.pk},
+            Hostingprovider,
+            name="start_import_from_csv",
+            kwargs={"provider": obj.pk},
         )
         link = f'<a href="{url}" class="start_csv_import">Import IP Ranges from CSV</a>'
         return link
 
     send_button.short_description = "Import IP Ranges from a CSV file"
-    
+
     @mark_safe
     def html_website(self, obj):
         html = f'<a href="{obj.website}" target="_blank">{obj.website}</a>'
@@ -874,23 +900,34 @@ class DatacenterAdmin(admin.ModelAdmin):
         return self.readonly_fields
 
     def get_fieldsets(self, request, obj=None):
-        fieldset = [
+        fieldsets = [
             (
                 "Datacenter info",
                 {
                     "fields": (
-                        ("name", "website",),
+                        (
+                            "name",
+                            "website",
+                        ),
                         ("country", "user"),
                         ("pue", "residualheat"),
-                        ("temperature", "temperature_type",),
+                        (
+                            "temperature",
+                            "temperature_type",
+                        ),
                         ("dc12v", "virtual", "greengrid", "showonwebsite"),
                         ("model",),
                     ),
                 },
             ),
-            (None, {"fields": ("hostingproviders",)}),
         ]
-        return fieldset
+        # we only allow green web staff to add hosting providers in the admin
+        # to make these changes
+        if request.user.is_admin:
+            fieldsets.append(
+                ("Associated hosting providers", {"fields": ("hostingproviders",)}),
+            )
+        return fieldsets
 
     def get_inlines(self, request, obj):
         """

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -952,6 +952,29 @@ class DatacenterAdmin(admin.ModelAdmin):
 
         return inlines
 
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+
+        # import ipdb
+
+        # ipdb.set_trace()
+        datacentre = self.model.objects.get(id=object_id)
+        associated_providers_count = datacentre.hostingproviders.all().count()
+
+        if associated_providers_count > 1000:
+            extra_context["associated_providers_count"] = associated_providers_count
+            extra_context["associated_providers"] = []
+        else:
+            extra_context["associated_providers_count"] = associated_providers_count
+            extra_context["associated_providers"] = datacentre.hostingproviders.all()
+
+        return super().change_view(
+            request,
+            object_id,
+            form_url,
+            extra_context=extra_context,
+        )
+
     @mark_safe
     def html_website(self, obj):
         html = f'<a href="{obj.website}" target="_blank">{obj.website}</a>'

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -955,18 +955,19 @@ class DatacenterAdmin(admin.ModelAdmin):
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
 
-        # import ipdb
+        if object_id is not None:
 
-        # ipdb.set_trace()
-        datacentre = self.model.objects.get(id=object_id)
-        associated_providers_count = datacentre.hostingproviders.all().count()
+            datacentre = self.model.objects.get(id=object_id)
+            associated_providers_count = datacentre.hostingproviders.all().count()
 
-        if associated_providers_count > 1000:
-            extra_context["associated_providers_count"] = associated_providers_count
-            extra_context["associated_providers"] = []
-        else:
-            extra_context["associated_providers_count"] = associated_providers_count
-            extra_context["associated_providers"] = datacentre.hostingproviders.all()
+            if associated_providers_count > 1000:
+                extra_context["associated_providers_count"] = associated_providers_count
+                extra_context["associated_providers"] = []
+            else:
+                extra_context["associated_providers_count"] = associated_providers_count
+                extra_context[
+                    "associated_providers"
+                ] = datacentre.hostingproviders.all()
 
         return super().change_view(
             request,

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -81,6 +81,8 @@ class TestDatacenterAdmin:
         sample_hoster_user.hostingprovider = hosting_provider
         sample_hoster_user.save()
         hosting_provider.save()
+        datacenter.user = sample_hoster_user
+        datacenter.save()
 
         gcip_admin = ac_admin.DatacenterAdmin(
             ac_models.Datacenter, admin_site.greenweb_admin

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -90,4 +90,5 @@
         </p>
     {% endif %}
     
+    <hr / style="margin-bottom:1rem;">
 {% endif %}

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -1,5 +1,6 @@
 {% load admin_helpers %}
 
+
 <fieldset class="module aligned {{ fieldset.classes }}">
     {% if fieldset.name %}<h2>{{ fieldset.name }}</h2>{% endif %}
     {% if fieldset.description %}
@@ -54,3 +55,39 @@
     {% endfor %}
 
 </fieldset>
+{% if fieldset.name == "Datacenter info" %}
+    
+    {% comment %} 
+        We have too many providers to list. Do not try to list them all. 
+    {% endcomment %}
+    {% if associated_providers_count > 1000 %}
+        <h2>Associated Hosting Providers</h2>    
+        <p>There are too many hosting providers using this datacentre to display.</p>
+        <p>If you need to see this please contact support</p>
+    {% endif %}
+
+    {% comment %} 
+        We have some providers listed in this DC, show them.
+    {% endcomment %}
+    {% if associated_providers_count < 1000 and associated_providers %}
+    <h2>Hosting Providers using this datacenter</h2>
+    
+    <ul>
+    {% for provider in associated_providers %}
+        <li>
+            {{ provider.name }}
+        </li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+    
+    {% comment %}
+        We have no datacentres listed at all, say so.
+    {% endcomment %}
+    {% if associated_providers_count == 0 %}
+        <h2>Hosting Providers using this datacenter</h2>
+        <p>No hosting providers registered in our system appear to be using this datacenter
+        </p>
+    {% endif %}
+    
+{% endif %}

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -63,7 +63,11 @@
     {% if associated_providers_count > 1000 %}
         <h2>Associated Hosting Providers</h2>    
         <p>There are too many hosting providers using this datacentre to display.</p>
-        <p>If you need to see this please contact support</p>
+        <p>If you need to see the full list, please 
+            <a href="https://www.thegreenwebfoundation.org/support-form/">
+            contact support.
+            </a>
+        </p>
     {% endif %}
 
     {% comment %} 
@@ -80,6 +84,11 @@
     {% endfor %}
     </ul>
     {% endif %}
+    <p>If you need to change this, this please 
+        <a href="https://www.thegreenwebfoundation.org/support-form/">
+        contact support.
+        </a>
+    </p>
     
     {% comment %}
         We have no datacentres listed at all, say so.
@@ -88,6 +97,11 @@
         <h2>Hosting Providers using this datacenter</h2>
         <p>No hosting providers registered in our system appear to be using this datacenter
         </p>
+        <p>If you need to change this, this please 
+            <a href="https://www.thegreenwebfoundation.org/support-form/">
+            contact support.
+        </a>
+    </p>
     {% endif %}
     
     <hr / style="margin-bottom:1rem;">

--- a/templates/admin/accounts/datacenter/fieldset.html
+++ b/templates/admin/accounts/datacenter/fieldset.html
@@ -58,50 +58,35 @@
 {% if fieldset.name == "Datacenter info" %}
     
     {% comment %} 
-        We have too many providers to list. Do not try to list them all. 
+        We have some providers listed in this DC, show them.
     {% endcomment %}
-    {% if associated_providers_count > 1000 %}
-        <h2>Associated Hosting Providers</h2>    
-        <p>There are too many hosting providers using this datacentre to display.</p>
-        <p>If you need to see the full list, please 
+    {% if dc_has_providers %}
+        <h2>Hosting Providers using this datacenter</h2>
+        
+        <ul>
+        {% for provider in associated_providers %}
+            <li>
+                {{ provider.name }}
+            </li>
+        {% endfor %}
+        </ul>
+        <p>If you need to change this, this please 
             <a href="https://www.thegreenwebfoundation.org/support-form/">
             contact support.
             </a>
         </p>
-    {% endif %}
-
-    {% comment %} 
-        We have some providers listed in this DC, show them.
-    {% endcomment %}
-    {% if associated_providers_count < 1000 and associated_providers %}
-    <h2>Hosting Providers using this datacenter</h2>
-    
-    <ul>
-    {% for provider in associated_providers %}
-        <li>
-            {{ provider.name }}
-        </li>
-    {% endfor %}
-    </ul>
-    {% endif %}
-    <p>If you need to change this, this please 
-        <a href="https://www.thegreenwebfoundation.org/support-form/">
-        contact support.
-        </a>
-    </p>
-    
     {% comment %}
         We have no datacentres listed at all, say so.
     {% endcomment %}
-    {% if associated_providers_count == 0 %}
+    {% else  %}
         <h2>Hosting Providers using this datacenter</h2>
         <p>No hosting providers registered in our system appear to be using this datacenter
         </p>
         <p>If you need to change this, this please 
             <a href="https://www.thegreenwebfoundation.org/support-form/">
             contact support.
-        </a>
-    </p>
+            </a>
+        </p>
     {% endif %}
     
     <hr / style="margin-bottom:1rem;">


### PR DESCRIPTION
This PR changes the how we present the data centre page to only allow green web staff to associate providers with a given datacentre.

Previously we allowed hosting providers to declare this connection, which we would validate afterwards, but this switches it around so that we only update information once we have had a request to update it, and approved the change.

**What normal, non staff users see**

With this PR merged in, regular users see something like this example provider. You can see hosting providers associated with the datacentre, but you can not change them. We link to a support form to request changes. Very few changes are made to datacentres each month (I only saw 6 in Sept) so this doesn't sound like it would create a massive support burden.

<img width="1248" alt="Screenshot 2022-10-13 at 12 17 35" src="https://user-images.githubusercontent.com/17906/195571452-3be00d98-06f7-4583-9ba6-cc0b698604f7.png">

**What green web staff see**

Our internal admin staff see a similar view, but have the widget to make a change too now.

<img width="918" alt="Screenshot 2022-10-13 at 12 17 48" src="https://user-images.githubusercontent.com/17906/195571503-64898054-227a-4294-9158-5d08a0d17db1.png">

