### PR TITLE
Update admin view to show staff labels for admins, and allow filtering by partner status

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -293,28 +293,39 @@ class HostingAdmin(admin.ModelAdmin):
     search_fields = ("name",)
 
     @admin.display(description="Services offered")
-    def service_list(obj):
+    def service_list(self, obj):
         return [service.name for service in obj.services.all()]
 
     @admin.display(description="Staff labels")
-    # TODO figure out how to show this only for staff in listings
-    def label_list(obj):
+    def label_list(self, obj):
+
         return [label.name for label in obj.staff_labels.all()]
 
-    list_display = [
-        "name",
-        "country_str",
-        "html_website",
-        "showonwebsite",
-        "partner",
-        "model",
-        "certificates_amount",
-        "datacenter_amount",
-        "ip_addresses",
-        # "services",
-        service_list,
-        label_list,
-    ]
+    def get_list_display(self, request):
+        """
+        Change the columns in the list depending on whether
+        the user is staff admin of not.
+        """
+
+        NON_STAFF_LIST = [
+            "name",
+            "country_str",
+            "html_website",
+            "showonwebsite",
+            "partner",
+            # "model",
+            # "certificates_amount",
+            "datacenter_amount",
+            "ip_addresses",
+            # "services",
+            self.service_list,
+        ]
+
+        if request.user.is_admin:
+            return [*NON_STAFF_LIST, self.label_list]
+
+        return NON_STAFF_LIST
+
     # these are not really fields, but buttons
     # see the corresponding methods
     readonly_fields = ["preview_email_button", "start_csv_import_button"]

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -296,6 +296,11 @@ class HostingAdmin(admin.ModelAdmin):
     def service_list(obj):
         return [service.name for service in obj.services.all()]
 
+    @admin.display(description="Staff labels")
+    # TODO figure out how to show this only for staff in listings
+    def label_list(obj):
+        return [label.name for label in obj.staff_labels.all()]
+
     list_display = [
         "name",
         "country_str",
@@ -308,6 +313,7 @@ class HostingAdmin(admin.ModelAdmin):
         "ip_addresses",
         # "services",
         service_list,
+        label_list,
     ]
     # these are not really fields, but buttons
     # see the corresponding methods

--- a/apps/accounts/filters.py
+++ b/apps/accounts/filters.py
@@ -3,7 +3,7 @@ from django_admin_multiple_choice_list_filter.list_filters import (
     MultipleChoiceListFilter,
 )
 from django.contrib import messages
-
+from .models.choices import PartnerChoice
 
 from django_countries.data import COUNTRIES
 from datetime import datetime
@@ -94,7 +94,7 @@ class PartnerFilter(SimpleListFilter):
     parameter_name = "partner"
 
     def lookups(self, request, model_admin):
-        return ((True, "Partners"),)
+        return PartnerChoice.choices
 
     def queryset(self, request, queryset):
         if self.value() is None:


### PR DESCRIPTION
This PR introduces two changes for the hosting provider view.

1. We show the staff labels that have been applied to existing providers. This should save needing to click through each time to see what labels have already been applied. Only green web admin see these labels - they're not intended to be visible for end users, because if we did we'd need to make sure every label was externally documented.
2. The partner filtering now filters by the status of the provider, rather than simply offering a boolean True/False option. It turned out that no partners are labeled as `True` anyway, and this now allows us to see the previous gold partners, the previous dev partners and so on.


As before this is visible on the staging site.