### PR TITLE
show example of overriding template

### DIFF
--- a/apps/accounts/templates/provider_registration/consent.html
+++ b/apps/accounts/templates/provider_registration/consent.html
@@ -1,47 +1,48 @@
 {% extends "./base_form.html" %}
-
+{% load i18n static %}
 
 {% block content %}
 <div class="container mx-auto">
 
-<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+	<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 
-<!-- override the parent block to add our custom HTML content inside the block -->
-{% block header_section %}
-<section class="prose mt-10">
-	<h1>One last thing...</h1>
-	<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
-</section>
-{% endblock %}
+	<!-- override the parent block to add our custom HTML content inside the block -->
+	{% block header_section %}
+		<section class="prose mt-10">
+			<h1>One last thing...</h1>
+			<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
+		</section>
+	{% endblock %}
 
-{% if form.is_multipart %}
-    <form enctype="multipart/form-data" method="post" action="" class="form__table">
-{% else %}
-    <form method="post" action="" class="form__table">
-{% endif %}
-{% csrf_token %}
+	{% if form.is_multipart %}
+		<form enctype="multipart/form-data" method="post" action="" class="form__table form__table--consent">
+	{% else %}
+		<form method="post" action="" class="form__table form__table--consent max-w-4xl">
+	{% endif %}
+	
+		{% csrf_token %}
 
-<table class="form__table--consent">
-{{ wizard.management_form }}
-{% if wizard.form.forms %}
-    {{ wizard.form.management_form }}
-    {% for form in wizard.form.forms %}
-        {{ form.as_table }}
-    {% endfor %}
-{% else %}
-    {{ wizard.form }}
-{% endif %}
-</table>
+		<table class="">
+			{{ wizard.management_form }}
+			
+			{% if wizard.form.forms %}
+				{{ wizard.form.management_form }}
+				{% for form in wizard.form.forms %}
+					{{ form.as_table }}
+				{% endfor %}
+			{% else %}
+				{{ wizard.form }}
+			{% endif %}
+		</table>
 
-<input class="btn" type="submit" value="{% trans "next" %}"/>
+		<input class="btn" type="submit" value="{% trans " next" %}" />
 
-{% if wizard.steps.prev %}
-<div class="">
-	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
-	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
-</div>
-{% endif %}
-
-</form>
+		{% if wizard.steps.prev %}
+			<div class="">
+				<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
+				<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+			</div>
+		{% endif %}
+	</form>
 </div>
 {% endblock %}

--- a/apps/accounts/templates/provider_registration/consent.html
+++ b/apps/accounts/templates/provider_registration/consent.html
@@ -13,9 +13,6 @@
 <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 
 <!-- child templates can override this to inject custom HTML content -->
-{% block header_section %}
-{% endblock %}
-
 {% if form.is_multipart %}
     <form enctype="multipart/form-data" method="post" action="" class="form__table">
 {% else %}

--- a/apps/accounts/templates/provider_registration/consent.html
+++ b/apps/accounts/templates/provider_registration/consent.html
@@ -1,10 +1,4 @@
 {% extends "./base_form.html" %}
-{% block header_section %}
-<section class="prose mt-10">
-	<h1>One last thing...</h1>
-	<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
-</section>
-{% endblock %}
 
 
 {% block content %}
@@ -12,7 +6,14 @@
 
 <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 
-<!-- child templates can override this to inject custom HTML content -->
+<!-- override the parent block to add our custom HTML content inside the block -->
+{% block header_section %}
+<section class="prose mt-10">
+	<h1>One last thing...</h1>
+	<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
+</section>
+{% endblock %}
+
 {% if form.is_multipart %}
     <form enctype="multipart/form-data" method="post" action="" class="form__table">
 {% else %}

--- a/apps/accounts/templates/provider_registration/consent.html
+++ b/apps/accounts/templates/provider_registration/consent.html
@@ -5,3 +5,45 @@
 	<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
 </section>
 {% endblock %}
