### PR TITLE
Verificaiton request form display fixes

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -525,6 +525,7 @@ class LocationExtraForm(forms.Form):
             "I have more than ten locations to add. Please contact me separately "
             "to arrange a bulk import of this information."
         ),
+        initial=False,
         required=False
     )
 

--- a/apps/accounts/templates/provider_registration/network_footprint.html
+++ b/apps/accounts/templates/provider_registration/network_footprint.html
@@ -148,14 +148,14 @@
       <section class="mt-4 ">
 
         <label for="{{ wizard.form.extra.description.id_for_label }}">
-          {{ wizard.form.extra.description.label }}
+          {{ wizard.form.extra.missing_network_explanation.label }}
         </label>
 
         <div class="mt-3 mb-3 prose">
           <p class="helptext">We know that in some cases a provider isn't allocated exclusive use of an IP range or an AS number. If this applies to you, please add some information why this might be the case, so we can account for it when people look up your service.</p>
         </div>
 
-        {{ wizard.form.extra.description.as_widget }}
+        {{ wizard.form.extra.missing_network_explanation.as_widget }}
 
       </section>
 

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -1,10 +1,12 @@
 <div class="bg-neutral-50 rounded-xl my-6 p-4">
-
 	{% for field in form %}
 	<div class="mb-4 last-of-type:mb-0">
 		<p class="font-bold m-0">{{ field.label }}</p>
-		<p class="m-0">{{ field.value }}</p>
+		{% if field.value|lower in "true,false,none,on,off" %}
+			<p class="m-0">{{ field.value|yesno:"Yes,No,-" }}</p>
+		{% else %}
+			<p class="m-0">{{ field.value }}</p>
+		{% endif %}
 	</div>
 	{% endfor %}
-
 </div>

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -1,12 +1,9 @@
+{% load preview_extras %}
 <div class="bg-neutral-50 rounded-xl my-6 p-4">
 	{% for field in form %}
 	<div class="mb-4 last-of-type:mb-0">
 		<p class="font-bold m-0">{{ field.label }}</p>
-		{% if field.value|lower in "true,false,none,on,off" %}
-			<p class="m-0">{{ field.value|yesno:"Yes,No,-" }}</p>
-		{% else %}
-			<p class="m-0">{{ field.value }}</p>
-		{% endif %}
+		<p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
 	</div>
 	{% endfor %}
 </div>

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -3,7 +3,11 @@
 	{% for field in form %}
 	<div class="mb-4 last-of-type:mb-0">
 		<p class="font-bold m-0">{{ field.label }}</p>
-		<p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
+		{% if render_services %}
+			<p class="m-0">{{ field.value|render_as_services|conditional_yesno:"Yes,No,-" }}</p>
+		{% else %}
+			<p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
+		{% endif %}
 	</div>
 	{% endfor %}
 </div>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -48,7 +48,7 @@
 
         <section class="my-10">
           <h3>Services provided by your organisation</h3>
-          {% include "provider_registration/partials/_preview.html" with form=preview_forms.2 %}
+          {% include "provider_registration/partials/_preview.html" with form=preview_forms.2 render_services=True %}
         </section>
 
         <section class="my-10">

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -40,7 +40,7 @@
 
         <section class="my-10">
           <h3>Locations</h3>
-          {% for location_form in preview_forms.1.initial_forms %}
+          {% for location_form in preview_forms.1.locations.initial_forms %}
             {% include "provider_registration/partials/_preview.html" with form=location_form %}
           {% endfor %}
         </section>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -43,6 +43,7 @@
           {% for location_form in preview_forms.1.locations.initial_forms %}
             {% include "provider_registration/partials/_preview.html" with form=location_form %}
           {% endfor %}
+          {% include "provider_registration/partials/_preview.html" with form=preview_forms.1.extra %}
         </section>
 
         <section class="my-10">

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -62,7 +62,12 @@
           <h3>Network footprint</h3>
 
           {% for ip_form in preview_forms.4.ips.initial_forms %}
-            {% include "provider_registration/partials/_preview.html" with form=ip_form %}
+            <div class="bg-neutral-50 rounded-xl my-6 p-4">
+              <div class="mb-4 last-of-type:mb-0">
+                <p class="font-bold m-0">IP range</p>
+                <p class="m-0">{{ ip_form.start.value }} - {{ ip_form.end.value }}</p>
+              </div>
+            </div>
           {% endfor %}
 
           {% for asn_form in preview_forms.4.asns.initial_forms %}

--- a/apps/accounts/templatetags/preview_extras.py
+++ b/apps/accounts/templatetags/preview_extras.py
@@ -10,16 +10,11 @@ register = template.Library()
 def conditional_yesno(value, arg=None):
     """
     Custom template filter that acts like the builtin "yesno" filter,
-    but is only applied to certain values.
+    but is only applied to certain values: explicitly True, False, None and "".
     """
-    # catch empty string case first
     if value == "":
         value = None
