### PR TITLE
First pass at directory filtering

### DIFF
--- a/.github/workflows/run-deploy-staging.yml
+++ b/.github/workflows/run-deploy-staging.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run playbook
         uses: dawidd6/action-ansible-playbook@v2
         with:
-          playbook: ./ansible/deploy-staging.yml
+          playbook: ./ansible/deploy.yml
           directory: ./
           key: ${{secrets.SSH_PRIVATE_KEY}}
           inventory: |

--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,6 @@ sphinxcontrib-mermaid = "==0.7.1"
 furo = "*"
 myst-parser = "*"
 ansible-lint = "*"
-awscli = "*"
 awscli-plugin-endpoint = "*"
 
 [packages]
@@ -86,6 +85,7 @@ pandas = "*"
 rich = "*"
 duckdb = "==0.5.0"
 dateutils = "*"
+django-filter = "*"
 
 [pipenv]
 # Needed for `black`. See https://github.com/microsoft/vscode-python/pull/5967.

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "99efcf7c5c8ab2b42d48d5d42121185a1661217969afd8fffb45ad0fd9f0385c"
+            "sha256": "379434175833c0fba2dd63fd382b3e5e64a78616f4f00991af894e6f3284e2f4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -167,19 +167,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:03e5055d64a596f7a95ed0ca9fda1b67b7aed00d428e4ccef97f2f82b72ec875",
-                "sha256:4bbfe9540673940f5a3dea505c5469f48708a56fb588640adb8b6ab7d5f425be"
+                "sha256:3b0fa19390895e664045713f2e47e63ad29c9f98b7bee6836dec7124953e48b8",
+                "sha256:9feb98e045736f943c2099d955415cfe44133e03d8e2d7581d2e5dc74d0ed064"
             ],
             "index": "pypi",
