### PR TITLE
Send email notification to support staff and user when submitting a form

### DIFF
--- a/apps/accounts/templates/emails/verification-request-notify.html
+++ b/apps/accounts/templates/emails/verification-request-notify.html
@@ -1,0 +1,21 @@
+<p>Hello</p>
+
+<p>Thank you for taking the time to complete a verification request for { company_name } in the Green Web Database.</p>
+
+<p>You can see your submitted request at the link below:</p>
+
+<p><a href="{{ link_to_verification_request }}"">{{ link_to_verification_request }}</a></p>
+
+<p>Your request is currently: {{ status }}</p>
+
+<h4>What happens next?</h4>
+
+<p>Assuming your request contains all the information we need to verify your organisation, you can expect to hear from us again, notifying you that you have been verified and how to tell others.</p>
+
+<p>We normally get back to people within 48 hours.</p>
+
+<p>If you have further questions, please contact support@thegreenwebfoundation.org, and please include the above link to your request.</p>
+
+<p>Many thanks,</p>
+
+<p>The Green Web Foundation Support Team</p>

--- a/apps/accounts/templates/emails/verification-request-notify.html
+++ b/apps/accounts/templates/emails/verification-request-notify.html
@@ -1,6 +1,6 @@
 <p>Hello</p>
 
-<p>Thank you for taking the time to complete a verification request for { company_name } in the Green Web Database.</p>
+<p>Thank you for taking the time to complete a verification request for {{ org_name }} in the Green Web Database.</p>
 
 <p>You can see your submitted request at the link below:</p>
 

--- a/apps/accounts/templates/emails/verification-request-notify.txt
+++ b/apps/accounts/templates/emails/verification-request-notify.txt
@@ -1,0 +1,21 @@
+Hello,
+
+Thank you for taking the time to complete a verification request for { company_name } in the Green Web Database.
+
+You can see your submitted request at the link below:
+
+{{ link_to_verification_request }}
+
+Your request is currently {{ status }}
+
+What happens next?
+
+Assuming your request contains all the information we need to verify your organisation, you can expect to hear from us again, notifying you that you have been verified and how to tell others.
+
+We normally get back to people within 48 hours.
+
+If you have further questions, please contact support@thegreenwebfoundation.org, and please include the above link to your request.
+
+Many thanks,
+
+The Green Web Foundation Support Team

--- a/apps/accounts/templates/emails/verification-request-notify.txt
+++ b/apps/accounts/templates/emails/verification-request-notify.txt
@@ -1,6 +1,6 @@
 Hello,
 
