### PR TITLE
Create management task for fetching files from object storage buckets

### DIFF
--- a/apps/greencheck/management/commands/fetch_from_bucket.py
+++ b/apps/greencheck/management/commands/fetch_from_bucket.py
@@ -1,0 +1,44 @@
+import logging
+from apps.greencheck import object_storage
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Fetch a file from object storage for the given bucket and path"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "bucket",
+            type=str,
+            help="the name of the bucket to look in",
+        )
+        parser.add_argument(
+            "source_path",
+            type=str,
+            help=("the path to the file in object storage to fetch"),
+        )
+        parser.add_argument(
+            "destination_path",
+            type=str,
+            help=("the path save the file to locally"),
+        )
+
+    def handle(self, *args, **options):
+        """Fetch the file from the bucket, and save locally"""
+
+        bucket_name = options.get('bucket')
+        file_path = options.get('source_path')
+        dest_path = options.get('destination_path')
+        
+        self.stdout.write(f"Fetching {file_path} from bucket {bucket_name}, saving to {dest_path}")
+        bucket = object_storage.object_storage_bucket(bucket_name)
+        
+        bucket.download_file(file_path, dest_path)
+        
+        self.stdout.write(
+            f"Done! Your file should be at {dest_path}"
+        )


### PR DESCRIPTION
This PR introduces a command to fetch files from buckets in object storage, where we store backups, exports of data and so on.

Because adapting the aws cli command is a bit involved when you're not using Amazon, this makes it easier to fetch files in our workflow.

You run it like so:

```
./manage.py fetch_from_bucket BUCKET_NAME PATH_TO_FILE LOCAL_FILENAME
```

Where `BUCKET_NAME` is the object storage you want to access, `PATH_TO_FILE` is the key for the given file in object storage, and `LOCAL_FILENAME` is the name of the file to save something to.

Under the hood, this uses the boto3 download_file command, so it uses multiple threads to speed up transferring big files

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html?highlight=s3transfer#boto3.s3.transfer.S3Transfer.download_file