### PR TITLE
Remove label suffix in the consent form

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -269,7 +269,9 @@ class ServicesForm(forms.Form):
         choices=ProviderRequest.get_service_choices,
         widget=forms.CheckboxSelectMultiple,
         label="What hosting services do you offer?",
-        help_text=mark_safe('Choose all the services that your organisation offers. <a href="https://www.thegreenwebfoundation.org/directory/services-offered/" target="_blank" rel="noopener noreferrer">More information on our services</a>.'),
+        help_text=mark_safe(
+            'Choose all the services that your organisation offers. <a href="https://www.thegreenwebfoundation.org/directory/services-offered/" target="_blank" rel="noopener noreferrer">More information on our services</a>.'
+        ),
     )
 
 
@@ -392,13 +394,16 @@ class ConsentForm(forms.ModelForm):
             "I consent to my submitted information being stored and processed to allow"
             " a response to my inquiry"
         ),
+        label_suffix="",
         help_text=mark_safe(
-            '<a href="https://www.thegreenwebfoundation.org/privacy-statement/" target="_blank" rel="noopener noreferrer">See our full privacy notice</a>'),
+            '<a href="https://www.thegreenwebfoundation.org/privacy-statement/" target="_blank" rel="noopener noreferrer">See our full privacy notice</a>'
+        ),
     )
     newsletter_opt_in = forms.BooleanField(
         required=False,
         initial=False,
         label="Sign me up to the newsletter",
+        label_suffix="",
         help_text=(
             "We run a newsletter, Greening Digital, where we share actionable news"
             " about greening the web and a sustainable digital transition. You can"
@@ -422,9 +427,7 @@ class LocationForm(forms.ModelForm):
         required=False,
         widget=forms.widgets.TextInput(
             attrs={
-                "placeholder": (
-                    "Location name"
-                ),
+                "placeholder": ("Location name"),
                 "size": 60,
             },
         ),
@@ -436,11 +439,9 @@ class LocationForm(forms.ModelForm):
         help_text=(
             "If this location is not within a given city, choose the nearest city."
         ),
-		widget=forms.widgets.TextInput(
+        widget=forms.widgets.TextInput(
             attrs={
-                "placeholder": (
-                    "City"
-                ),
+                "placeholder": ("City"),
                 "size": 60,
             },
         ),
@@ -474,4 +475,5 @@ class PreviewForm(forms.Form):
     It is used as a placeholder for the last step of the Wizard,
     in order to render a preview of all data from the previous steps.
     """
+
     pass


### PR DESCRIPTION
Sets `label_suffix=""` to both fields of the `ConsentForm`, which removes the default colon (`:`) character from the label. 

See the docs here: https://docs.djangoproject.com/en/4.1/ref/forms/api/#django.forms.Form.label_suffix

Now the consent form looks like this (notice lack of `:` at the end of the text after the checkbox)
![Screenshot 2023-02-08 at 15-06-28 The Green Web Foundation](https://user-images.githubusercontent.com/5598055/217552327-a585816d-c290-4733-89f8-15362cd23352.png)

This was prompted by @hanopcan question in https://trello.com/c/MpxIk6d8/89-style-consent-page#comment-63d3f66c43f8c55b495f6f9f and was very easy to implement.