### PR TITLE
Hyperlink to user page from the ProviderRequest admin

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1172,7 +1172,7 @@ class ProviderRequest(ActionInChangeFormMixin, admin.ModelAdmin):
     formfield_overrides = {TaggableManager: {"widget": LabelWidget}}
     empty_value_display = "(empty)"
     list_filter = ("status",)
-    readonly_fields = ("authorised_by_org",)
+    readonly_fields = ("authorised_by_org", "created_by")
     actions = [
         "mark_approved",
     ]


### PR DESCRIPTION
This was requested by Justine at the demo session today. In case we need to reach out for more information to the user who submitted a verification request, it's useful to have their contact info one click away from the admin change view. The readonly field is rendered as a hyperlink to the User admin change view, that contains the email address.

Before:
![Screenshot 2023-02-20 at 16-13-09 test user 1 demo Change provider request Django site admin](https://user-images.githubusercontent.com/5598055/220143456-13078a5d-ac22-46f3-97ea-de435276648f.png)


After:
![Screenshot 2023-02-20 at 16-11-17 test user 1 demo Change provider request Django site admin](https://user-images.githubusercontent.com/5598055/220143483-2040a77d-7544-4826-a7c1-3650533d14f6.png)
