### PR TITLE
Update path, add verification request in admin

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -11,6 +11,9 @@ from django.shortcuts import render
 from django.views.generic.edit import FormView
 from django import forms
 
+from waffle import flag_is_active
+
+
 import ipwhois
 
 from apps.greencheck.views import GreenUrlsView
@@ -144,8 +147,31 @@ class GreenWebAdmin(AdminSite):
         return patterns + urls
 
     def get_app_list(self, request):
+
         app_list = super().get_app_list(request)
+
+        if flag_is_active(request, "provider_request"):
+
+            verification_request_item = {
+                "name": "Verification requests",
+                "app_label": "greencheck",
+                "app_url": reverse("provider_request_list"),
+                "models": [
+                    {
+                        "name": "See verification requests",
+                        "object_name": "greencheck_url",
+                        "admin_url": reverse("provider_request_list"),
+                        "view_only": True,
+                    }
+                ],
+            }
+            app_list.insert(0, verification_request_item)
+
+
+
         app_list += [
+
+
             {
                 "name": "Try out greencheck",
                 "app_label": "greencheck",

--- a/apps/accounts/templates/provider_request/list.html
+++ b/apps/accounts/templates/provider_request/list.html
@@ -1,52 +1,65 @@
 {% extends 'base.html' %}
 
-{% load i18n static humanize widget_tweaks tailwind_filters %}
+{% load i18n static humanize widget_tweaks tailwind_filters waffle_tags %}
 
 {% block content %}
 
-<article>
-	<div class="prose mx-auto mt-8">
-		<h1 class="text-center">Provider portal</h1>
-		<p>As a small and independent non-profit organisation, we've been maintaining the world's 
-			largest open dataset on green hosting providers, <strong>the Green Web Dataset</strong>, 
-			since 2012. Every day, across the globe, around seven million checks against it are 
-			made by people using our 
-			<a href="https://developers.thegreenwebfoundation.org/api/greencheck/v3/check-single-domain/" target="_blank" rel="noopener noreferrer">Green Web Check API</a> 
-			and <a href="https://www.thegreenwebfoundation.org/green-web-check/" target="_blank" rel="noopener noreferrer">Green Web Check</a> tools.
-		<p>
-		<p>This portal helps hosting providers become included in the Green Web Dataset
-			and keep their submitted data up to date.</p>
-	</div>		
+  <article>
+    <div class="prose mx-auto mt-8">
+      <h1 class="text-center">Provider portal</h1>
+      <p>As a small and independent non-profit organisation, we've been maintaining the world's
+        largest open dataset on green hosting providers, <strong>the Green Web Dataset</strong>,
+        since 2012. Every day, across the globe, around seven million checks against it are
+        made by people using our
+        <a href="https://developers.thegreenwebfoundation.org/api/greencheck/v3/check-single-domain/" target="_blank" rel="noopener noreferrer">Green Web Check API</a>
+        and <a href="https://www.thegreenwebfoundation.org/green-web-check/" target="_blank" rel="noopener noreferrer">Green Web Check</a> tools.
+        <p>
+          <p>This portal helps hosting providers become included in the Green Web Dataset
+            and keep their submitted data up to date.</p>
+        </div>
 
-	<div class="lg:grid grid-cols-2 gap-16 my-10">
-		<section class="prose border-2 rounded-xl mb-6 lg:mb-0 p-6">
-			<h3 class="text-2xl border-b-2">How can my organisation be included in the dataset?</h3>
-			<p>Hosting providers can submit a <span class="font-bold">verification request</span> to us to <a href="https://www.thegreenwebfoundation.org/what-you-need-to-register/" target="_blank" rel="noopener noreferrer">demonstrate they are green</a>. The verification process is free of charge.</p>
-			<p>Once verified, hosting providers are included in the Green Web dataset for free and checks against their sites or services will show as green.</p>
-			<p>Verified hosting providers can choose to further support our work by paying a modest fee to be featured in our <a href="https://www.thegreenwebfoundation.org/directory/" target="_blank" rel="noopener noreferrer">Green Hosting Directory</a> service.</p>
-			<p>Whether you want to be included in just the dataset or the directory as well, the starting point is the same - submit a verification request.</p>
-		</section>
+        <div class="lg:grid grid-cols-2 gap-16 my-10">
+          <section class="prose border-2 rounded-xl mb-6 lg:mb-0 p-6">
+            <h3 class="text-2xl border-b-2">How can my organisation be included in the dataset?</h3>
+            <p>Hosting providers can submit a <span class="font-bold">verification request</span> to us to <a href="https://www.thegreenwebfoundation.org/what-you-need-to-register/" target="_blank" rel="noopener noreferrer">demonstrate they are green</a>. The verification process is free of charge.</p>
+            <p>Once verified, hosting providers are included in the Green Web dataset for free and checks against their sites or services will show as green.</p>
+            <p>Verified hosting providers can choose to further support our work by paying a modest fee to be featured in our <a href="https://www.thegreenwebfoundation.org/directory/" target="_blank" rel="noopener noreferrer">Green Hosting Directory</a> service.</p>
+            <p>Whether you want to be included in just the dataset or the directory as well, the starting point is the same - submit a verification request.</p>
+          </section>
 
-		<section class="prose bg-white border-2 rounded-xl p-6">
-			<h3 class="text-2xl border-b-2">Your verification requests</h3>
-			<p>Before starting the verification process, we recommend reading our guide <a href="https://www.thegreenwebfoundation.org/what-you-need-to-register/" target="_blank" rel="noopener noreferrer">What you need to register</a> and preparing your evidence in advance.</p>
-			<p>On completion of the form, your submission will be reviewed by our staff. 
-				If we have all the evidence we need, we’ll notify you to let you know that checks against 
-				your site or services show as green. If we can't find the evidence we need, we’ll reply letting you know what else is required.</p>
-			
-			<p class="mt-8"><a href="/requests/new" class="btn">Start a verification request</a></p>
+          <section class="prose bg-white border-2 rounded-xl p-6">
+            <h3 class="text-2xl border-b-2">Your verification requests</h3>
+            <p>Before starting the verification process, we recommend reading our guide <a href="https://www.thegreenwebfoundation.org/what-you-need-to-register/" target="_blank" rel="noopener noreferrer">What you need to register</a> and preparing your evidence in advance.</p>
+            <p>On completion of the form, your submission will be reviewed by our staff.
+              If we have all the evidence we need, we’ll notify you to let you know that checks against
+              your site or services show as green. If we can't find the evidence we need, we’ll reply letting you know what else is required.</p>
 
-			<h3 class="text-xl pt-10">Your submitted requests</h3>
+            <p class="mt-8"><a href="/requests/new" class="btn">Start a verification request</a></p>
 
-			{% for request in object_list %}
-				<p><a href="{{ request.get_absolute_url }}">{{ request.name }} | <b>{{ request.status | upper }}</b></a></p>
+            <h3 class="text-xl pt-10">Your submitted requests</h3>
 
-				{% empty %}
-				<p>No submitted requests
-			
-			{% endfor %}
-		</section>
-	</div>
-</article>
+            {% for request in object_list %}
+              <p><a href="{{ request.get_absolute_url }}">{{ request.name }} | <b>{{ request.status | upper }}</b></a></p>
+
+            {% empty %}
+              <p>No submitted requests
+
+            {% endfor %}
+
+            {% comment %}
+				Use the flag below to grant easy access to the old admin site using the waffle flag
+				feature.
+			{% endcomment %}
+            {% flag "access_old_admin_from_verification_list" %}
+
+              <h3 class="text-xl pt-10">Your approved providers</h3>
+
+              <p>Already been verified, or updating an existing provider? <a href="{% url 'greenweb_admin:index' %}"> Log into our old admin interface</a>.</p>
+
+            {% endflag %}
+
+          </section>
+        </div>
+      </article>
 
 {% endblock %}

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
         auth_views.PasswordResetView.as_view(),
         name="admin_password_reset",
     ),
-    path("registration/", AdminRegistrationView.as_view(), name="registration"),
+    path("accounts/signup/", AdminRegistrationView.as_view(), name="registration"),
     url(
         r"activation/(?P<activation_key>[-:\w]+)/",
         AdminActivationView.as_view(),

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -84,7 +84,7 @@ class AdminRegistrationView(RegistrationView):
         """
         Return the URL to redirect to after successful redirection.
         """
-        return reverse("admin:index")
+        return reverse("provider_request_list")
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()


### PR DESCRIPTION
This is matched to the trello card below:

https://trello.com/c/GVakUTC9/7-verification-request-self-serviced-user-creation

This PR adds a few main changes:

1. It changes the default styled sign urls, so we now have `/accounts/login/` to log in, and `/accounts/signup/` to sign up / register.
2. Changes the default place you end up when signing in to be the verification list, with the new branding

I added two smaller changes after adding this, as I realised once you had signed in, it wasn't obvious how to move between the two worlds of the old admin (where existing users might need to update info on an existing provider), and the new one (where if you are on the old admin, you can't easily access the new verification screen).

These are: 

1. It make the verification requests accessible from the admin that existing users sign into.
2. Add a link back to the old admin interface for folks who already have an provider they are maintaining the info for.

In the second case, the link behind the to the old admin is behind the `access_old_admin_from_verification_list` flag.

This allows us to share in selectively (by adding people specifically to the flag in production), or roll it our more widely.