-Thank you for taking the time to complete a verification request for { company_name } in the Green Web Database.
+Thank you for taking the time to complete a verification request for {{ org_name }} in the Green Web Database.
 
 You can see your submitted request at the link below:
 

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -361,9 +361,12 @@ def test_wizard_sends_email_on_submission(
     eml = mailoutbox[0]
 
     # then: our email is addressed to the people we expect it to be
-    assert "support@thegreenwebfoundation.org" in eml.to
     assert user.email in eml.to
+    assert "support@thegreenwebfoundation.org" in eml.cc
 
     # then: our email has the subject and copy we were expecting
-    assert eml.body == "Thank you for taking the time to complete a verification request."
+    # import ipdb; ipdb.set_trace()
     assert eml.subject == "Your verification request for the Green Web Database"
+    assert "Thank you for taking the time to complete a verification request" in eml.body
+
+    # then: our email links back to the submission, contains the status, and the correct organisation

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -356,10 +356,14 @@ def test_wizard_sends_email_on_submission(
     pr = response.context_data["providerrequest"]
     assert models.ProviderRequest.objects.filter(id=pr.id).exists()
 
-    # check email exists
+    # then: an email is in the outbox waiting to be sent
     assert len(mailoutbox) == 1
     eml = mailoutbox[0]
 
-    # check our email looks how we expect
+    # then: our email is addressed to the people we expect it to be
+    assert "support@thegreenwebfoundation.org" in eml.to
+    assert user.email in eml.to
+
+    # then: our email has the subject and copy we were expecting
     assert eml.body == "Thank you for taking the time to complete a verification request."
     assert eml.subject == "Your verification request for the Green Web Database"

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -322,11 +322,11 @@ def test_wizard_sends_email_on_submission(
     wizard_form_preview,
     mailoutbox
 ):
-"""
-Given: a working set of data
-When: a user has completed a form submission,
-Then: an email should have been sent to the user and internal staff
-"""
+    """
+    Given: a working set of data
+    When: a user has completed a form submission,
+    Then: an email should have been sent to the user and internal staff
+    """
 
     # given: valid form data and authenticated user
     form_data = [

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -374,12 +374,16 @@ def test_wizard_sends_email_on_submission(
     provider_request = models.ProviderRequest.objects.get(name=provider_name)
     request_path = reverse("provider_request_detail", args=[provider_request.id])
 
+    # should be something like http://testserver/requests/1 ,
+    # but more like https://app.greenweb/requests/1 when live
+    link_to_verification_request = f"http://testserver{request_path}"
+
+    assert link_to_verification_request in msg_body_txt
+    assert link_to_verification_request in msg_body_html
+
     assert provider_request.name in msg_body_txt
     assert provider_request.name in msg_body_html
 
     assert provider_request.status == models.ProviderRequestStatus.OPEN
     assert provider_request.status in msg_body_txt
     assert provider_request.status in msg_body_html
-
-    assert request_path in msg_body_txt
-    assert request_path in msg_body_html

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -279,7 +279,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         consent.request = pr
         consent.save()
 
-
+        # send an email notification to the author and green web staff
         self._send_notification_email(self.request.user, pr)
 
         return redirect(pr)

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,6 +1,8 @@
 import waffle
 from waffle.mixins import WaffleFlagMixin
 from enum import Enum
+
+import smtplib
 from django.core.files.storage import DefaultStorage
 from django.contrib import messages
 from django.contrib.auth.models import Group
@@ -343,11 +345,15 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         email_subject = "Your verification request for the Green Web Database"
         email_body = render_to_string("emails/verification-request-notify.txt", context=ctx)
 
-
         msg = AnymailMessage(
             subject=email_subject,
             body=email_body,
             to=[user.email],
             cc=["support@thegreenwebfoundation.org"],
         )
-        msg.send()
+        try:
+            msg.send()
+        except smtplib.SMTPException as err:
+            logger.warn(f"Failed to send because of {err}. See https://docs.python.org/3/library/smtplib.html for more")
+        except Exception as err:
+            logger.exception("Unexpected fatal error sending email: {err}")

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -333,8 +333,10 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         """
 
         current_site = get_current_site(self.request)
+
         request_path = reverse("provider_request_detail", args=[provider_request.id])
-        link_to_verification_request = f"{current_site.domain}/{request_path}"
+
+        link_to_verification_request = f"{self.request.scheme}://{current_site.domain}/{request_path}"
 
         ctx = {
             "org_name": provider_request.name,
@@ -344,6 +346,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
 
         email_subject = "Your verification request for the Green Web Database"
         email_body = render_to_string("emails/verification-request-notify.txt", context=ctx)
+        email_html = render_to_string("emails/verification-request-notify.html", context=ctx)
 
         msg = AnymailMessage(
             subject=email_subject,
@@ -351,6 +354,9 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
             to=[user.email],
             cc=["support@thegreenwebfoundation.org"],
         )
+        msg.attach_alternative(email_html, "text/html")
+
+
         try:
             msg.send()
         except smtplib.SMTPException as err:

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -280,7 +280,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         consent.save()
 
         # send an email notification to the author and green web staff
-        self._send_notification_email(self.request.user, pr)
+        self._send_notification_email(pr)
 
         return redirect(pr)
 
@@ -327,16 +327,17 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
             context["preview_forms"] = self._get_data_for_preview()
         return context
 
-    def _send_notification_email(self, user: User, provider_request: ProviderRequest):
+    def _send_notification_email(self, provider_request: ProviderRequest):
         """
-        Send notification to support staff, and the user to acknowledge their submission
+        Send notification to support staff, and the user to acknowledge their submission.
         """
 
         current_site = get_current_site(self.request)
-
+        connection_scheme = self.request.scheme
+        user = self.request.user
         request_path = reverse("provider_request_detail", args=[provider_request.id])
 
-        link_to_verification_request = f"{self.request.scheme}://{current_site.domain}/{request_path}"
+        link_to_verification_request = f"{connection_scheme}://{current_site.domain}/{request_path}"
 
         ctx = {
             "org_name": provider_request.name,

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -337,7 +337,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
         user = self.request.user
         request_path = reverse("provider_request_detail", args=[provider_request.id])
 
-        link_to_verification_request = f"{connection_scheme}://{current_site.domain}/{request_path}"
+        link_to_verification_request = f"{connection_scheme}://{current_site.domain}{request_path}"
 
         ctx = {
             "org_name": provider_request.name,


### PR DESCRIPTION
This PR introduces the logic to send an email to:

1. our internal support address
2. the user who submitted the form

The email message contains a link to the submission for reference along with a helpful message.

- [x] email uses a text template we can read and change the copy
- [x] email uses an html template we can read and change the copy
- [x] email links back to to the provider, and includes relevant details
- [x] an email is sent to the submission author and the support staff
- [x] we have fail gracefully when email is not working, with a intelligible error message