### PR TITLE
Preview of the verification request

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -484,20 +484,12 @@ class WizardSteps(Enum):
     PREVIEW = "6"
 
 
-class PreviewForm(MultiForm):
+class PreviewForm(forms.Form):
     """
-    Gathers all forms from the verification request for a preview before submitting.
+    A dummy Form without any data.
+
+    It is used as a placeholder for the last step of the Wizard,
+    in order to render a preview of all data from the previous steps.
     """
 
-    # We have to set base_fields to a dictionary because
-    # the WizardView tries to introspect it.
-    base_fields = {}
-
-    form_classes = {
-        WizardSteps.ORG_DETAILS.value: OrgDetailsForm,
-        WizardSteps.LOCATIONS.value: LocationsForm,
-        WizardSteps.SERVICES.value: ServicesForm,
-        WizardSteps.GREEN_EVIDENCE.value: GreenEvidenceForm,
-        WizardSteps.NETWORK_FOOTPRINT.value: NetworkFootprintForm,
-        WizardSteps.CONSENT.value: ConsentForm,
-    }
+    pass

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -473,13 +473,15 @@ class WizardSteps(Enum):
     This Enum structure provides human-readable names
     for these steps.
     """
+
     # TODO: change values to be meaningful after switching to NamedWizard
     ORG_DETAILS = "0"
-    SERVICES = "1"
-    GREEN_EVIDENCE = "2"
-    NETWORK_FOOTPRINT = "3"
-    CONSENT = "4"
-    PREVIEW = "5"
+    LOCATIONS = "1"
+    SERVICES = "2"
+    GREEN_EVIDENCE = "3"
+    NETWORK_FOOTPRINT = "4"
+    CONSENT = "5"
+    PREVIEW = "6"
 
 
 class PreviewForm(MultiForm):
@@ -493,6 +495,7 @@ class PreviewForm(MultiForm):
 
     form_classes = {
         WizardSteps.ORG_DETAILS.value: OrgDetailsForm,
+        WizardSteps.LOCATIONS.value: LocationsForm,
         WizardSteps.SERVICES.value: ServicesForm,
         WizardSteps.GREEN_EVIDENCE.value: GreenEvidenceForm,
         WizardSteps.NETWORK_FOOTPRINT.value: NetworkFootprintForm,

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import Enum
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -10,7 +11,7 @@ from django_countries.fields import CountryField
 from taggit_labels.widgets import LabelWidget
 from taggit.models import Tag
 from dal_select2_taggit import widgets as dal_widgets
-from betterforms.multiform import MultiModelForm
+from betterforms.multiform import MultiModelForm, MultiForm
 from convenient_formsets import ConvenientBaseFormSet
 from typing import Tuple
 
@@ -461,3 +462,39 @@ LocationsForm = forms.formset_factory(
     extra=1,
     formset=MoreConvenientFormset,
 )
+
+
+class WizardSteps(Enum):
+    """
+    Pre-defined list of verification request forms.
+    WizardView uses numbers from 0 up, encoded as strings,
+    to refer to specific steps.
+
+    This Enum structure provides human-readable names
+    for these steps.
+    """
+    # TODO: change values to be meaningful after switching to NamedWizard
+    ORG_DETAILS = "0"
+    SERVICES = "1"
+    GREEN_EVIDENCE = "2"
+    NETWORK_FOOTPRINT = "3"
+    CONSENT = "4"
+    PREVIEW = "5"
+
+
+class PreviewForm(MultiForm):
+    """
+    Gathers all forms from the verification request for a preview before submitting.
+    """
+
+    # We have to set base_fields to a dictionary because
+    # the WizardView tries to introspect it.
+    base_fields = {}
+
+    form_classes = {
+        WizardSteps.ORG_DETAILS.value: OrgDetailsForm,
+        WizardSteps.SERVICES.value: ServicesForm,
+        WizardSteps.GREEN_EVIDENCE.value: GreenEvidenceForm,
+        WizardSteps.NETWORK_FOOTPRINT.value: NetworkFootprintForm,
+        WizardSteps.CONSENT.value: ConsentForm,
+    }

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -1,5 +1,4 @@
 import datetime
-from enum import Enum
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -11,14 +10,11 @@ from django_countries.fields import CountryField
 from taggit_labels.widgets import LabelWidget
 from taggit.models import Tag
 from dal_select2_taggit import widgets as dal_widgets
-from betterforms.multiform import MultiModelForm, MultiForm
+from betterforms.multiform import MultiModelForm
 from convenient_formsets import ConvenientBaseFormSet
-from typing import Tuple
 
 from apps.accounts.models.provider_request import (
     ProviderRequest,
-    ProviderRequestLocation,
-    ProviderRequestConsent,
 )
 
 from . import models as ac_models
@@ -464,26 +460,6 @@ LocationsForm = forms.formset_factory(
 )
 
 
-class WizardSteps(Enum):
-    """
-    Pre-defined list of verification request forms.
-    WizardView uses numbers from 0 up, encoded as strings,
-    to refer to specific steps.
-
-    This Enum structure provides human-readable names
-    for these steps.
-    """
-
-    # TODO: change values to be meaningful after switching to NamedWizard
-    ORG_DETAILS = "0"
-    LOCATIONS = "1"
-    SERVICES = "2"
-    GREEN_EVIDENCE = "3"
-    NETWORK_FOOTPRINT = "4"
-    CONSENT = "5"
-    PREVIEW = "6"
-
-
 class PreviewForm(forms.Form):
     """
     A dummy Form without any data.