+
+
+{% block content %}
+<div class="container mx-auto">
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+<!-- child templates can override this to inject custom HTML content -->
+{% block header_section %}
+{% endblock %}
+
+{% if form.is_multipart %}
+    <form enctype="multipart/form-data" method="post" action="" class="form__table">
+{% else %}
+    <form method="post" action="" class="form__table">
+{% endif %}
+{% csrf_token %}
+
+<table class="form__table--consent">
+{{ wizard.management_form }}
+{% if wizard.form.forms %}
+    {{ wizard.form.management_form }}
+    {% for form in wizard.form.forms %}
+        {{ form.as_table }}
+    {% endfor %}
+{% else %}
+    {{ wizard.form }}
+{% endif %}
+</table>
+
+<input class="btn" type="submit" value="{% trans "next" %}"/>
+
+{% if wizard.steps.prev %}
+<div class="">
+	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
+	<button class="btn btn-sm btn-black" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+</div>
+{% endif %}
+
+</form>
+</div>
+{% endblock %}

--- a/apps/theme/static_src/src/css/custom/forms-custom.css
+++ b/apps/theme/static_src/src/css/custom/forms-custom.css
@@ -4,10 +4,11 @@
 /* Styles for forms that are laid out as tables */
 /* 1. GENERAL form_table         */
 /* 2. NETWORK FOOTPRINT TABLE    */
+/* 3. CONSENT TABLE              */
 
 /* Other kinds of form layout. */
-/* 3. EVIDENCE FORM             */
-/* 4. DIRECTORY FORMS           */
+/* 21. EVIDENCE FORM             */
+/* 22. DIRECTORY FORMS           */
 
 
 
@@ -53,6 +54,7 @@
 .form__table label {
 	@apply block;
 	@apply mb-4;
+	@apply text-left;
 }
 .form__table span.helptext {
 	@apply order-first;
@@ -95,8 +97,28 @@ table[class^="form__table--"] label {
 	@apply mb-1;
 }
 
+/* 3. CONSENT TABLE               */
+.form__table--consent tr {
+	@apply relative;
+}
+.form__table--consent tr th {
+	@apply ml-16;
+}
+.form__table--consent tr td input {
+	@apply absolute;
+	@apply top-10;
+	width: 2rem;
+	height: 2rem;
+	@apply border-2;
+}
+.form__table--consent .helptext {
+	@apply ml-16;
+}
 
-/* 3. EVIDENCE FORM              */
+
+/* **************************** */
+
+/* 21. EVIDENCE FORM              */
 .form__evidence .convenient-form {
 	@apply md:flex;
 	@apply flex-wrap;
@@ -144,7 +166,7 @@ table[class^="form__table--"] label {
 }
 
 
-/* 4. DIRECTORY FORMS           */
+/* 22. DIRECTORY FORMS           */
 .form__directory label {
 	@apply block;
 	@apply text-white;

--- a/apps/theme/static_src/src/css/custom/forms.css
+++ b/apps/theme/static_src/src/css/custom/forms.css
@@ -32,6 +32,7 @@ textarea {
 	@apply mb-2;
 	@apply mr-2;
 	@apply text-black;
+	@apply border-black;
 }
 [type="checkbox"]:checked, 
 [type="radio"]:checked {


### PR DESCRIPTION
To override how a table is styled in the consent page, we overridde the `content` block.

You can see us doing this already in the `consent` page, where we add this extra stuff.

```
{% block header_section %}
<section class="prose mt-10">
	<h1>One last thing...</h1>
	<p>We want to check you consent to us storing and processing the data you provided in different ways.</p>
</section>
{% endblock %}
```

This inserts it into the  `header_section`  block that is otherwise empty in the base_form, which normally looks like this:

```
<!-- child templates can override this to inject custom HTML content -->
{% block header_section %}
{% endblock %}
```

In this case because the content block contains the `header_section` section anyway, we put it _inside_ the content block