-            "version": "==1.25.4"
+            "version": "==1.26.1"
         },
         "botocore": {
             "hashes": [
-                "sha256:09387978a75e7108aa15e8d67bfeb7938cce3d7043339c971daf4277dc4db804",
-                "sha256:ade670506c9e837f61d590873a11c5d06ab9a8492b8d5b853d6c4059ecddc03d"
+                "sha256:75c65130ffab527d0a3d948c6d87eb8eac210e079e1ff2768c66484be57bb77c",
+                "sha256:e38b7cdce927cefabe45608dde61660b76458fba6624240dcdb6c4b8453d17f7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.4"
+            "version": "==1.29.1"
         },
         "brotli": {
             "hashes": [
@@ -423,6 +423,14 @@
             ],
             "index": "pypi",
             "version": "==2.2.5"
+        },
+        "django-filter": {
+            "hashes": [
+                "sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb",
+                "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"
+            ],
+            "index": "pypi",
+            "version": "==22.1"
         },
         "django-logentry-admin": {
             "hashes": [
@@ -704,64 +712,64 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:0502524e5564efcbaa8fe95e3f954567d7c3d8b1081954051e427ecdf5975e06",
-                "sha256:059857703c87d93053057e1f00556204fd59e5c00818a717edad3357606cc8fb",
-                "sha256:08107508d0f275199ad862db88a0f4c07421f8702c9c9ebe846729b92d357315",
-                "sha256:0e2aac2d1afeb3c42dc2a8f008e54712da5c0553161dc39e553f249ee301c759",
-                "sha256:0f8fcac3b98c1149d3f35c57c10b62bc672b283f859a3d86f0a98d0e2aa65c66",
-                "sha256:10f74c6ae5fb1a474bc7fb7f7bd9343e756e5fd51e7a75beaf8cbe284cf0b5ba",
-                "sha256:11a63231b3fb172419beb83cae40bc7d1c485e836d73bad39e4f011b018f8044",
-                "sha256:1603a8a3e52073cabe7c4d1b59fc12649d11c31a1421a9eb4a452866dae24d17",
-                "sha256:20a6e4c4a4de7f7249dc5523332c4acbff78a950ff6e28833b879e307e99820f",
-                "sha256:298c8a0b44c119a7b40dfd30385f9e078fbc1cd8875159af923f0387d18ca3cb",
-                "sha256:2bbfe78832e7ef297a5f3b6fb46803dd3c9f656682958344aa8b52a6301033eb",
-                "sha256:2cd5c7f7ba5d10722afb1d21ffd8e0538cc87b2addb66e8a47e67140acd3c755",
-                "sha256:37a975cc65c6f7e76df87791784e4e7004040b54f853d2fb860efa8d01375cfa",
-                "sha256:3a6e7e0cfc30bd20c9d272576cd1dae924072ce97e87072d5bd4ae625b928978",
-                "sha256:3dd36c8127e0422324cff24b3ee60e5a53af649fdab45c90502b8dc29f18a861",
-                "sha256:3dff863b7b33ce1509d9896e6485d17753ff877a56563179bb46224cf3387474",
-                "sha256:430a57d72026b79d85725d98e83b450fbc121103a6fd98e3ca109013e609428e",
-                "sha256:466fd81096a849ddbfc5c4e24d5796ba2a9323301e95adb32e5d75e055534950",
-                "sha256:4d021fbc6b2bcdb6c21da96c33652f9e6fc7737dc16b7b6abc039f4c34a44c57",
-                "sha256:5195aae644098e8c3022a2549facc43ff774930f5a6ec095aea0cd366570e098",
-                "sha256:52e29d146b54562916d01d7473265c31e5cba2214f5b2bb4b08ae291d7665779",
-                "sha256:58051fa14f1f4693aab9d1766382defc81e4a18290f7f98a999df0a54ee67873",
-                "sha256:5a627c76f8b5345aadd3a219dfaa0186302fb2392ca49fe6b63fc44b9636172e",
-                "sha256:652cf364f02c2670896e4d8a6102e873569a9987c0e0ca824e9785e52c30c950",
-                "sha256:73177d1c8fefc8c3be69da5c08b7e302ac603cc45e7d26ed574339e535f6ad66",
-                "sha256:782eb56931441178314e916585e55a777602df5c985ad83e6ea3486a1d1d898d",
-                "sha256:7fbf5fc684b1acf470d3003f9fe39cadad246d870bb50d4cc98bd898ce5669c6",
-                "sha256:8ad507fe529ab09191d388e2608adae480ff7c5752b3161dc4725d0c834e90f1",
-                "sha256:923ada3455752cd9797167f4bf22c18143098e67330cdabcf26816d9dee00e93",
-                "sha256:9a8fbf932e4f3916f721efcb669159ba7a485ed8d2d0d8a6dbb393f333bbc693",
-                "sha256:9dbc50c2caf149240edf30375958be364a5bd2bd40454bfcd47311652d5a24de",
-                "sha256:9e83b1b229a5cd141c0f5c76250923429eb64ed7e780c2e158a91fbcf3b6a460",
-                "sha256:a0cad06726797abce4d357865f4e8627ea10f37c4b25f3d643943e92ee0277b1",
-                "sha256:a185ab29aa37980f296be03ff45a1e6290fd2f7d8faced3932ee1a59d76cdf7b",
-                "sha256:aa602ee1bf0ab3886de926916269d2f78259d8aaa756c58bc299b14c2ef99cea",
-                "sha256:abb2f9fd173337c88151de7ae9058f492c5b46e9caa3a340cf305e2a44d46240",
-                "sha256:b57cb7fe60c4a33321805143db3305d73401550bc718237878c1c334a7cb4a15",
-                "sha256:b6dcc481c0a56d5b4bb72b46dde437d824c65d238300c86a3f74a1828faf9281",
-                "sha256:b92eb2eb267412aebd82981689f46f646e188f6363138c3ba0052a415f8a8cd3",
-                "sha256:be0ce0bb1f2b190b63ba8fbcd3421bf4f5ea8638c2dd31bc8e56df581fc8b18e",
-                "sha256:be5b0adf7127065f1f4dafb2a720c58a01fc73487549c44051cf1a87c77b3c1c",
-                "sha256:d19e9df8cc5d15f14ce85d50732cdbd79995d15d423d753324a40eb34b4b9400",
-                "sha256:dd80083896e84b3960e2a8d88d827047497103d1c20e11230ca41202e160a83d",
-                "sha256:de0fbcce865d9103fb26c0ccba520f1ad384dcb26320e7f0656f97ceab1a3286",
-                "sha256:e001d4399a0295f1c836b09f53c61bb7dec10991979a4d62298cb0ce88d7ce71",
-                "sha256:e1da38d414d96d9a3623a0d65a636177ba615099d559c456b722eb097675d1d3",
-                "sha256:e9793e903e82bbcc179c70e9ffa60f232deef9be9f05a10a122e53d41af258d3",
-                "sha256:efe988844097d1014b89ea14e105459163fa98d4446f719c357bdf3fe1f6d951",
-                "sha256:f378d6e190203c3981d3a3e1c0e0ae928410fdfa8ee11006aa2a91f9ede7309f",
-                "sha256:f463a2da1ce1a3b79caf15a9146a359e96efd51856f868928602da998bf1486b",
-                "sha256:f482a5017c67376160a3d1604f546d49ffe6e67e064cab5f91e236477116a8c2",
-                "sha256:f9da3ef1f005e7dca76885f8878d9cc0192e6898aef49d89ac6c45be46d63246",
-                "sha256:fad5d3f33691f080a01dbe819f75d59ee0d5a54d8bea3543d0c6731a0233e63f",
-                "sha256:fe42f3d63936a8777ec8e432f91937b436fa311acc2a2541e27834fe93f0448c",
-                "sha256:ff7f2838d1d2bff570b6f699aee7572e73d8ddb102d254aab9d3d175070da609"
+                "sha256:069a8a557541a04518dc3beb9a78637e4e6b286814849a2ecfac529eaa78562b",
+                "sha256:089e123d80dbc6f61fff1ff0eae547b02c343d50968832716a7b0a33bea5f792",
+                "sha256:09f00f9938eb5ae1fe203558b56081feb0ca34a2895f8374cd01129ddf4d111c",
+                "sha256:0ba0f2e5c4a8f141952411e356dba05d6fe0c38325ee0e4f2d0c6f4c2c3263d5",
+                "sha256:0fa2a66fdf0d09929e79f786ad61529d4e752f452466f7ddaa5d03caf77a603d",
+                "sha256:1cfeae4dda32eb5c64df05d347c4496abfa57ad16a90082798a2bba143c6c854",
+                "sha256:20bf68672ae14ef2e2e6d3ac1f308834db1d0b920b3b0674eef48b2dce0498dd",
+                "sha256:2b8e1c939b363292ecc93999fb1ad53ffc5d0aac8e933e4362b62365241edda5",
+                "sha256:2be628bca0395610da08921f9376dd14317f37256d41078f5c618358467681e1",
+                "sha256:2f5d396a5457458460b0c28f738fc8ab2738ee61b00c3f845c7047a333acd96c",
+                "sha256:30198bccd774f9b6b1ba7564a0d02a79dd1fe926cfeb4107856fe16c9dfb441c",
+                "sha256:341053e0a96d512315c27c34fad4672c4573caf9eb98310c39e7747645c88d8b",
+                "sha256:3cc1abaf47cfcfdc9ac0bdff173cebab22cd54e9e3490135a4a9302d0ff3b163",
+                "sha256:3dc294afebf2acfd029373dbf3d01d36fd8d6888a03f5a006e2d690f66b153d9",
+                "sha256:49fcdd8ae391ffabb3b672397b58a9737aaff6b8cae0836e8db8ff386fcea802",
+                "sha256:4a1953465b7651073cffde74ed7d121e602ef9a9740d09ee137b01879ac15a2f",
+                "sha256:4be4dedbd2fa9b7c35627f322d6d3139cb125bc18d5ef2f40237990850ea446f",
+                "sha256:4c5ddadfe40e903c6217ed2b95a79f49e942bb98527547cc339fc7e43a424aad",
+                "sha256:5392ddb893e7fba237b988f846c4a80576557cc08664d56dc1a69c5c02bdc80c",
+                "sha256:6b28420ae290bfbf5d827f976abccc2f74f0a3f5e4fb69b66acf98f1cbe95e7e",
+                "sha256:6c66f0da8049ee3c126b762768179820d4c0ae0ca46ae489039e4da2fae39a52",
+                "sha256:6fd342126d825b76bf5b49717a7c682e31ed1114906cdec7f5a0c2ff1bc737a7",
+                "sha256:75c022803de010294366f3608d4bba3e346693b1b7427b79d57e3d924ed03838",
+                "sha256:79687c48e7f564be40c46b3afea6d141b8d66ffc2bc6147e026d491c6827954a",
+                "sha256:7acaa51355d5b9549d474dc71be6846ee9a8f2cb82f4936e5efa7a50bbeb94ad",
+                "sha256:8e8dbad9b4f4c3e37898914cfccb7c4f00dbe3146333cfe52a1a3103cc2ff97c",
+                "sha256:939963d0137ec92540d95b68b7f795e8dbadce0a1fca53e3e7ef8ddc18ee47cb",
+                "sha256:98b848a0b75e76b446dc71fdbac712d9078d96bb1c1607f049562dde1f8801e1",
+                "sha256:99e9851e40150504474915605649edcde259a4cd9bce2fcdeb4cf33ad0b5c293",
+                "sha256:9a4a9fea68fd98814999d91ea585e49ed68d7e199a70bef13a857439f60a4609",
+                "sha256:9d8dca31a39dd9f25641559b8cdf9066168c682dfcfbe0f797f03e4c9718a63a",
+                "sha256:9e5ead803b11b60b347e08e0f37234d9a595f44a6420026e47bcaf94190c3cd6",
+                "sha256:a245898ec5e9ca0bc87a63e4e222cc633dc4d1f1a0769c34a625ad67edb9f9de",
+                "sha256:a65205e6778142528978b4acca76888e7e7f0be261e395664e49a5c21baa2141",
+                "sha256:aa2b371c3633e694d043d6cec7376cb0031c6f67029f37eef40bda105fd58753",
+                "sha256:adcf45221f253b3a681c99da46fa6ac33596fa94c2f30c54368f7ee1c4563a39",
+                "sha256:b4fd73b62c1038e7ee938b1de328eaa918f76aa69c812beda3aff8a165494201",
+                "sha256:b89b78ffb516c2921aa180c2794082666e26680eef05996b91f46127da24d964",
+                "sha256:bc283f99a4815ef70cad537110e3e03abcef56ab7d005ba9a8c6ec33054ce9c0",
+                "sha256:c1e93ef863810fba75faf418f0861dbf59bfe01a7b5d0a91d39603df58d3d3fa",
+                "sha256:c3aa7d3bc545162a6676445709b24a2a375284dc5e2f2432d58b80827c2bd91c",
+                "sha256:c8c67ecda450ad4eac7837057f5deb96effa836dacaf04747710ccf8eeb73092",
+                "sha256:cc211c2ff5d3b2ba8d557a71e3b4f0f0a2020067515143a9516ea43884271192",
+                "sha256:d4e7642366e638f45d70c5111590a56fbd0ffb7f474af20c6c67c01270bcf5cf",
+                "sha256:d58d4b4dc82e2d21ebb7dd7d3a6d370693b2236a1407fe3988dc1d4ea07575f9",
+                "sha256:d65d7d1ff64fb300127d2ffd27db909de4d21712a5dde59a3ad241fb65ee83d7",
+                "sha256:d71feebf5c8041c80dfda76427e14e3ca00bca042481bd3e9612a9d57b2cbbf7",
+                "sha256:d8bacecee0c9348ab7c95df810e12585e9e8c331dfc1e22da4ed0bd635a5f483",
+                "sha256:e0d7efab8418c1fb3ea00c4abb89e7b0179a952d0d53ad5fcff798ca7440f8e8",
+                "sha256:e7a0dca752b4e3395890ab4085c3ec3838d73714261914c01b53ed7ea23b5867",
+                "sha256:e7ec3f2465ba9b7d25895307abe1c1c101a257c54b9ea1522bbcbe8ca8793735",
+                "sha256:eca9c0473de053dcc92156dd62c38c3578628b536c7f0cd66e655e211c14ac32",
+                "sha256:efdbbbf7b6c8d5be52977afa65b9bb7b658bab570543280e76c0fabc647175ed",
+                "sha256:f7edbd2957f72aea357241fe42ffc712a8e9b8c2c42f24e2ef5d97b255f66172",
+                "sha256:f8a10e14238407be3978fa6d190eb3724f9d766655fefc0134fd5482f1fb0108"
             ],
             "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
-            "version": "==2.0.0rc4"
+            "version": "==2.0.0"
         },
         "gunicorn": {
             "hashes": [
@@ -1004,7 +1012,7 @@
                 "sha256:f2f390aa4da44454db40a1f0201401f9036e8d578a25f01a6e237cea238337ef",
                 "sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.10'",
             "version": "==1.23.4"
         },
         "packaging": {
@@ -1168,10 +1176,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
-                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
+                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
+                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
             ],
-            "version": "==2022.5"
+            "version": "==2022.6"
         },
         "pyyaml": {
             "hashes": [
@@ -1418,7 +1426,7 @@
                 "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
                 "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.9'",
             "version": "==4.4.0"
         },
         "unicodecsv": {
@@ -1440,7 +1448,7 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.26.12"
         },
         "whitenoise": {
@@ -1608,27 +1616,27 @@
         },
         "ansible-compat": {
             "hashes": [
-                "sha256:7a012753a0a02dab2f22b0e574e3e7b00399f660606154474ffe25621fa80d3b",
-                "sha256:8857b317bf36a00dbb0b06640d19b68bb64f667bf2a5355189f3c5961f4b1c10"
+                "sha256:5589582a165a44a7ab012dabd91a28a897e63daf96ffea655b7e9db38517b648",
+                "sha256:6a2c3ade5005530cdfdd8e961c784b1718f17ad480a1be5a8014bff89c9c9c2e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.1"
+            "version": "==2.2.4"
         },
         "ansible-core": {
             "hashes": [
-                "sha256:26dcd9218d5544cc15144f60bb5b634f2276e476c89f481b3f619c4f9def1588",
-                "sha256:3d2503ede324e0e73051b14e77f732a3cb0aed2437f94608af53929d2d1d54c8"
+                "sha256:698b41f0ec6e5c3f0a6b6593d451d1b7286a890e681736ec26c6f1124647d90a",
+                "sha256:f6e6ee485447ac02ef5efe31c2650b798c10119a8c73dda0f93bf76613f50348"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.13.5"
+            "version": "==2.13.6rc1"
         },
         "ansible-lint": {
             "hashes": [
-                "sha256:6064cfa95403674ed6ea77b852705333f79f545d154b62a9ec7968179ba4f72b",
-                "sha256:b7c9afbda3da25e106ce648fb9846765237c672bacafd069f11bdaa85ece1648"
+                "sha256:171fe8dad62078b9819b5c74d60eb5afaa30ea9cb9c9ba8706149e56c55a9b6e",
+                "sha256:bac923e2fa805973838390565e2ddd792ca4ffd33d66f21ab629dd6a84407d67"
             ],
             "index": "pypi",
-            "version": "==6.8.4"
+            "version": "==6.8.6"
         },
         "asgiref": {
             "hashes": [
@@ -1640,11 +1648,11 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:86b0a340a512c65abf4368b80252754cda17c02cdbbd3f587dddf98112233e7b",
-                "sha256:bb24615c77f4837c707669d16907331374ae8a964650a66999da3f5ca68dc946"
+                "sha256:1c00a14f5a3ed0339d38d2e2e5b74ea2591df5861c0936bb292b84ccf3a78d83",
+                "sha256:72702205200b2a638358369d90c222d74ebc376787af8fb2f7f2a86f7b5cc85f"
             ],
-            "markers": "python_full_version >= '3.6.2'",
-            "version": "==2.11.7"
+            "markers": "python_full_version >= '3.7.2'",
+            "version": "==2.12.12"
         },
         "asttokens": {
             "hashes": [
@@ -1663,11 +1671,11 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:af4b6893d659af3109d90b9a645d271fb980e5b4ffd2755d7968eafd79b97590",
-                "sha256:c63311d99ae709e44c986d71503ca84221d8396856116609a8e9e1af755ccbbf"
+                "sha256:8f562da4b9dccd7fbfe0325635619f9d9f55ed0c07aa0b537d62d020b9b7726b",
+                "sha256:f6f02bf549d14378095ae20c44e42047d7e9db2c9f88a1e623ad15cb7f2ac4a6"
             ],
-            "index": "pypi",
-            "version": "==1.26.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.27.1"
         },
         "awscli-plugin-endpoint": {
             "hashes": [
@@ -1679,11 +1687,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51",
-                "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"
+                "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe",
+                "sha256:5ef4b3226b0180dedded4229651c8b0e1a3a6a2837d45a073272f313e4cf97f6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.10.3"
+            "version": "==2.11.0"
         },
         "backcall": {
             "hashes": [
@@ -1751,11 +1759,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:09387978a75e7108aa15e8d67bfeb7938cce3d7043339c971daf4277dc4db804",
-                "sha256:ade670506c9e837f61d590873a11c5d06ab9a8492b8d5b853d6c4059ecddc03d"
+                "sha256:75c65130ffab527d0a3d948c6d87eb8eac210e079e1ff2768c66484be57bb77c",
+                "sha256:e38b7cdce927cefabe45608dde61660b76458fba6624240dcdb6c4b8453d17f7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.28.4"
+            "version": "==1.29.1"
         },
         "bracex": {
             "hashes": [
@@ -1883,99 +1891,103 @@
             "version": "==0.9.1"
         },
         "coverage": {
+            "extras": [
+                "toml"
+            ],
             "hashes": [
-                "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79",
-                "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a",
-                "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f",
-                "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a",
-                "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa",
-                "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398",
-                "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba",
-                "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d",
-                "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf",
-                "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b",
-                "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518",
-                "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d",
-                "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795",
-                "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2",
-                "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e",
-                "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32",
-                "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745",
-                "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b",
-                "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e",
-                "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d",
-                "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f",
-                "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660",
-                "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62",
-                "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6",
-                "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04",
-                "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c",
-                "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5",
-                "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef",
-                "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc",
-                "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae",
-                "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578",
-                "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466",
-                "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4",
-                "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91",
-                "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0",
-                "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4",
-                "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b",
-                "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe",
-                "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b",
-                "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75",
-                "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b",
-                "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c",
-                "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72",
-                "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b",
-                "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f",
-                "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e",
-                "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53",
-                "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3",
-                "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84",
-                "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"
+                "sha256:00858a6213ea829ab417b6e05ac0a4c22eac7d3aae67c0187de2935d0548786b",
+                "sha256:08fd9ad5dfc490b7403027b20eebb8ac470621ae1ce0b33a13cab9ec8d4aed0a",
+                "sha256:0c52c8f0243a2e4c0b81db2f6468a9084dd380e0b69e931253aa24529eb812f3",
+                "sha256:0e857ef99769a54595c8801086e310dabb8205a1e742d66f6702544aeddfb1ba",
+                "sha256:1b1cca186e74d258d983a1e1a134ffba0b991effbc8e46ee65c5fbf4009dfce1",
+                "sha256:1dcb5c17b361b35d2a339c6031417f8dcce915b09ea55e7214a398833ec9a63f",
+                "sha256:22cca1925841e2655ce35a4e17c21b42dd0de2b85c5d6fe9c5bf4a45f58950f3",
+                "sha256:25ab1d4ae4bce324d427732bf0f7967493405daa0c2675385016102b0a5e87bf",
+                "sha256:2ca9c7735da025b0f0ca00ab15c5290798b62a49feaf312cb895ab4c4bc1575e",
+                "sha256:3008ace59d566e110e9351c855c6bf2f2b4037f772caffdfaa977c485bf96e8e",
+                "sha256:3de7363b0f21ac6fc97767f78036b900006e06eadd3cc72f040d57494405f44c",
+                "sha256:409d14e37de692f94689578cbbb0a26408da9d9354f8ff658e148f1750940b2f",
+                "sha256:425ba4ae75be4e2c9ce336a523265e6e1214ad624e8d18fb638771475dec2ebf",
+                "sha256:42d7ee01583d4db8098510d08e7505db0f5dbb70edc88a7350cafc336ae81048",
+                "sha256:4e07fc0e0dc8bdeae4f23b8ff821c711dcb2537bbc782f61ff726ca07fcfdb9b",
+                "sha256:4f32113f131edcd26266b8bfc9e24698b6dee4d9ea63362b7dd3cf0a351231a6",
+                "sha256:539ca9a37aaab0ed31ccb535039e33170cf2144b8cd5006c48ad724ba2ab5797",
+                "sha256:572867facf73374a9c8686691bf1b43abe3425f31a2a9b48043d0de9f669ad0d",
+                "sha256:583f5b9a414fcabe1c14d82519b9d24dfd69c3505e9030415c3c6b692bff9062",
+                "sha256:590411083d46c182e852e879a533fa99988937a3af96f836cacbc16a1bcfd058",
+                "sha256:5a0bc8377854cc2f447093149bc9774b0628e9db218f85026d7982466840040e",
+                "sha256:5f3ee269b6d32913eccd78eefce6da7d5120d8fbef059c463c028267c1a0d1ce",
+                "sha256:639bc5e8cf323a50d17b52554269e72c21c2cb5ad14ca1b43e095ce60abbc2b3",
+                "sha256:644b9c4e7e951aa210a8150b09f9c02dcea8701d14bff1564a50e054ce0ae48d",
+                "sha256:6591db6f6bbd5120c9475fdb12305a3216355ae4797b0e44528040f6d0d8f73f",
+                "sha256:7538a24505abb5dc61ac3bbf58d5232a76ad6fd2be63cf797c2e1caa9c60077c",
+                "sha256:75598efc204f513cc4d5ca99a8f9103867993c091e5cd62d78c1020a0affc7be",
+                "sha256:7911833a156476096d209569cbe600faf22a057a46c5e8bb19fffc387abad101",
+                "sha256:7f96cd694673191583acaef50ed01c8db3b47f49602b7046a15775fa6f753e9f",
+                "sha256:89230ec0b1f3817237a8f98fc593dec061eebd753cea097772e7abcf5fb9c6bc",
+                "sha256:959d65e8c5f84878a741dcddcbf71ccc22270c6981e5dfe0806517d49be0c1f2",
+                "sha256:98220679df217b9635c3c6a7a490c408f4de169c33ac4f708a86f9e97b2d9b14",
+                "sha256:996c74a93f6fac2099c288e709e7d0bcc37f3c700d878d7d52accdcc2b6550bd",
+                "sha256:9ec68b342a82dc821d4384e7a5b266c2b78bc5ec3a59fcadf8e96445f4002366",
+                "sha256:b3b6582423aeece24478028b8c9127cd1392d584dfade6c925421c91710cdad5",
+                "sha256:b48273db5287a185017f2150eb49581245777ba30c6e749bfd5567afcab27c3f",
+                "sha256:c1b862d4718a103cd090b6b91155503574918c498a381a13970e22785c7ae5a3",
+                "sha256:c87885ca7357e85e9e1550d804c7b2c42d6e4e8260849af499fc2b0dfe58962c",
+                "sha256:c976faf3bed96d2b94ee8b005ff26a075cfbc00782b532342119cbd172481f81",
+                "sha256:ca922b6558e1fe09c2ffc772faaa411f94cb47845d366d7aa6a887d934a25200",
+                "sha256:e0101d0cb004db88891ffb87ddfccd93ee76abbe4c0bf784c4214f467d026dd2",
+                "sha256:e7a0f9ab01ccd873d21584ddcad488ad752944f6a9e5bdff1aefbe5289ffd823",
+                "sha256:e83b73d8edf255187388b8d14c0c0df580bbf8e7099060e590915e3fbcf39598",
+                "sha256:e8b80f94e15676dbaa7ce2cef6e5433cdb2427d3d81ea9fe4c3d788fae3bc4a2",
+                "sha256:e9c1a662c837cf9b4b815f977404475b555fafc0fb12ae92667d0cdbf0f3c9eb",
+                "sha256:eb54a60e3819d60de6828b5bd197996f9ecb2306d280bd532a4a4291f3285658",
+                "sha256:efb09e5004fd1e4d05cf433d7ad7a6784d090c0afd68b46e8ef785ae169a31ed",
+                "sha256:f0ae2fd15eedb5f749cd9b3da01087b7dba2f76cc783866459d8b3f3feb7c969",
+                "sha256:f0aefc3015ae4a188dc48f2ea934ddbdf158c8c4b0b3d5691acfdad684857702",
+                "sha256:f47e5f3c5acbc3b843ae89b042faf64b366a4976099813487161ce3c50649db3",
+                "sha256:fd868a0eb8eb35a84847935fe36a5b285fed2e4b99c2b90cf44778fa0e9418e9"
             ],
             "index": "pypi",
-            "version": "==6.5.0"
+            "version": "==6.6.0b1"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a",
-                "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
-                "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0",
-                "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407",
-                "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7",
-                "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6",
-                "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153",
-                "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750",
-                "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
-                "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6",
-                "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b",
-                "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5",
-                "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a",
-                "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d",
-                "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d",
-                "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294",
-                "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0",
-                "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a",
-                "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac",
-                "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61",
-                "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013",
-                "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
-                "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb",
-                "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9",
-                "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd",
-                "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"
+                "sha256:068147f32fa662c81aebab95c74679b401b12b57494872886eb5c1139250ec5d",
+                "sha256:06fc3cc7b6f6cca87bd56ec80a580c88f1da5306f505876a71c8cfa7050257dd",
+                "sha256:25c1d1f19729fb09d42e06b4bf9895212292cb27bb50229f5aa64d039ab29146",
+                "sha256:402852a0aea73833d982cabb6d0c3bb582c15483d29fb7085ef2c42bfa7e38d7",
+                "sha256:4e269dcd9b102c5a3d72be3c45d8ce20377b8076a43cbed6f660a1afe365e436",
+                "sha256:5419a127426084933076132d317911e3c6eb77568a1ce23c3ac1e12d111e61e0",
+                "sha256:554bec92ee7d1e9d10ded2f7e92a5d70c1f74ba9524947c0ba0c850c7b011828",
+                "sha256:5e89468fbd2fcd733b5899333bc54d0d06c80e04cd23d8c6f3e0542358c6060b",
+                "sha256:65535bc550b70bd6271984d9863a37741352b4aad6fb1b3344a54e6950249b55",
+                "sha256:6ab9516b85bebe7aa83f309bacc5f44a61eeb90d0b4ec125d2d003ce41932d36",
+                "sha256:6addc3b6d593cd980989261dc1cce38263c76954d758c3c94de51f1e010c9a50",
+                "sha256:728f2694fa743a996d7784a6194da430f197d5c58e2f4e278612b359f455e4a2",
+                "sha256:785e4056b5a8b28f05a533fab69febf5004458e20dad7e2e13a3120d8ecec75a",
+                "sha256:78cf5eefac2b52c10398a42765bfa981ce2372cbc0457e6bf9658f41ec3c41d8",
+                "sha256:7f836217000342d448e1c9a342e9163149e45d5b5eca76a30e84503a5a96cab0",
+                "sha256:8d41a46251bf0634e21fac50ffd643216ccecfaf3701a063257fe0b2be1b6548",
+                "sha256:984fe150f350a3c91e84de405fe49e688aa6092b3525f407a18b9646f6612320",
+                "sha256:9b24bcff7853ed18a63cfb0c2b008936a9554af24af2fb146e16d8e1aed75748",
+                "sha256:b1b35d9d3a65542ed2e9d90115dfd16bbc027b3f07ee3304fc83580f26e43249",
+                "sha256:b1b52c9e5f8aa2b802d48bd693190341fae201ea51c7a167d69fc48b60e8a959",
+                "sha256:bbf203f1a814007ce24bd4d51362991d5cb90ba0c177a9c08825f2cc304d871f",
+                "sha256:be243c7e2bfcf6cc4cb350c0d5cdf15ca6383bbcb2a8ef51d3c9411a9d4386f0",
+                "sha256:bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd",
+                "sha256:c46837ea467ed1efea562bbeb543994c2d1f6e800785bd5a2c98bc096f5cb220",
+                "sha256:dfb4f4dd568de1b6af9f4cda334adf7d72cf5bc052516e1b2608b683375dd95c",
+                "sha256:ed7b00096790213e09eb11c97cc6e2b757f15f3d2f85833cd2d3ec3fe37c1722"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==38.0.1"
+            "version": "==38.0.3"
         },
         "decorator": {
             "hashes": [
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
                 "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.5'",
             "version": "==5.1.1"
         },
         "dill": {
@@ -2046,11 +2058,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:096c15e136adb365db24d8c3964fe26bfc68fe060c9385071a339f8c14e09c8a",
-                "sha256:a741b77f484215c3aab2604100669657189548f440fcb2ed0f8b7ee21c385629"
+                "sha256:1bfb1b447cd45169a74a09f821cee47f51548508b62a29f6dfdab1d001d448a4",
+                "sha256:bd922a6ad210bb96a5b31987e10918851131c9670429172d5bfb3a5ede238a79"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==15.1.1"
+            "version": "==15.1.3"
         },
         "filelock": {
             "hashes": [
@@ -2151,7 +2163,7 @@
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.1'",
             "version": "==5.10.1"
         },
         "jedi": {
@@ -2180,11 +2192,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23",
-                "sha256:9e74b8f9738d6a946d70705dc692b74b5429cd0960d58e79ffecfc43b2221eb9"
+                "sha256:5bfcf2bca16a087ade17e02b282d34af7ccd749ef76241e7f9bd7c0cb8a9424d",
+                "sha256:f660066c3966db7d6daeaea8a75e0b68237a48e51cf49882087757bb59916248"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.16.0"
+            "version": "==4.17.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -2444,11 +2456,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:487ce2192eee48211269a0e976421f334cf94de1806ca9d0a99449adcdf0285e",
-                "sha256:fabe30000de7d07636d2e82c9a518ad5ad7908590fe135ace169b44839c15f90"
+                "sha256:2f3e1f00bf4b7f5a1b9880f62d89351754caa3e87d96b1eebc6fdbc84a92cab8",
+                "sha256:371977f62fab339be3fac7705963e3f6cba9e641191b53e216350f70d4838981"
             ],
             "index": "pypi",
-            "version": "==2.14.5"
+            "version": "==2.16.0.dev0"
         },
         "pylint-django": {
             "hashes": [
@@ -2476,31 +2488,31 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:06579d46d8ad69529b28f88711191a7fe7103c92d04a9f338dc754f71b92efa0",
-                "sha256:1d0620474d509172e1c50b79d5626bfe1899f174bf650186a50c6ce31289ff52",
-                "sha256:2032d971711643049b4f2c3ca5155a855d507d73bad26dac8d4349e5c5dd6758",
-                "sha256:2c641111c3f110379bb9001dbb26b34eb8cafab3d0fa855dc161c391461a4aab",
-                "sha256:327f99800d04a9abcf580daecfd6dd4bfdb4a7e61c71bf2cd1189ef1ca44bade",
-                "sha256:39f15ad754384e744ac8b00805913bfa66c41131faaa3e4c45c4af0731f3e8f6",
-                "sha256:4c58bd93c4d502f52938fccdbe6c9d70df3a585c6b39d900fab5f76b604282aa",
-                "sha256:62a41037387ae849a493cd945e22b34d167a843d57f75b07dbfad6d96cef485c",
-                "sha256:62b704f18526a8fc243152de8f3f40ae39c5172baff10f50c0c5d5331d6f2342",
-                "sha256:6df99c3578dc4eb33f3eb26bc28277ab40a720b71649d940bff9c1f704377772",
-                "sha256:6ef7430e45c5fa0bb6c361cada4a08ed9c184b5ed086815a85c3bc8c5054566b",
-                "sha256:73b2db09fe15b6e444c0bd566a125a385ca6493456224ce8b367d734f079f576",
-                "sha256:73d4ec2997716af3c8f28f7e3d3a565d273a598982d2fe95639e07ce4db5da45",
-                "sha256:73e3e2fd9da009d558050697cc22ad689f89a14a2ef2e67304628a913e59c947",
-                "sha256:890f577aec554f142e01daf890221d10e4f93a9b1107998d631d3f075b55e8f8",
-                "sha256:8a34a2a8b220247658f7ced871197c390b3a6371d796a5869ab1c62abe0be527",
-                "sha256:8bc23e9ddcb523c3ffb4d712aa0bd5bc67b34ff4e2b23fb557012171bdb4013a",
-                "sha256:945297fc344fef4d540135180ce7babeb2291d124698cc6282f3eac624aa5e82",
-                "sha256:aaa869d9199d7d4c70a57678aff21654cc179c0c32bcfde87f1d65d0ff47e520",
-                "sha256:bc33fc20ddfd89b86b7710142963490d8c4ee8307ed6cc5e189a58fa72390eb9",
-                "sha256:cfe6d8b293d123255fd3b475b5f4e851eb5cbaee2064c8933aa27344381744ae",
-                "sha256:d16ac5ab3d9db78fed40c884d67079524e4cf8276639211ad9e6fa73e727727e"
+                "sha256:055ab45d5911d7cae397dc418808d8802fb95262751872c841c170b0dbf51eed",
+                "sha256:111156137b2e71f3a9936baf27cb322e8024dac3dc54ec7fb9f0bcf3249e68bb",
+                "sha256:187d5730b0507d9285a96fca9716310d572e5464cadd19f22b63a6976254d77a",
+                "sha256:21455e2b16000440e896ab99e8304617151981ed40c29e9507ef1c2e4314ee95",
+                "sha256:2aede922a488861de0ad00c7630a6e2d57e8023e4be72d9d7147a9fcd2d30712",
+                "sha256:3ba4134a3ff0fc7ad225b6b457d1309f4698108fb6b35532d015dca8f5abed73",
+                "sha256:456cb30ca8bff00596519f2c53e42c245c09e1a4543945703acd4312949bfd41",
+                "sha256:71d332b0320642b3261e9fee47ab9e65872c2bd90260e5d225dabeed93cbd42b",
+                "sha256:879b4c2f4d41585c42df4d7654ddffff1239dc4065bc88b745f0341828b83e78",
+                "sha256:9cd3e9978d12b5d99cbdc727a3022da0430ad007dacf33d0bf554b96427f33ab",
+                "sha256:a178209e2df710e3f142cbd05313ba0c5ebed0a55d78d9945ac7a4e09d923308",
+                "sha256:b39725209e06759217d1ac5fcdb510e98670af9e37223985f330b611f62e7425",
+                "sha256:bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2",
+                "sha256:bfd880614c6237243ff53a0539f1cb26987a6dc8ac6e66e0c5a40617296a045e",
+                "sha256:c43bec251bbd10e3cb58ced80609c5c1eb238da9ca78b964aea410fb820d00d6",
+                "sha256:d690b18ac4b3e3cab73b0b7aa7dbe65978a172ff94970ff98d82f2031f8971c2",
+                "sha256:d6982b5a0237e1b7d876b60265564648a69b14017f3b5f908c5be2de3f9abb7a",
+                "sha256:dec3eac7549869365fe263831f576c8457f6c833937c68542d08fde73457d291",
+                "sha256:e371b844cec09d8dc424d940e54bba8f67a03ebea20ff7b7b0d56f526c71d584",
+                "sha256:e5d8f84d81e3729c3b506657dddfe46e8ba9c330bf1858ee33108f8bb2adb38a",
+                "sha256:ea6b79a02a28550c98b6ca9c35b9f492beaa54d7c5c9e9949555893c8a9234d0",
+                "sha256:f1258f4e6c42ad0b20f9cfcc3ada5bd6b83374516cd01c0960e3cb75fdca6770"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.19.1"
+            "version": "==0.19.2"
         },
         "pytest": {
             "hashes": [
@@ -2560,10 +2572,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
-                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
+                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
+                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
             ],
-            "version": "==2022.5"
+            "version": "==2022.6"
         },
         "pyyaml": {
             "hashes": [
@@ -2639,7 +2651,7 @@
                 "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
                 "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
             ],
-            "markers": "python_version >= '3.5' and python_version < '4.0'",
+            "markers": "python_version >= '3.5' and python_version < '4'",
             "version": "==4.7.2"
         },
         "ruamel.yaml": {
@@ -2696,14 +2708,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.6.0"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17",
-                "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==65.5.0"
         },
         "six": {
             "hashes": [
@@ -2876,7 +2880,7 @@
                 "sha256:d3a2f5999215a3a06a4fc218026cd84c61b8b2b40ac5296a6db1f1451ef04c1e",
                 "sha256:e5f923aa6a47e133d1cf87d60700889d7eae68988704e20c75fb2d65677a8e4b"
             ],
-            "markers": "python_version > '2.7'",
+            "markers": "python_version >= '3.7'",
             "version": "==6.2"
         },
         "traitlets": {
@@ -2892,7 +2896,7 @@
                 "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
                 "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.9'",
             "version": "==4.4.0"
         },
         "urllib3": {
@@ -2900,7 +2904,7 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.26.12"
         },
         "wcmatch": {

--- a/apps/greencheck/directory_urls.py
+++ b/apps/greencheck/directory_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import DirectoryView
+
+urlpatterns = [
+    path("", DirectoryView.as_view(), name="directory-index"),
+]

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView
-
+from taggit.models import Tag
 import django_filters
 
 from apps.accounts.models.hosting import Hostingprovider
@@ -216,29 +216,18 @@ class GreencheckStatsView(TemplateView):
         return context
 
 
-from taggit.forms import TagField
-
-
-# class TagFilter(django_filters.CharFilter):
-class TagFilter(django_filters.CharFilter):
-    field_class = TagField
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("lookup_expr", "in")
-        super().__init__(*args, **kwargs)
-
-
-from taggit.models import Tag
-
-
 class ProviderFilter(django_filters.FilterSet):
-    name = django_filters.CharFilter(lookup_expr="icontains")
 
-    services = TagFilter(field_name="services__slug")
+    services = django_filters.ModelChoiceFilter(
+        field_name="services__slug",
+        label="Services offered",
+        queryset=Tag.objects.all(),
+    )
+    name = django_filters.CharFilter(lookup_expr="icontains")
 
     class Meta:
         model = Hostingprovider
-        fields = ["country"]
+        fields = ["services", "country", "name"]
 
 
 class DirectoryView(TemplateView):

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -217,8 +217,12 @@ class GreencheckStatsView(TemplateView):
 
 
 class ProviderFilter(django_filters.FilterSet):
-    name = django_filters.CharFilter(lookup_expr="iexact")
+    name = django_filters.CharFilter(lookup_expr="icontains")
 
+    # TODO - figure our the correct syntax for tag queries
+    # services = django_filters.CharFilter(
+    #     field_name="services", lookup_expr="services__name__in"
+    # )
     class Meta:
         model = Hostingprovider
         fields = ["country"]

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -219,7 +219,7 @@ class GreencheckStatsView(TemplateView):
 class ProviderFilter(django_filters.FilterSet):
 
     services = django_filters.ModelChoiceFilter(
-        field_name="services__slug",
+        field_name="services",
         label="Services offered",
         queryset=Tag.objects.all(),
     )
@@ -245,7 +245,9 @@ class DirectoryView(TemplateView):
         ctx = super().get_context_data(**kwargs)
 
         filter_results = ProviderFilter(
-            self.request.GET, queryset=queryset, request=self.request
+            self.request.GET,
+            queryset=queryset,
+            request=self.request,
         )
 
         ctx["filter"] = filter_results

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -216,13 +216,26 @@ class GreencheckStatsView(TemplateView):
         return context
 
 
+from taggit.forms import TagField
+
+
+# class TagFilter(django_filters.CharFilter):
+class TagFilter(django_filters.CharFilter):
+    field_class = TagField
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("lookup_expr", "in")
+        super().__init__(*args, **kwargs)
+
+
+from taggit.models import Tag
+
+
 class ProviderFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(lookup_expr="icontains")
 
-    # TODO - figure our the correct syntax for tag queries
-    # services = django_filters.CharFilter(
-    #     field_name="services", lookup_expr="services__name__in"
-    # )
+    services = TagFilter(field_name="services__slug")
+
     class Meta:
         model = Hostingprovider
         fields = ["country"]
@@ -236,7 +249,9 @@ class DirectoryView(TemplateView):
     template_name = "greencheck/directory_index.html"
 
     def get_context_data(self, *args, **kwargs):
-        queryset = Hostingprovider.objects.filter(showonwebsite=True)
+        queryset = Hostingprovider.objects.filter(showonwebsite=True).prefetch_related(
+            "services"
+        )
 
         ctx = super().get_context_data(**kwargs)
 

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -30,10 +30,10 @@
 
       <div class="mv-3">
       {% if obj.services.names %}
-      <p class="leading-5">
+      <p class="leading-loose" style="line-height:3rem;">
         {% for service in obj.services.all %}
-          <span class="border m-2 p-2 text-sm" style="background-color: #EAF5E0;">
-            {{ service.name }} | {{ service.slug }}
+          <span class="inline-block border m-4 p-2 text-sm" style="background-color: #EAF5E0; margin-right:1rem;">
+            {{ service.name }} |
           </span>
         {% endfor %}
       {% endif %}

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -12,7 +12,9 @@
 
     <section class="main-content p-4">
 
-      <h1 class="text-xl mb-3 pb-4"> this is just a demo view for directory filtering - please forgive the mess</h1>
+      <h1 class="text-xl mb-3 pb-4">
+        This is
+      a demo view for directory filtering</h1>
 
     <form method="get" class="mt-4">
         {{ filter.form.as_p }}
@@ -33,7 +35,7 @@
       <p class="leading-loose" style="line-height:3rem;">
         {% for service in obj.services.all %}
           <span class="inline-block border m-4 p-2 text-sm" style="background-color: #EAF5E0; margin-right:1rem;">
-            {{ service.name }} |
+            {{ service.name }}
           </span>
         {% endfor %}
       {% endif %}

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -8,17 +8,22 @@
 <div class="container mx-auto">
   <section class="mx-auto max-w-6xl bg-white border-2 border-dark-gray rounded-md  h-100-l mt-8 py-8">
 
-    <section class="main-content">
-    <form method="get">
+
+
+    <section class="main-content p-4">
+
+      <h1 class="text-xl mb-3 pb-4"> this is just a demo view for directory filtering - please forgive the mess</h1>
+
+    <form method="get" class="mt-4">
         {{ filter.form.as_p }}
         <input type="submit" class="p-4 mt-4 mb-4" />
     </form>
     </section>
 
-    <section class="main-content">
+    <section class="main-content px-4">
       <ul>
       {% for obj in filter.qs %}
-      <li class="m-3 px-8 mt-4">
+      <li class="m-3 mt-4">
         <h4 class="my-4 font-bold text-l">
         {{ obj.name }} - {{ obj.country.name }}
         </h4>

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -8,42 +8,43 @@
 <div class="container mx-auto">
   <section class="mx-auto max-w-6xl bg-white border-2 border-dark-gray rounded-md  h-100-l mt-8 py-8">
 
-
-
     <section class="main-content p-4">
 
       <h1 class="text-xl mb-3 pb-4">
-        This is
-      a demo view for directory filtering</h1>
+        This is a demo view for directory filtering.
+      </h1>
 
-    <form method="get" class="mt-4">
-        {{ filter.form.as_p }}
-        <input type="submit" class="p-4 mt-4 mb-4" />
-    </form>
+      <form method="get" class="mt-4">
+          {{ filter.form.as_p }}
+          <input type="submit" class="p-4 mt-4 mb-4" />
+      </form>
+
     </section>
 
     <section class="main-content px-4">
+
       <ul>
       {% for obj in filter.qs %}
-      <li class="m-3 mt-4">
-        <h4 class="my-4 font-bold text-l">
-        {{ obj.name }} - {{ obj.country.name }}
-        </h4>
+        <li class="m-3 mt-4">
+          
+          <h4 class="my-4 font-bold text-l">
+            {{ obj.name }} - {{ obj.country.name }}
+          </h4>
 
-      <div class="mv-3">
-      {% if obj.services.names %}
-      <p class="leading-loose" style="line-height:3rem;">
-        {% for service in obj.services.all %}
-          <span class="inline-block border m-4 p-2 text-sm" style="background-color: #EAF5E0; margin-right:1rem;">
-            {{ service.name }}
-          </span>
-        {% endfor %}
-      {% endif %}
-      </p>
-      </div>
+          <div class="mv-3">
+          {% if obj.services.names %}
+            <p class="leading-loose" style="line-height:3rem;">
+              {% for service in obj.services.all %}
+                <span class="inline-block border m-4 p-2 text-sm" style="background-color: #EAF5E0; margin-right:1rem;">
+                  {{ service.name }}
+                </span>
+              {% endfor %}
+            </p>
+          {% endif %}
+          </div>
 
         </li>
-    {% endfor %}
+      {% endfor %}
     </ul>
     
     </section>

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -31,8 +31,10 @@
       <div class="mv-3">
       {% if obj.services.names %}
       <p class="leading-5">
-        {% for service in obj.services.names %}
-          <span class="border m-2 p-2 text-sm" style="background-color: #EAF5E0;">{{ service }}</span>
+        {% for service in obj.services.all %}
+          <span class="border m-2 p-2 text-sm" style="background-color: #EAF5E0;">
+            {{ service.name }} | {{ service.slug }}
+          </span>
         {% endfor %}
       {% endif %}
       </p>

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% load static %}
+{% load widget_tweaks %}
+{% load tailwind_filters %}
+{% block content %}
+
+<div class="container mx-auto">
+  <section class="mx-auto max-w-6xl bg-white border-2 border-dark-gray rounded-md  h-100-l mt-8 py-8">
+
+    <section class="main-content">
+    <form method="get">
+        {{ filter.form.as_p }}
+        <input type="submit" />
+    </form>
+    </section>
+    
+    <section class="main-content">
+    
+    </section>
+    
+  </section>
+{% endblock %}

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -11,11 +11,31 @@
     <section class="main-content">
     <form method="get">
         {{ filter.form.as_p }}
-        <input type="submit" />
+        <input type="submit" class="p-4 mt-4 mb-4" />
     </form>
     </section>
-    
+
     <section class="main-content">
+      <ul>
+      {% for obj in filter.qs %}
+      <li class="m-3 px-8 mt-4">
+        <h4 class="my-4 font-bold text-l">
+        {{ obj.name }} - {{ obj.country.name }}
+        </h4>
+
+      <div class="mv-3">
+      {% if obj.services.names %}
+      <p class="leading-5">
+        {% for service in obj.services.names %}
+          <span class="border m-2 p-2 text-sm" style="background-color: #EAF5E0;">{{ service }}</span>
+        {% endfor %}
+      {% endif %}
+      </p>
+      </div>
+
+        </li>
+    {% endfor %}
+    </ul>
     
     </section>
     

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
     "taggit_serializer",
     "waffle",
     "nested_admin",
+    "django_filters",
     # UI
     "tailwind",
     "crispy_forms",
@@ -173,7 +174,9 @@ PASSWORD_HASHERS = [
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa
+        "NAME": (  # noqa
+            "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+        ),
     },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
@@ -248,7 +251,9 @@ REST_FRAMEWORK = {
 
 DRAMATIQ_BROKER = {
     "BROKER": "dramatiq.brokers.rabbitmq.RabbitmqBroker",
-    "OPTIONS": {"url": RABBITMQ_URL,},  # noqa
+    "OPTIONS": {
+        "url": RABBITMQ_URL,
+    },  # noqa
     "MIDDLEWARE": [
         # remove until we are actually using it
         # "dramatiq.middleware.Prometheus"

--- a/greenweb/urls.py
+++ b/greenweb/urls.py
@@ -39,7 +39,7 @@ from apps.accounts.admin import LabelAutocompleteView
 from apps.accounts import urls as accounts_urls
 from rest_framework.authtoken import views
 
-from apps.greencheck import urls as greencheck_urls
+from apps.greencheck import urls as greencheck_urls, directory_urls
 
 
 urlpatterns = []
@@ -114,7 +114,11 @@ urlpatterns += [
         legacy_views.latest_greenchecks,
         name="legacy-latest-greenchecks",
     ),
-    path("data/directory/", legacy_views.directory, name="legacy-directory-listing",),
+    path(
+        "data/directory/",
+        legacy_views.directory,
+        name="legacy-directory-listing",
+    ),
     path(
         "data/hostingprovider/<id>",
         legacy_views.directory_provider,
@@ -131,4 +135,5 @@ urlpatterns += [
         name="legacy-greencheck-multi",
     ),
     path("stats/", include(greencheck_urls)),
+    path("directory/", include(directory_urls)),
 ]


### PR DESCRIPTION
This is a work in progress demo of setting up our filtering.

If you visit `/directory`, you'll see a filterable view, allowing you to filter by country, service provided and provider name.

This work is behind a the `directory_listing` feature flag.

### Where I'd appreciate some help

I've done almost no work to try to speed up queries, and as as result it's not fast.

I think this is because for every provider on a page, we do more queries to fetch the tags and the names, when we could get them just one with `prefetch_related`. It's not a thing I'm so familiar  with, so I'd appreciate someone pairing with me to figure it out.