@@ -491,5 +467,4 @@ class PreviewForm(forms.Form):
     It is used as a placeholder for the last step of the Wizard,
     in order to render a preview of all data from the previous steps.
     """
-
     pass

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -3,22 +3,7 @@
         {% for field in form %}
         <div>
             <b>{{ field.label }}</b><br>
-
-            {% if field.widget_type == "checkboxselectmultiple" %}
-
-                {% comment %}
-                    Special treatment for MultipleSelectField in order to
-                    display human-readable labels instead of slugs,
-                    (e.g. "Platform as a Service" instead of "paas")
-                {% endcomment %}
-
-                {% for choice in field %}
-                    {{ choice.choice_label }}<br>
-                {% endfor %}
-            
-            {% else %}
-                {{ field.value }}
-            {% endif %}
+            {{ field.value }}
         </div>
         {% endfor %}
     </div>

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -2,8 +2,23 @@
     <div>
         {% for field in form %}
         <div>
-            <b>{{ field.label }}</b>
-            {{ field.value }}
+            <b>{{ field.label }}</b><br>
+
+            {% if field.widget_type == "checkboxselectmultiple" %}
+
+                {% comment %}
+                    Special treatment for MultipleSelectField in order to
+                    display human-readable labels instead of slugs,
+                    (e.g. "Platform as a Service" instead of "paas")
+                {% endcomment %}
+
+                {% for choice in field %}
+                    {{ choice.choice_label }}<br>
+                {% endfor %}
+            
+            {% else %}
+                {{ field.value }}
+            {% endif %}
         </div>
         {% endfor %}
     </div>

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -1,0 +1,10 @@
+<div class="bg-neutral-200 rounded-xl my-6 p-4">
+    <div>
+        {% for field in form %}
+        <div>
+            <b>{{ field.label }}</b>
+            {{ field.value }}
+        </div>
+        {% endfor %}
+    </div>
+</div>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -9,43 +9,69 @@
 {{ wizard.form.media }}
 
 <div class="container mx-auto">
+    <form method="post" action="">
+        {% csrf_token %}
+        {{ wizard.management_form }}
+        
+        {% comment %}
+            This is a "dummy" form - no data is actually being submitted.
+        {% endcomment %}
 
-<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+        <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 
-<section class="prose my-10">
-	<h1>Preview of your request</h1>
-	<p>Take a look if everything is aight, then submit</p>
-</section>
+        <section class="prose my-10">
+            <h1>Your verification request</h1>
+            <p>If everything is correct, submit your request</p>
+        </section>
 
-    {% csrf_token %}
-    {{ wizard.management_form }}
+        <div>
+            <section class="prose my-10">
+                <h3>About your organisation</h3>
+                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.0 %}
+            </section>
+            <section class="prose my-10">
+                <h3>Locations</h3>
+                {% for location_form in wizard.form.forms.1.forms %}
+                {% include "provider_registration/partials/_preview.html" with form=location_form %}
+                {% endfor %}
+            </section>
+            <section class="prose my-10">
+                <h3>Services provided by your organisation</h3>
+                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.2 %}
+            </section>
+            <section class="prose my-10">
+                <h3>Green evidence</h3>
+                {% for evidence_form in wizard.form.forms.3.forms %}
+                {% include "provider_registration/partials/_preview.html" with form=evidence_form %}
+                {% endfor %}
+            </section>
+            <section class="prose my-10">
+                <h3>Network footprint</h3>
 
-    <!-- wizard.form is a MultiForm (from django-betterforms) -->
+                {% for ip_form in wizard.form.forms.4.ips.forms %}
+                {% include "provider_registration/partials/_preview.html" with form=ip_form %}
+                {% endfor %}
 
-	<div class="lg:grid grid-cols-2 gap-16 my-10">
+                {% for asn_form in wizard.form.forms.4.asns.forms %}
+                {% include "provider_registration/partials/_preview.html" with form=asn_form %}
+                {% endfor %}
+            </section>
+            <section class="prose my-10">
+                <h3>Consent</h3>
+                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.5 %}
+            </section>
+        </div>
 
-		<section class="prose border-2 rounded-xl mb-6 lg:mb-0 p-6">
+        <input class="btn" type="submit" value="{% trans " submit" %}" />
 
-            {% for form in wizard.form.forms.values %}
-            <div class="bg-neutral-200 rounded-xl my-6 p-4">
-                <table class="form__table mt-0 mb-2">
-                    {{ form.as_table }}
-                </table>
-            </div>
-            {% endfor %}
-		</section>
-
-	</div>
-
-	<input class="btn" type="submit" value="{% trans "SUBMIT THIS ALREADY" %}" />
-
-    {% if wizard.steps.prev %}
-	<div>
-    	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
-    	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
-	</div>
-    {% endif %}
-
-</form>
+        {% if wizard.steps.prev %}
+        <div>
+            <button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit"
+                value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
+            <button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit"
+                value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+        </div>
+        {% endif %}
+    </form>
 </div>
 {% endblock %}

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -12,53 +12,53 @@
     <form method="post" action="">
         {% csrf_token %}
         {{ wizard.management_form }}
-        
+
         {% comment %}
-            This is a "dummy" form - no data is actually being submitted.
+            This is a placeholder form - only wizard metadata is being submitted.
         {% endcomment %}
 
         <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 
         <section class="prose my-10">
             <h1>Your verification request</h1>
-            <p>If everything is correct, submit your request</p>
+            <p>Confirm that the data is correct and submit your request</p>
         </section>
 
         <div>
             <section class="prose my-10">
                 <h3>About your organisation</h3>
-                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.0 %}
+                {% include "provider_registration/partials/_preview.html" with form=preview_forms.0 %}
             </section>
             <section class="prose my-10">
                 <h3>Locations</h3>
-                {% for location_form in wizard.form.forms.1.forms %}
+                {% for location_form in preview_forms.1.initial_forms %}
                 {% include "provider_registration/partials/_preview.html" with form=location_form %}
                 {% endfor %}
             </section>
             <section class="prose my-10">
                 <h3>Services provided by your organisation</h3>
-                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.2 %}
+                {% include "provider_registration/partials/_preview.html" with form=preview_forms.2 %}
             </section>
             <section class="prose my-10">
                 <h3>Green evidence</h3>
-                {% for evidence_form in wizard.form.forms.3.forms %}
+                {% for evidence_form in preview_forms.3.initial_forms %}
                 {% include "provider_registration/partials/_preview.html" with form=evidence_form %}
                 {% endfor %}
             </section>
             <section class="prose my-10">
                 <h3>Network footprint</h3>
 
-                {% for ip_form in wizard.form.forms.4.ips.forms %}
+                {% for ip_form in preview_forms.4.ips.initial_forms %}
                 {% include "provider_registration/partials/_preview.html" with form=ip_form %}
                 {% endfor %}
 
-                {% for asn_form in wizard.form.forms.4.asns.forms %}
+                {% for asn_form in preview_forms.4.asns.initial_forms %}
                 {% include "provider_registration/partials/_preview.html" with form=asn_form %}
                 {% endfor %}
             </section>
             <section class="prose my-10">
                 <h3>Consent</h3>
-                {% include "provider_registration/partials/_preview.html" with form=wizard.form.forms.5 %}
+                {% include "provider_registration/partials/_preview.html" with form=preview_forms.5 %}
             </section>
         </div>
 

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -14,7 +14,7 @@
         {{ wizard.management_form }}
 
         {% comment %}
-            This is a placeholder form - only wizard metadata is being submitted.
+        This is a placeholder form - only wizard metadata is being submitted.
         {% endcomment %}
 
         <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{% block head %}
+
+{% endblock %}
+
+{% block content %}
+{{ wizard.form.media }}
+
+<div class="container mx-auto">
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+<section class="prose my-10">
+	<h1>Preview of your request</h1>
+	<p>Take a look if everything is aight, then submit</p>
+</section>
+
+    {% csrf_token %}
+    {{ wizard.management_form }}
+
+    <!-- wizard.form is a MultiForm (from django-betterforms) -->
+
+	<div class="lg:grid grid-cols-2 gap-16 my-10">
+
+		<section class="prose border-2 rounded-xl mb-6 lg:mb-0 p-6">
+
+            {% for form in wizard.form.forms.values %}
+            <div class="bg-neutral-200 rounded-xl my-6 p-4">
+                <table class="form__table mt-0 mb-2">
+                    {{ form.as_table }}
+                </table>
+            </div>
+            {% endfor %}
+		</section>
+
+	</div>
+
+	<input class="btn" type="submit" value="{% trans "SUBMIT THIS ALREADY" %}" />
+
+    {% if wizard.steps.prev %}
+	<div>
+    	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
+    	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+	</div>
+    {% endif %}
+
+</form>
+</div>
+{% endblock %}

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -142,6 +142,17 @@ def wizard_form_consent():
 
 
 @pytest.fixture()
+def wizard_form_preview():
+    """
+    Returns valid data for step PREVIEW of the wizard,
+    as expected by the POST request.
+    """
+    return {
+        "provider_registration_view-current_step": "6",
+    }
+
+
+@pytest.fixture()
 def mock_open(mocker):
     file_mock = mocker.patch("builtins.open")
     file_mock.return_value = io.StringIO("file contents")
@@ -265,6 +276,7 @@ def test_wizard_view_happy_path(
     wizard_form_evidence_data,
     wizard_form_network_data,
     wizard_form_consent,
+    wizard_form_preview,
 ):
 
     # given: valid form data and authenticated user
@@ -275,6 +287,7 @@ def test_wizard_view_happy_path(
         wizard_form_evidence_data,
         wizard_form_network_data,
         wizard_form_consent,
+        wizard_form_preview,
     ]
     client.force_login(user)
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -30,7 +30,7 @@ from .forms import (
     GreenEvidenceForm,
     NetworkFootprintForm,
     ConsentForm,
-    PreviewForm
+    PreviewForm,
 )
 from .models import User, ProviderRequest
 
@@ -282,7 +282,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         Reference: https://docs.djangoproject.com/en/3.2/ref/class-based-views/mixins-simple/#django.views.generic.base.TemplateResponseMixin.get_template_names
         """
         return [self.TEMPLATES[self.steps.current]]
