### PR TITLE
Add service and required tagged item base model

### DIFF
--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -156,9 +156,42 @@ class ProviderLabel(tag_models.TaggedItemBase):
     to help us categorise and segment providers.
     """
 
-    content_object = models.ForeignKey("Hostingprovider", on_delete=models.CASCADE,)
+    content_object = models.ForeignKey(
+        "Hostingprovider",
+        on_delete=models.CASCADE,
+    )
     tag = models.ForeignKey(
-        Label, related_name="%(app_label)s_%(class)s_items", on_delete=models.CASCADE,
+        Label,
+        related_name="%(app_label)s_%(class)s_items",
+        on_delete=models.CASCADE,
+    )
+
+
+class Service(tag_models.TagBase):
+    """
+    The base tag class for our hosted services that providers offer
+    We extend the base class to provide a description and allow listing
+    """
+
+    class Meta:
+        verbose_name = _("Service")
+        verbose_name_plural = _("Services")
+
+
+class ProviderService(tag_models.TaggedItemBase):
+    """
+    A different "through" model for hosted services that we want to
+    link to our providers.
+    """
+
+    content_object = models.ForeignKey(
+        "Hostingprovider",
+        on_delete=models.CASCADE,
+    )
+    tag = models.ForeignKey(
+        Label,
+        related_name="%(app_label)s_%(class)s_items",
+        on_delete=models.CASCADE,
     )
 
 
@@ -179,7 +212,10 @@ class Hostingprovider(models.Model):
     )
     services = TaggableManager(
         verbose_name="Services Offered",
-        help_text="Click the services that your organisation offers. These will be listed in the green web directory.",
+        help_text=(
+            "Click the services that your organisation offers. These will be listed in"
+            " the green web directory."
+        ),
         blank=True,
     )
     # this should not be exposed publicly to end users.
@@ -304,7 +340,9 @@ class Hostingprovider(models.Model):
         """
 
         msg = AnymailMessage(
-            subject=subject, body=email_txt, to=["support@thegreenwebfoundation.org"],
+            subject=subject,
+            body=email_txt,
+            to=["support@thegreenwebfoundation.org"],
         )
 
         if email_html:
@@ -329,7 +367,7 @@ class Hostingprovider(models.Model):
             "link_url": link_url,
         }
         notification_subject = (
-            f"TGWF: {self.name} - " "has been updated and needs a review"
+            f"TGWF: {self.name} - has been updated and needs a review"
         )
 
         notification_email_copy = render_to_string("flag_for_review_text.txt", ctx)
@@ -481,13 +519,22 @@ class AbstractSupportingDocument(models.Model):
     attachment = models.FileField(
         upload_to="uploads/",
         blank=True,
-        help_text="If you have a sustainability report, or bill from a energy provider provider, or similar certificate of supply from a green tariff add it here.",
+        help_text=(
+            "If you have a sustainability report, or bill from a energy provider"
+            " provider, or similar certificate of supply from a green tariff add it"
+            " here."
+        ),
     )
     url = models.URLField(
         blank=True,
-        help_text="Alternatively, if you add a link, we'll fetch a copy at the URL you list, so we can point to the version when you listed it",
+        help_text=(
+            "Alternatively, if you add a link, we'll fetch a copy at the URL you list,"
+            " so we can point to the version when you listed it"
+        ),
     )
-    description = models.TextField(blank=True,)
+    description = models.TextField(
+        blank=True,
+    )
     valid_from = models.DateField()
     valid_to = models.DateField()
 


### PR DESCRIPTION
Hey Oliwia / @tortila 

One thing that came up when speaking to Hannah today was the set of services that providers list themselves as offering.

We currently use the basic Taggit 'Tag' model, but given that each service has a description, I'm wondering if we might be better off making the move sooner rather than later, as we maintain a list of services anyway at the link below.

https://www.thegreenwebfoundation.org/directory/services-offered/

I can imagine scenarios where we have specific urls like `/service/object-storage` in future as a way to help people understand what specific services are, and who different providers might be.

Also, given that all our forms would likely need these listed in tests, and in development, if we're going to add a migration to list them, it might be worth adding the new models too. We already use them for the internal staff labels, and making these new models was really quick.

What do you think? I'm parking this here to discuss in future.