### PR TITLE
Add ways for staff to navigate IP and AS ranges

### DIFF
--- a/apps/greencheck/admin.py
+++ b/apps/greencheck/admin.py
@@ -182,8 +182,6 @@ class StatusAsFilter(admin.SimpleListFilter):
         return queryset.filter(status=self.value())
 
 
-
-
 @admin.register(GreencheckIpApprove, site=greenweb_admin)
 class GreencheckIpApproveAdmin(admin.ModelAdmin):
     list_display = [
@@ -327,7 +325,8 @@ class GreenDomainAdmin(admin.ModelAdmin):
 class GreenASNAdmin(admin.ModelAdmin):
     list_filter = [
         "active",
-        "hostingprovider"
+        "hostingprovider__archived",
+        "hostingprovider",
     ]
     list_display = [
         "active",
@@ -358,7 +357,9 @@ class GreenASNAdmin(admin.ModelAdmin):
 class GreenIPAdmin(admin.ModelAdmin):
     list_filter = [
         "active",
-        "hostingprovider"
+        "hostingprovider__archived",
+        "hostingprovider",
+
     ]
     list_display = [
         "active",

--- a/apps/greencheck/admin.py
+++ b/apps/greencheck/admin.py
@@ -182,6 +182,8 @@ class StatusAsFilter(admin.SimpleListFilter):
         return queryset.filter(status=self.value())
 
 
+
+
 @admin.register(GreencheckIpApprove, site=greenweb_admin)
 class GreencheckIpApproveAdmin(admin.ModelAdmin):
     list_display = [
@@ -281,8 +283,15 @@ class GreencheckASNApprove(admin.ModelAdmin):
     readonly_fields = ["link"]
 
     def get_queryset(self, request):
+
         qs = super().get_queryset(request)
         qs = qs.select_related("hostingprovider")
+
+        # only show a normal user's own requests
+        if not request.user.is_staff:
+            res = qs.filter(hostingprovider=request.user.hostingprovider)
+            return res
+
         return qs
 
     @mark_safe
@@ -313,3 +322,65 @@ class GreenDomainAdmin(admin.ModelAdmin):
         "green",
 
     ]
+
+@admin.register(models.GreencheckASN, site=greenweb_admin)
+class GreenASNAdmin(admin.ModelAdmin):
+    list_filter = [
+        "active",
+        "hostingprovider"
+    ]
+    list_display = [
+        "active",
+        "asn",
+        "hostingprovider",
+    ]
+    search_fields = ["hostingprovider"]
+    fields = [
+        "active",
+        "asn",
+        "hostingprovider",
+    ]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.select_related("hostingprovider")
+
+        # only show a normal user's own requests
+        if not request.user.is_staff:
+            res = qs.filter(hostingprovider=request.user.hostingprovider)
+            return res
+
+        return qs
+
+
+
+@admin.register(models.GreencheckIp, site=greenweb_admin)
+class GreenIPAdmin(admin.ModelAdmin):
+    list_filter = [
+        "active",
+        "hostingprovider"
+    ]
+    list_display = [
+        "active",
+        "ip_start",
+        "ip_end",
+        "hostingprovider",
+    ]
+    search_fields = ["hostingprovider"]
+    fields = [
+        "active",
+        "ip_start",
+        "ip_end",
+        "hostingprovider",
+    ]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        qs = qs.select_related("hostingprovider")
+
+        # only show a normal user's own requests
+        if not request.user.is_staff:
+            res = qs.filter(hostingprovider=request.user.hostingprovider)
+            return res
+
+        return qs

--- a/apps/greencheck/models/checks.py
+++ b/apps/greencheck/models/checks.py
@@ -378,6 +378,13 @@ class GreencheckASN(mu_models.TimeStampedModel):
         ac_models.Hostingprovider, on_delete=models.CASCADE, db_column="id_hp"
     )
 
+    def __str__(self):
+        active_state = "Inactive"
+        if self.active:
+            active_state = "Active"
+
+        return f"{self.hostingprovider} - {self.asn} - {active_state}"
+
     class Meta:
         db_table = "greencheck_as"
         indexes = [
@@ -522,7 +529,7 @@ class GreenDomain(models.Model):
             logger.warn(
                 (
                     f"Couldn't find a hosting provider for url: {self.url}, "
-                    f"and hosted_by_id: {hosted_by_id}."
+                    f"and hosted_by_id: {self.hosted_by_id}."
                 )
             )
             logger.warn(err)


### PR DESCRIPTION
This PR introduces the ability for staff to lookup AS and IP ranges, and filter by a number of criteria including:

- hosting provider
- whether the provider is archived or not
- active / inactive state



This also provides a search feature for quickly finding the IPs or ASNs that should be allocated to a given provider