### PR TITLE
First pass at making a carbon.txt parser

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -1,22 +1,107 @@
 import logging
 import typing
+from urllib import parse
 
 from django import forms
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
+
 from django.urls import path, reverse
 from django.views.generic.edit import FormView
 from waffle import flag_is_active
 
+from django.shortcuts import render
+from django.urls import path, reverse
+from django.views.generic.edit import FormView
+
+import ipwhois
+import requests
+import toml
+from waffle.mixins import WaffleFlagMixin
+
 from apps.greencheck.views import GreenUrlsView
 
-from ..greencheck import domain_check
+from ..greencheck import carbon_txt, domain_check
 from ..greencheck import models as gc_models
 
-checker = domain_check.GreenDomainChecker()
 
+checker = domain_check.GreenDomainChecker()
 logger = logging.getLogger(__name__)
+
+
+class CarbonTxtForm(forms.Form):
+    """
+    A form for previewing what is in the database given a carbon txt file,
+    at a specific domain.
+    You can also paste the carbon.txt contents into a textfield, for convenience.
+    """
+
+    url = forms.URLField()
+    body = forms.CharField(widget=forms.Textarea(attrs={"rows": 30}), required=False)
+
+    preview = None
+    parser = carbon_txt.CarbonTxtParser()
+
+    def clean(self):
+        submitted_text = self.cleaned_data["body"]
+        url = self.cleaned_data["url"]
+        parsed_toml = None
+
+        # check that the submitted text is valid TOML
+
+        if not submitted_text:
+            try:
+                response = requests.get(url)
+                if response.ok:
+                    submitted_text = response.content
+            except requests.HTTPError:
+                # flag up an error about the domain
+                raise forms.ValidationError(
+                    f"Unable to fetch content from url: %(url)s",
+                    code="bad_http_lookup",
+                    params={"url": url},
+                )
+
+        if submitted_text:
+            if isinstance(submitted_text, bytes):
+                submitted_text = submitted_text.decode("utf-8")
+            try:
+                parsed_toml = toml.loads(submitted_text)
+            except toml.decoder.TomlDecodeError as ex:
+                logger.warn(f"Unable to read TOML at {url}")
+                raise forms.ValidationError(
+                    f"Unable to parse the provided TOML.", code="toml_parse_error"
+                )
+
+            parsed_url = parse.urlparse(url)
+            domain = parsed_url.netloc
+
+            if parsed_toml:
+                self.cleaned_data["preview"] = self.parser.parse_and_preview(
+                    domain, submitted_text
+                )
+
+
+class CarbonTxtCheckView(LoginRequiredMixin, WaffleFlagMixin, FormView):
+    template_name = "carbon_txt_preview.html"
+    form_class = CarbonTxtForm
+    success_url = "/admin/carbon-txt-preview"
+
+    def form_valid(self, form):
+        """Show the valid"""
+
+        ctx = self.get_context_data()
+
+        preview = form.cleaned_data.get("preview")
+
+        if preview:
+            ctx["preview"] = form.cleaned_data["preview"]
+
+        # return early if no submitted text
+        return render(self.request, self.template_name, ctx)
+
 
 class CheckUrlForm(forms.Form):
     """
@@ -137,6 +222,11 @@ class GreenWebAdmin(AdminSite):
             path("extended-greencheck/", CheckUrlView.as_view(), name="check_url"),
             path("green-urls", GreenUrlsView.as_view(), name="green_urls"),
             path("import-ip-ranges", GreenUrlsView.as_view(), name="import_ip_ranges"),
+            path(
+                "carbon-txt-preview",
+                CarbonTxtCheckView.as_view(),
+                name="carbon_txt_preview",
+            ),
         ]
         return patterns + urls
 

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -2,30 +2,23 @@ import logging
 import typing
 from urllib import parse
 
+import requests
+import toml
 from django import forms
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
-
-from django.urls import path, reverse
-from django.views.generic.edit import FormView
-from waffle import flag_is_active
-
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.views.generic.edit import FormView
-
-import ipwhois
-import requests
-import toml
+from waffle import flag_is_active
 from waffle.mixins import WaffleFlagMixin
 
 from apps.greencheck.views import GreenUrlsView
 
 from ..greencheck import carbon_txt, domain_check
 from ..greencheck import models as gc_models
-
 
 checker = domain_check.GreenDomainChecker()
 logger = logging.getLogger(__name__)
@@ -58,15 +51,15 @@ class CarbonTxtForm(forms.Form):
                     submitted_text = response.content
                 else:
                     raise forms.ValidationError(
-                        f"Unable to fetch content from url: %(url)s. HTTP response"
-                        f" code: %(response_code)s",
+                        "Unable to fetch content from url: %(url)s. HTTP response"
+                        " code: %(response_code)s",
                         code="bad_http_lookup",
                         params={"url": url, "response_code": response.status_code},
                     )
             except requests.HTTPError:
                 # flag up an error about the domain
                 raise forms.ValidationError(
-                    f"Unable to fetch content from url: %(url)s",
+                    "Unable to fetch content from url: %(url)s",
                     code="bad_http_lookup",
                     params={"url": url},
                 )
@@ -76,10 +69,10 @@ class CarbonTxtForm(forms.Form):
                 submitted_text = submitted_text.decode("utf-8")
             try:
                 parsed_toml = toml.loads(submitted_text)
-            except toml.decoder.TomlDecodeError as ex:
+            except toml.decoder.TomlDecodeError:
                 logger.warn(f"Unable to read TOML at {url}")
                 raise forms.ValidationError(
-                    f"Unable to parse the provided TOML.", code="toml_parse_error"
+                    "Unable to parse the provided TOML.", code="toml_parse_error"
                 )
 
             parsed_url = parse.urlparse(url)

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -56,6 +56,13 @@ class CarbonTxtForm(forms.Form):
                 response = requests.get(url)
                 if response.ok:
                     submitted_text = response.content
+                else:
+                    raise forms.ValidationError(
+                        f"Unable to fetch content from url: %(url)s. HTTP response"
+                        f" code: %(response_code)s",
+                        code="bad_http_lookup",
+                        params={"url": url, "response_code": response.status_code},
+                    )
             except requests.HTTPError:
                 # flag up an error about the domain
                 raise forms.ValidationError(
@@ -88,6 +95,7 @@ class CarbonTxtCheckView(LoginRequiredMixin, WaffleFlagMixin, FormView):
     template_name = "carbon_txt_preview.html"
     form_class = CarbonTxtForm
     success_url = "/admin/carbon-txt-preview"
+    waffle_flag = "carbon_txt_preview"
 
     def form_valid(self, form):
         """Show the valid"""

--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -228,6 +228,12 @@ class Hostingprovider(models.Model):
         """
         return AWAITING_REVIEW_SLUG in self.staff_labels.slugs()
 
