### PR TITLE
WIP - Update API to list more of the supply chain for a given resolved IP address. Fixes #316

### DIFF
--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -16,7 +16,17 @@ from ..serializers import GreenDomainSerializer
 
 logger = logging.getLogger(__name__)
 
+from ..viewsets import AbstractGreenDomainViewset
+
 checker = GreenDomainChecker()
+
+
+class GreenDomainViewset(AbstractGreenDomainViewset):
+    """
+    The legacy version of our API, served at the older `greencheck` routes, with
+    """
+
+    pass
 
 
 def augmented_greencheck(check):

--- a/apps/greencheck/tests/__init__.py
+++ b/apps/greencheck/tests/__init__.py
@@ -5,6 +5,8 @@ import webbrowser
 
 from django.utils import timezone
 
+from apps.greencheck.models.checks import SiteCheck
+
 from ...accounts import models as ac_models
 from .. import legacy_workers
 from .. import models as gc_models
@@ -24,14 +26,18 @@ def create_greendomain(hosting_provider, sitecheck):
 
 
 def greencheck_sitecheck(
-    domain,
+    domain: str,
     hosting_provider: ac_models.Hostingprovider,
     green_ip: gc_models.GreencheckIp,
-):
+) -> SiteCheck:
+    """
+    Return a sitecheck object for the provided domain,
+    hosting provider and green ip range.
+    """
 
     return gc_models.SiteCheck(
         url=domain,
-        ip="192.30.252.153",
+        ip=green_ip.ip_start,
         data=True,
         green=True,
         hosting_provider_id=hosting_provider.id,

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,7 @@ register(gc_factories.GreenIpFactory)
 register(gc_factories.GreenDomainFactory)
 register(gc_factories.DailyStatFactory)
 register(gc_factories.SiteCheckFactory)
+register(gc_factories.GreenIpFactory)
 
 
 @pytest.fixture

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,11 @@ author = (
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinxcontrib.mermaid"]
+extensions = ["myst_parser", "sphinxcontrib.mermaid", ""]
+
+# Myst has some extra extensions if we want to support some
+# https://myst-parser.readthedocs.io/en/latest/syntax/optional.html?highlight=admonition#
+myst_enable_extensions = ["html_admonition"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/how-we-check-for-green.md
+++ b/docs/how-we-check-for-green.md
@@ -36,7 +36,6 @@ There will be cases where an organisation isn't running its own servers or other
 
 In this case a domain might be `my-cool-site.com`, which resolving to the IP address, which we then link to Provider A, the organisation.
 
-
 ### Domain, to IP to provider, by ASN
 
 For some larger providers, maintaining a register of every single IP Range with the green web foundation can be cumbersome, so we also support lookups by Autonomous System Network (ASN) instead.
@@ -68,3 +67,20 @@ The final supported approach, which is currently under development, is to avoid 
 Here we follow a link from the domain name to a `carbon.txt` file at one of a few well known locations, somewhat like `robots.txt` works, or how some DNS TXT record lookups work. We then parse the `carbon.txt` file to follow the links to the necessary providers.
 
 For more, please follow the link to the [github repo where the syntax and conventions are being worked at out](https://github.com/thegreenwebfoundation/carbon.txt).
+
+###  Handling multiple IP matches
+
+<div class="admonition note" name="html-admonition">
+<p class="title">This is the **title**</p>
+Ths section below is WIP, and not in production
+</div>
+
+When we get a request for a domain, we convert this to a single IP, and if we find a matching hosting provider, we return the provider.
+
+in the case of multiple matches we return the first match, PLUS the extra matches as a separate property. We account for this ordering in the following places
+
+1. looking up a the response for detail lookup we currently offer in the admin
+2. ~~how we build an API response for the quick lookups from the green domain 'cache' table~~
+3. ~~how we build an API response for the extended lookups when we skip the green domain cache table~~
+4. ~~how we return results for the workers in the message queue writing to the greencheck log table~~
+5. ~~how we build the image badges~~

--- a/greenweb/urls.py
+++ b/greenweb/urls.py
@@ -106,7 +106,7 @@ urlpatterns += [
     # it behind the reverse proxy
     path(
         "greencheck/<url>",
-        GreenDomainViewset.as_view({"get": "retrieve"}),
+        legacy_views.GreenDomainViewset.as_view({"get": "retrieve"}),
         name="green-domain-detail",
     ),
     path(
@@ -114,7 +114,11 @@ urlpatterns += [
         legacy_views.latest_greenchecks,
         name="legacy-latest-greenchecks",
     ),
-    path("data/directory/", legacy_views.directory, name="legacy-directory-listing",),
+    path(
+        "data/directory/",
+        legacy_views.directory,
+        name="legacy-directory-listing",
+    ),
     path(
         "data/hostingprovider/<id>",
         legacy_views.directory_provider,


### PR DESCRIPTION
This PR introduces an update to our v3 API, to expand the payload we return in API requests, to show the full list of matching providers instead of just the first one.

This paves the way to update the greencheck on our main website to do the same, which should help resolve issue #316, which provides more detail.

https://github.com/thegreenwebfoundation/admin-portal/issues/316

### Implementing this

To make this change, we will need to account for the way we perform lookups in a number of other places, as a change in the underlying greencheck logic will cascade through the following places:

1. looking up a the response for detail lookup we currently offer in the admin
2. how we build an API response for the quick lookups from the green domain 'cache' table
3. how we build an API response for the extended lookups when we skip the green domain cache table
4. how we return results for the workers in the message queue writing to the greencheck log table
5. how we build the image badges



