### PR TITLE
Validate IP addresses in the registration form correctly

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -283,7 +283,7 @@ class CredentialForm(forms.ModelForm):
         fields = ["type", "title", "link", "file", "description", "public"]
         help_texts = {
             "type": "What kind of evidence are you adding? Choose from the dropdown list.",
-			"title": "Give this piece of evidence a title.",
+            "title": "Give this piece of evidence a title.",
             "description": "What else should we know about this document?",
             "link": "Provide link to supporting document, include the https:// part.",
             "file": "OR upload a supporting document in PDF or image format.",
@@ -330,6 +330,10 @@ GreenEvidenceForm = forms.formset_factory(
 
 
 class IpRangeForm(forms.ModelForm):
+
+    start = forms.GenericIPAddressField()
+    end = forms.GenericIPAddressField()
+
     class Meta:
         model = ac_models.ProviderRequestIPRange
         exclude = ["request"]

--- a/apps/accounts/models/provider_request.py
+++ b/apps/accounts/models/provider_request.py
@@ -144,7 +144,18 @@ class ProviderRequestIPRange(models.Model):
         return f"{self.start} - {self.end}"
 
     def clean(self) -> None:
-        return validate_ip_range(self.start, self.end)
+        """
+        Validates an IP range.
+
+        Checking if values are not falsy is a workaround
+        for a surprising ModelForm implementation detail:
+
+        ModelForm connected to this Model executes Model.full_clean
+        with "None" values in case the values were considered invalid
+        according to the ModelForm validation logic.
+        """
+        if self.start and self.end:
+            validate_ip_range(self.start, self.end)
 
 
 class EvidenceType(models.TextChoices):

--- a/apps/accounts/templates/provider_registration/network_footprint.html
+++ b/apps/accounts/templates/provider_registration/network_footprint.html
@@ -84,7 +84,7 @@
 					<table class="form__table--network">
 						{{ form.as_table }}
 					</table>
-					<input class="text-sm hover:text-base" type="button" id="delete-form-button-ips" value="&#x274C; Delete these IP ranges">
+					<input class="text-sm hover:text-base" type="button" id="delete-form-button-ips" value="&#x274C; Delete this IP range">
 				</div>
 				{% endfor %}
 			</div>
@@ -98,7 +98,7 @@
 					<table class="form__table--network">
 						{{ wizard.form.ips.empty_form.as_table }}
 					</table>
-					<input class="text-sm hover:text-base" type="button" id="delete-form-button-ips" value="&#x274C; Delete these IP ranges">
+					<input class="text-sm hover:text-base" type="button" id="delete-form-button-ips" value="&#x274C; Delete this IP range">
 				</div>
 			</div>
 		</section>

--- a/apps/accounts/tests/test_form.py
+++ b/apps/accounts/tests/test_form.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from apps.greencheck import forms as gc_forms
 from apps.greencheck import models as gc_models
-from apps.accounts.forms import GreenEvidenceForm
+from apps.accounts.forms import GreenEvidenceForm, IpRangeForm
 from apps.accounts.models import EvidenceType
 
 from faker import Faker
@@ -141,3 +141,29 @@ def test_green_evidence_form_validation():
     assert len(formset.forms[3].non_field_errors()) == 1
     # then: the whole formset is invalid
     assert not formset.is_valid()
+
+
+@pytest.mark.parametrize(
+    "form_data",
+    [
+        {
+            "start": "127.0.0.100",
+            "end": "127.0.0.1",
+        },
+        {
+            "start": "127.0.0.100",
+            "end": "this one is not a valid IP address",
+        },
+        {
+            "start": "127.0.0.3/32",
+            "end": "127.0.0.100",
+        },
+    ],
+    ids=["end_before_start", "invalid_range_end", "invalid_range_start"],
+)
+def test_ip_range_form_validation(form_data):
+    # when: the form is instantiated with invalid data
+    ip_form = IpRangeForm(data=form_data)
+
+    # then: the form is invalid
+    assert ip_form.is_valid() is False


### PR DESCRIPTION
Scope of changes:
- changed the type of the field for IP addresses in the form to [`GenericIPAddressField`](https://docs.djangoproject.com/en/4.1/ref/forms/fields/#genericipaddressfield) for both: IP start and end. This is a built in type that provides the validation for IPv4 and IPv6 addresses,
- added a small change in the `ProviderRequestIPRange.clean` so that the validation provided by `GenericIPAddressField` kicks in properly + documented the unexpected behavior,
- added form tests that cover edge cases,
- minor changes in the wording on the IP ranges form ("delete" button is tied to a single IP range, not multiple)