### PR TITLE
Add success notification on submitted verification request

### DIFF
--- a/apps/accounts/templates/provider_request/detail.html
+++ b/apps/accounts/templates/provider_request/detail.html
@@ -2,6 +2,15 @@
 {% load i18n static %}
 
 {% block content %}
+
+{% if messages %}
+<div class="messages">
+    {% for message in messages %}
+    <div{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</div>
+    {% endfor %}
+</div>
+{% endif %}
+
 <section class="prose mx-auto">
 
 	<header class="">

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -282,6 +282,16 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         # send an email notification to the author and green web staff
         self._send_notification_email(pr)
 
+        # display a notification on the next page
+        messages.success(
+            self.request,
+            """
+            Thank you! 
+            
+            Your verification request was submitted successfully.
+            We are now reviewing your request - we'll be in touch.
+            """,
+        )
         return redirect(pr)
 
     def get_template_names(self):

--- a/apps/theme/static_src/src/css/base.css
+++ b/apps/theme/static_src/src/css/base.css
@@ -30,4 +30,13 @@
 	h1, h2, h3, h4, h5, h6 {
 		@apply font-bold;
 	}
+
+	/* SUCCESS NOTIFICATION */
+	.messages .success {
+		@apply p-6;
+		@apply bg-green-50;
+		@apply border-2;
+		@apply rounded-xl;
+		margin-bottom: 50px;
+	}
 }


### PR DESCRIPTION
On successful submission of the verification request, we display a success notification on top of the page (detail view of the request). Here's what it looks like:

![Screenshot 2023-02-08 at 14-18-10 The Green Web Foundation](https://user-images.githubusercontent.com/5598055/217542357-9fab2038-4d68-4530-94b6-82d39aef16ed.png)


Please feel free to give suggestions on either styling or the copy. 