+    @property
+    def admin_url(self) -> str:
+        return reverse(
+            "greenweb_admin:accounts_hostingprovider_change", args=[str(self.id)]
+        )
+
     def label_as_awaiting_review(self, notify_admins=False):
         """
         Mark this hosting provider as in need of review by staff.

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -1,0 +1,105 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}
+    The Green Web Foundation Member portal: Carbon text preview
+{% endblock %}
+
+
+{% block pretitle %}
+<h1>Preview how your carbon.txt would be parsed</h1>
+{% endblock %}
+
+{% block content %}
+
+<style>
+    form div {
+      margin-top:1rem;
+      margin-bottom:1rem;
+    }
+    form input[type='url'],
+    form textarea {
+        min-width:30rem;
+    }
+    form div label {
+      display: inline-block;
+      min-width: 10rem;
+    }
+</style>
+
+<form action="{{ form_url }}" method="post" class="try_out">
+    {% csrf_token %}
+
+    {{ form.url.errors }}
+    <div>
+      <label for="{{ form.url.id_for_label }}">Url: </label>
+    {{ form.url }}
+    </div>
+
+    <div>
+      <label for="{{ form.body.id_for_label }}">body: </label>
+      {{ form.body }}
+    </div>
+
+    <input type="submit" value="Submit"
+        style="margin-top: 0px; padding: 6px 15px">
+</form>
+
+<hr />
+
+<section>
+
+{% if preview %}
+
+  {% if preview.upstream %}
+    <h2>Upstream providers</h2>
+
+    {% if preview.upstream.providers %}
+      <p>
+        We were able to find the following upstream providers in the green web database
+      </p>
+    {% else %}
+      <p>
+        Sorry, we could not find any of the named upstream providers in the green web database.
+      </p>
+    {% endif %}
+
+    <ul>
+    {% for provider in preview.upstream.providers %}
+
+      <li>
+        <h3>
+          <a href="{{ provider.admin_url }}">
+            {{ provider.name}}
+          </a>
+        </h3>
+
+          {% comment %} Add the supporting evidence here {% endcomment %}
+      </li>
+      {% endfor %}
+
+    </ul>
+  {% endif %}
+
+
+  {% if preview.org %}
+    <h2>Primary Organisation</h2>
+
+    <p>This is the organisation hosting the carbon.txt file being viewed and processed</p>
+
+    <h3>
+      <a href="{{ preview.org.admin_url }}">
+      {{ preview.org }}
+      </a>
+    </h3>
+
+{% endif %}
+
+
+{% endif %}
+
+
+</section>
+
+
+{% endblock content %}

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -30,6 +30,8 @@
 <form action="{{ form_url }}" method="post" class="try_out">
     {% csrf_token %}
 
+    {{ form.non_field_errors }}
+
     {{ form.url.errors }}
     <div>
       <label for="{{ form.url.id_for_label }}">Url: </label>

--- a/apps/greencheck/admin.py
+++ b/apps/greencheck/admin.py
@@ -293,3 +293,23 @@ class GreencheckASNApprove(admin.ModelAdmin):
         return '<a href="{}">Link to {}</a>'.format(url, obj.hostingprovider.name)
 
     link.short_description = "Link to Hostingprovider"
+
+@admin.register(models.GreenDomain, site=greenweb_admin)
+class GreenDomainAdmin(admin.ModelAdmin):
+    list_display = [
+        "url",
+        "modified",
+        "green",
+        "hosted_by_website",
+        "hosting_provider",
+    ]
+    search_fields = ("url", "hosted_by_website")
+    fields = [
+        "url",
+        "hosted_by",
+        "hosted_by_website",
+        "hosted_by_id",
+        "modified",
+        "green",
+
+    ]

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -195,10 +195,12 @@ class CarbonTxtParser:
             ).hosting_provider
 
             result_data["org"] = provider
+            logger.info(provider)
         except django.core.exceptions.ObjectDoesNotExist:
             logger.warn(f"No provider found to match {domain}")
             pass
 
+        logger.info(result_data['org'])
         return result_data
 
     def import_from_url(self, url: str):

--- a/apps/greencheck/tests/carbon-txt-refined.toml
+++ b/apps/greencheck/tests/carbon-txt-refined.toml
@@ -1,0 +1,28 @@
+[upstream]
+providers = [
+  { domain = 'syseleven.com', doctype = 'sustainability-page', url = 'https://www.syseleven.de/en/about-us/our-data-centers/' },
+  { domain = 'akamai.com', doctype = 'sustainability-page', url = 'https://www.akamai.com/company/corporate-responsibility/sustainability' },
+]
+
+[org]
+credentials = [
+  # this is the 'primary' entity, and these are included on any of the other pages
+  { domain = 'www.bergfreunde.de', doctype = 'sustainability-page', url = 'https://www.bergfreunde.de/klimaneutral/' },
+  { domain = 'www.bergfreunde.de', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
+  # these are secondary entities. These are displayed listed first in when checking
+  # against the domain, followed by the bergfruende.de credentials above
+  #
+  { domain = 'alpinetrek.co.uk', doctype = 'sustainability-page', url = 'https://www.alpinetrek.co.uk/climate-neutral/' },
+  { domain = 'bergfreunde.nl', doctype = 'sustainability-page', url = 'https://www.bergfreunde.nl/klimaatneutraliteit/' },
+  { domain = 'alpiniste.fr', doctype = 'sustainability-page', url = 'https://www.alpiniste.fr/carbone-neutre/' },
+  { domain = 'bergfreunde.eu', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'berg-freunde.at', doctype = 'sustainability-page', url = 'https://www.berg-freunde.at/klimaneutral/' },
+  { domain = 'berg-freunde.ch', doctype = 'sustainability-page', url = 'https://www.berg-freunde.ch/klimaneutral/' },
+  { domain = 'bergfreunde.dk', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bergfreunde.se', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bergfreunde.no', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bergfreunde.fi', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bergfreunde.it', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bergfreunde.es', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+  { domain = 'bfgcdn.com', doctype = 'sustainability-page', url = 'https://www.bergfreunde.eu/climate-neutral/' },
+]

--- a/apps/greencheck/tests/carbon-txt-test.toml
+++ b/apps/greencheck/tests/carbon-txt-test.toml
@@ -1,13 +1,19 @@
 [upstream]
 providers = [
-  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/', aliases = ["www.sys-ten.com", "www.systen.com"]},
+  { domain = 'sys-ten.com', doctype = 'sustainability-page', url = 'https://www.sys-ten.de/en/about-us/our-data-centers/', aliases = [
+    "www.sys-ten.com",
+    "www.systen.com",
+  ] },
   { domain = 'cdn.com', doctype = 'sustainability-page', url = 'https://cdn.com/company/corporate-responsibility/sustainability' },
 ]
 
 [org]
+# we don't represent location here right now, and it's important to our model
+# TODO figure out how to represent this
 credentials = [
   { domain = 'www.hillbob.de', doctype = 'sustainability-page', url = 'https://www.hillbob.de/klimaneutral/', aliases = [
-    "hillbob.de", "hill-bob.de"
+    "hillbob.de",
+    "hill-bob.de",
   ] },
   { domain = 'www.hillbob.de', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
@@ -26,7 +32,11 @@ credentials = [
   { domain = 'hillbob.at', doctype = 'sustainability-page', url = 'https://www.hillbob.at/klimaneutral/' },
   { domain = 'hillbob.at', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
-  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/', aliases = ["hill-bob.ch", "www.hilbob.ch", "www.hill-bob.ch"]},
+  { domain = 'hillbob.ch', doctype = 'sustainability-page', url = 'https://www.hillbob.ch/klimaneutral/', aliases = [
+    "hill-bob.ch",
+    "www.hilbob.ch",
+    "www.hill-bob.ch",
+  ] },
   { domain = 'hillbob.ch', doctype = 'carbon-compensation', url = 'https://fpm.climatepartner.com/tracking/13467-1912-1001/en' },
 
   { domain = 'hillbob.dk', doctype = 'sustainability-page', url = 'https://www.hillbob.eu/climate-neutral/' },

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -85,7 +85,7 @@ class TestCarbonTxtParser:
         provider = ac_models.Hostingprovider.objects.get(id=res.hosted_by_id)
 
         # do we have a green result?
-        assert res.green == True
+        assert res.green is True
         assert res.hosted_by_id == provider.id
 
     def test_check_with_alternative_domain(self, db, carbon_txt_string):
@@ -100,7 +100,7 @@ class TestCarbonTxtParser:
         provider = ac_models.Hostingprovider.objects.get(id=res.hosted_by_id)
 
         # do we have a green result?
-        assert res.green == True
+        assert res.green is True
         assert res.hosted_by_id == provider.id
 
     def test_import_from_remote_carbon_text_file(self, db):
@@ -121,17 +121,17 @@ class TestCarbonTxtParser:
         # now check for the domains
         primary_check = gc_models.GreenDomain.check_for_domain("www.hillbob.de")
         secondary_check = gc_models.GreenDomain.check_for_domain("valleytrek.co.uk")
-        assert primary_check.green == True
-        assert secondary_check.green == True
+        assert primary_check.green is True
+        assert secondary_check.green is True
 
         # and the aliases
         for domain_alias in ["www.sys-ten.com", "www.systen.com"]:
             check = gc_models.GreenDomain.check_for_domain(domain_alias)
-            assert check.green == True
+            assert check.green is True
 
         for domain_alias in ["hill-bob.ch", "www.hilbob.ch", "www.hill-bob.ch"]:
             check = gc_models.GreenDomain.check_for_domain(domain_alias)
-            assert check.green == True
+            assert check.green is True
 
     @pytest.mark.skip(reason="pending")
     def test_creation_of_corporate_grouping(self):
@@ -193,7 +193,8 @@ class TestLogCarbonTxtCheck:
             url="www.hillbob.de",
             ip=None,
             hosting_provider_id=hillbob_de.id,
-            # we use WHOIS here, until we can use the correcrt ENUM for mariadb in a migration
+            # we use WHOIS here, until we can use the correct ENUM
+            # for mariadb in a migration
             match_type=choices.GreenlistChoice.WHOIS,
         )
 
@@ -206,7 +207,7 @@ class TestLogCarbonTxtCheck:
             return_value=dummy_check,
         )
 
-        res = check_logger.log_sitecheck_for_domain("www.hilbob.de")
+        check_logger.log_sitecheck_for_domain("www.hilbob.de")
 
         assert gc_models.Greencheck.objects.count() == 1
         logged_check = gc_models.Greencheck.objects.first()


### PR DESCRIPTION
This PR adds a some sample scaffolding for building a parser for carbon.txt files, so we are able to:

1. fetch a carbon.txt file from a given url
2. parse the TOML, raising exceptions if parsing fails
3. replace the linked providers with info we have in our database in the results

This is very WIP, and not really intended for public consumption yet, but should allow us to start checking and validating real files in the wild, while we start working on some outreach with other partners