-    # for some reason yesno does not map "off" to False
-    if str(value).lower() == "off":
-        value = False
-    # then see if value should be filtered with "yesno"
-    if str(value).lower() in "true,false,none,on":
+    if str(value).lower() in ["true", "false", "none"]:
         return yesno(value, arg)
     return value
 

--- a/apps/accounts/templatetags/preview_extras.py
+++ b/apps/accounts/templatetags/preview_extras.py
@@ -1,5 +1,7 @@
 from django.template.defaultfilters import yesno
 from django import template
+from apps.accounts.models import Tag
+
 
 register = template.Library()
 
@@ -17,3 +19,15 @@ def conditional_yesno(value, arg=None):
     if str(value).lower() in "true,false,none,on,off":
         return yesno(value, arg)
     return value
+
+
+@register.filter
+def render_as_services(value):
+    """
+    Attempts to map slugs in to service names
+    based on a database query.
+    """
+    tags = Tag.objects.filter(slug__in=value)
+    if tags:
+        return ", ".join([tag.name for tag in tags])
+    return None

--- a/apps/accounts/templatetags/preview_extras.py
+++ b/apps/accounts/templatetags/preview_extras.py
@@ -1,0 +1,19 @@
+from django.template.defaultfilters import yesno
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def conditional_yesno(value, arg=None):
+    """
+    Custom template filter that acts like the builtin "yesno" filter,
+    but is only applied to certain values.
+    """
+    # catch empty string case first
+    if value == "":
+        value = None
+    # then see if value should be filtered with "yesno"
+    if str(value).lower() in "true,false,none,on,off":
+        return yesno(value, arg)
+    return value

--- a/apps/accounts/templatetags/preview_extras.py
+++ b/apps/accounts/templatetags/preview_extras.py
@@ -15,8 +15,11 @@ def conditional_yesno(value, arg=None):
     # catch empty string case first
     if value == "":
         value = None
+    # for some reason yesno does not map "off" to False
+    if str(value).lower() == "off":
+        value = False
     # then see if value should be filtered with "yesno"
-    if str(value).lower() in "true,false,none,on,off":
+    if str(value).lower() in "true,false,none,on":
         return yesno(value, arg)
     return value
 

--- a/apps/accounts/tests/test_templatetags.py
+++ b/apps/accounts/tests/test_templatetags.py
@@ -1,5 +1,7 @@
-from apps.accounts.templatetags.preview_extras import conditional_yesno
-
+from apps.accounts.templatetags.preview_extras import (
+    conditional_yesno,
+    render_as_services,
+)
 import pytest
 
 
@@ -9,11 +11,31 @@ import pytest
         ("", "-"),
         (None, "-"),
         (True, "Yes"),
-        ("on", "Yes"),
         (False, "No"),
-        ("off", "No"),
         ("this value should not be mapped", "this value should not be mapped"),
     ],
 )
 def test_conditional_yesno(input, output):
     assert conditional_yesno(input, "Yes,No,-") == output
+
+
+@pytest.fixture
+def service_tags(db, tag_factory):
+    tag_factory.create(slug="slug1", name="Service 1")
+    tag_factory.create(slug="slug2", name="Service 2")
+    tag_factory.create(slug="slug3", name="Service 3")
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        (["slug1"], "Service 1"),
+        (["slug2", "xyz"], "Service 2"),
+        (["slug2", "slug3"], "Service 2, Service 3"),
+        (["xyz"], None),
+        ([], None),
+        ("xyz", None),
+    ],
+)
+def test_render_as_services(input, output, service_tags):
+    assert render_as_services(input) == output

--- a/apps/accounts/tests/test_templatetags.py
+++ b/apps/accounts/tests/test_templatetags.py
@@ -1,0 +1,19 @@
+from apps.accounts.templatetags.preview_extras import conditional_yesno
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        ("", "-"),
+        (None, "-"),
+        (True, "Yes"),
+        ("on", "Yes"),
+        (False, "No"),
+        ("off", "No"),
+        ("this value should not be mapped", "this value should not be mapped"),
+    ],
+)
+def test_conditional_yesno(input, output):
+    assert conditional_yesno(input, "Yes,No,-") == output


### PR DESCRIPTION
Various fixes for the verification request form:
- the locations bulk import checkbox is not checked by default,
- the "missing network explanation" text box is now displayed on the network footprint screen (it was missing after https://github.com/thegreenwebfoundation/admin-portal/pull/405 was merged, the template was not updated),
- on the preview screen, `True`/`False`/`None` and empty values are now displayed as `Yes`/`No`/`-` - this is implemented in a custom template filter: `conditional_yesno`,
- services are displayed as human-readable names instead of slugs on the preview screen - this is implemented in a custom template filter: `render_as_services`,
- locations are now displayed correctly on the preview screen (the template needed to be updated after a Multiform was introduced in https://github.com/thegreenwebfoundation/admin-portal/pull/410),
- IP ranges are now displayed in a single line (instead of start and end in separate lines) on the preview screen

BEFORE and AFTER side by side comparison:
![preview-before-and-after](https://user-images.githubusercontent.com/5598055/221808351-89db7c70-ce24-4b8b-939e-e5dcb4e6e3fe.png)
