### PR TITLE
Display URL/file name on the detail view of ProviderRequest

### DIFF
--- a/apps/accounts/models/provider_request.py
+++ b/apps/accounts/models/provider_request.py
@@ -176,10 +176,11 @@ class ProviderRequestEvidence(models.Model):
     request = models.ForeignKey(ProviderRequest, on_delete=models.CASCADE)
 
     def __str__(self) -> str:
-        name = f"{self.title}, {self.type}"
+        name = self.link or self.file.name
+        long_name = f"{name}: {self.title}"
         if self.public:
-            return f"{name}, public"
-        return f"{name}, private"
+            return f"{long_name} (public)"
+        return f"{long_name} (private)"
 
     def clean(self) -> None:
         reason = "Provide a link OR a file for this evidence"


### PR DESCRIPTION
Small change to display the URL or file name for each evidence on the detail view of the `ProviderRequest` object.

![Screenshot 2023-02-08 at 17-06-03 The Green Web Foundation](https://user-images.githubusercontent.com/5598055/217584511-24a32726-720d-4db7-bea6-b3667f392967.png)
