### PR TITLE
Add simple style guide view and template

### DIFF
--- a/apps/theme/templates/style-guide.html
+++ b/apps/theme/templates/style-guide.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% comment %}
+  We extend from the base in this template.
+  Add whatever forms and so on that feel necessary
+{% endcomment %}
+
+{% block content %}
+
+<div class="container mx-auto mt-6 px-4">
+  <div class="prose">
+    <h2>Our content goes here</h2>
+  </div>
+</div>
+{% endblock  %}

--- a/apps/theme/tests.py
+++ b/apps/theme/tests.py
@@ -1,0 +1,14 @@
+from django.urls import reverse
+
+import pytest
+
+
+def test_visit_styleguide(client):
+    """
+    When we visit the style guide url, do we get our template ?
+    """
+    res = client.get(reverse("style-guide"))
+    templates = [tpl.name for tpl in res.templates]
+
+    assert res.status_code == 200
+    assert "style-guide.html" in templates

--- a/apps/theme/views.py
+++ b/apps/theme/views.py
@@ -1,0 +1,8 @@
+from django.shortcuts import render
+
+
+def style_guide(request):
+    """
+    Return our style guide template for reference
+    """
+    return render(request, "style-guide.html")

--- a/greenweb/urls.py
+++ b/greenweb/urls.py
@@ -40,7 +40,7 @@ from apps.accounts import urls as accounts_urls
 from rest_framework.authtoken import views
 
 from apps.greencheck import urls as greencheck_urls, directory_urls
-
+from apps.theme.views import style_guide
 
 urlpatterns = []
 
@@ -146,4 +146,6 @@ urlpatterns += [
     path("stats/", include(greencheck_urls)),
     path("directory/", include(directory_urls)),
     path("explorer/", include("explorer.urls")),
+    # style guide for front end
+    path("style-guide", style_guide, name="style-guide"),
 ]


### PR DESCRIPTION
This PR adds a new style guide template.

This doesn't do anything clever to tell tailwind to exclude it when building form templates,  so as we build out this guide we will likely need make sure our build steps don't automatically include the classes for every component  used of they're not actually used in our app.

Visit `/style-guide`, to serve the style guide template file.

This combined with the ability to create services using the taggit app in the django admin looks like it would be what's needed to create at least one service for completing the styling on the multipart form. 

Visit `admin/taggit/tag` as the superuser in development to be able to create the services - you will need to add the name and the 'slug'.