-    
+
     def _get_data_for_preview(self):
         """
         Returns cleaned data from all the steps before the PREVIEW step

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -301,5 +301,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         return self.initial_dict.get(step, {})
 
     def get_context_data(self, form, **kwargs):
-        breakpoint()
-        return super().get_context_data(form, **kwargs)
+        context = super().get_context_data(form, **kwargs)
+        # uncomment here to peek inside `context["form"]` on page reload
+        # breakpoint()
+        return context

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ installation.md
 how-to.md
 deployment.md
 key-concepts.md
+verification-request.md
 how-we-check-for-green.md
 other-greenweb-software.md
 working-with-greenweb-datasets.md

--- a/docs/veirification-request.md
+++ b/docs/veirification-request.md
@@ -1,0 +1,25 @@
+# Verification request
+This page documents the design decision and implementation details of the verification request.
+
+## What is a verification request?
+It's a multi-step form allowing green hosting providers to onboard their organisations' data to be available in the Green Web Foundation dataset. 
+
+## How to access the verification request form?
+It's not publicly available yet: it's only available for selected users,
+based on a feature flag called `provider_request` that is [managed in the admin panel](https://admin.thegreenwebfoundation.org/admin/waffle/flag/2/change/). 
+
+Authenticated users that have the flag enabled can access the following pages:
+- `/requests/new/` to start a new verification request,
+- `/requests/` to view all submitted requests.
+
+## How is the form implemented?
+We are using [`WizardView`](https://django-formtools.readthedocs.io/en/latest/wizard.html#creating-a-wizardview-subclass) from the library [`django-formtools`](https://django-formtools.readthedocs.io/) to display a single form per page, over multiple pages. The consecutive forms of the wizard are validated when each step is submitted.
+
+The use of [`SessionWizardView`](https://django-formtools.readthedocs.io/en/latest/wizard.html#formtools.wizard.views.SessionWizardView) makes it convenient for keeping the in-progress forms in a database-backed user sessions. No data loss should occur as long as the user keeps the session cookie in their browser (and as long as their session remains valid).
+
+The final step of the wizard is a preview: all submitted data can be reviewed one last time before submitting the whole verification request.
+
+Upon submitting the final step, the data is persisted as a `ProviderRequest` object (and related objects). 
+
+## Preview implementation details
+The preview step is configured to display a `PreviewForm`: a form that does not contain any data or validation logic. When the `WizardView` renders the `PreviewForm` in a template, all cleaned data from the previous steps is injected to the template context. This way we are able to render the already submitted and validated data, without running validation on it again.


### PR DESCRIPTION
**Scope of the changes:**
- the last step in the wizard (PREVIEW step) renders all cleaned data from the previous steps.
- new template for the PREVIEW step


**Out of scope** for now (will be delivered in the upcoming PRs):
- printing of the summary to a file
- "Edit" buttons for each section with hyperlinks to the corresponding wizard step

**Implementation details:**
- new `PreviewForm` that has no fields or logic and only serves as a placeholder in order to render an additional template at the end of the wizard steps,
- cleaned data from all previous steps is injected to the template context as unbound forms,
- the preview template renders each form in a separate section on the page.

I added comments in the code to describe all the weird bits of this implementation and I hope this will make it easier to extend in the future if need be.
