### PR TITLE
Add checks for empty formsets in form wizard

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -568,7 +568,16 @@ class LocationStepForm(MultiModelForm):
         errors = super().non_field_errors()
         for form in self.forms.values():
             if isinstance(form, BaseFormSet):
-                errors.extend(form.non_form_errors())
+                # replace the original message to contain more precise information
+                # TODO: after upgrading to Django 4.1 use `too_few_forms` from this API instead:
+                # https://docs.djangoproject.com/en/4.1/topics/forms/formsets/#formsets-error-messages
+                original_msg = "Please submit at least 1 form."
+                target_msg = "Please submit at least 1 location."
+                formset_errors = [
+                    error.replace(original_msg, target_msg)
+                    for error in form.non_form_errors()
+                ]
+                errors.extend(formset_errors)
         return errors
 
 

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -581,7 +581,7 @@ class LocationStepForm(MultiModelForm):
                     ORIGINAL_ERROR_MSG = "Please submit at least 1 form."
                     REPLACEMENT_ERROR_MSG = "Please submit at least 1 location."
 
-                    # swap out the error message for one that make more
+                    # swap out the error message for one that makes more
                     # sense in the multiform
                     if formset_name_error == ORIGINAL_ERROR_MSG:
                         form_errs[index] = REPLACEMENT_ERROR_MSG

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -511,9 +511,7 @@ class LocationForm(forms.ModelForm):
 # Uses ConvenientBaseFormSet to display add/delete buttons
 # and manage the forms inside the formset dynamically.
 LocationsFormSet = forms.formset_factory(
-    LocationForm,
-    extra=1,
-    formset=MoreConvenientFormset,
+    LocationForm, extra=1, formset=MoreConvenientFormset, validate_min=True, min_num=1
 )
 
 

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -330,9 +330,7 @@ class MoreConvenientFormset(ConvenientBaseFormSet):
 # Uses ConvenientBaseFormSet to display add/delete buttons
 # and manage the forms inside the formset dynamically.
 GreenEvidenceForm = forms.formset_factory(
-    CredentialForm,
-    extra=1,
-    formset=MoreConvenientFormset,
+    CredentialForm, extra=1, formset=MoreConvenientFormset, validate_min=True, min_num=1
 )
 
 

--- a/apps/accounts/templates/provider_registration/evidence.html
+++ b/apps/accounts/templates/provider_registration/evidence.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n static %}
-
 {% block head %}
 
 {% endblock %}
@@ -49,10 +48,31 @@
 {% endif %}
 
 	{% csrf_token %}
+
 	{{ wizard.management_form }}
 	{{ wizard.form.management_form }}
 
+	{% comment %}
+
+	Formsets don't just have form errors, we need to account for the errors relating
+	to the number of submitted options in a set of forms
+
+	{% endcomment %}
+	{% if wizard.form.non_form_errors %}
+		<div class="prose my-10 mx-auto">
+			<div class="convenient-form bg-neutral-50 rounded-xl px-4 ">
+				<div class="form__basetext-fields form--location lg:flex lg:flex-wrap">
+					<div class="w-full">
+						{{ wizard.form.non_form_errors}}
+					</div>
+				</div>
+			</div>
+		</div>
+	{% endif %}
+
 	<div id="convenient-formset">
+
+	{{ wizard.form.non_field_errors}}
 
 		{% for form in wizard.form.forms %}
 		<div class="convenient-form bg-neutral-50 rounded-xl my-6 pb-6">

--- a/apps/accounts/templates/provider_registration/locations.html
+++ b/apps/accounts/templates/provider_registration/locations.html
@@ -47,6 +47,19 @@
 		{{ wizard.management_form }}
 		{{ wizard.form.locations.management_form }}
 
+		{% if wizard.form.errors.locations %}
+			<div class="prose my-10 mx-auto">
+				<div class="convenient-form bg-neutral-50 rounded-xl my-6 px-4 py-6">
+					<div class="form__basetext-fields form--location lg:flex lg:flex-wrap">
+						<div class="w-full">
+							{{ wizard.form.errors.locations}}
+						</div>
+					</div>
+				</div>
+			</div>
+		{% endif %}
+
+
 		<div id="convenient-formset">
 
 			{% for form in wizard.form.locations %}

--- a/apps/accounts/templates/provider_registration/locations.html
+++ b/apps/accounts/templates/provider_registration/locations.html
@@ -46,19 +46,23 @@
 		{% csrf_token %}
 		{{ wizard.management_form }}
 		{{ wizard.form.locations.management_form }}
+		{% comment %}
 
-		{% if wizard.form.errors.locations %}
+		Formsets don't just have form errors, we need to account for the errors relating
+		to the number of submitted options in a set of forms
+
+		{% endcomment %}
+		{% if wizard.form.non_field_errors %}
 			<div class="prose my-10 mx-auto">
-				<div class="convenient-form bg-neutral-50 rounded-xl my-6 px-4 py-6">
+				<div class="convenient-form bg-neutral-50 rounded-xl px-4 ">
 					<div class="form__basetext-fields form--location lg:flex lg:flex-wrap">
 						<div class="w-full">
-							{{ wizard.form.errors.locations}}
+							{{ wizard.form.non_field_errors}}
 						</div>
 					</div>
 				</div>
 			</div>
 		{% endif %}
-
 
 		<div id="convenient-formset">
 

--- a/apps/accounts/templates/provider_registration/network_footprint.html
+++ b/apps/accounts/templates/provider_registration/network_footprint.html
@@ -72,8 +72,29 @@
   {% csrf_token %}
   {{ wizard.management_form }}
 
-  <!-- wizard.form is a MultiForm (from django-betterforms) -->
-  <!-- that has 2 separate forms: ips, asns -->
+  {% comment %}
+  wizard.form is a MultiForm (from django-betterforms)
+  that has 3 separate 'child' forms
+   - two 'formset' forms: 'ips', 'asns',
+   - one 'regular' form: 'missing_network_explanation'
+
+  We each form has it's own local errors, but we need to also
+  show errors not tied to any specific child form, hence the
+  'non_field_errors'
+  {% endcomment %}
+
+
+  {% if wizard.form.non_field_errors %}
+    <div class="prose my-10 mx-auto">
+      <div class="convenient-form bg-neutral-50 rounded-xl px-4 ">
+        <div class="form__basetext-fields form--location lg:flex lg:flex-wrap">
+          <div class="w-full">
+            {{ wizard.form.non_field_errors }}
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
 
   <div class="lg:grid grid-cols-2 gap-16 my-10">
 

--- a/apps/accounts/tests/test_form.py
+++ b/apps/accounts/tests/test_form.py
@@ -9,6 +9,7 @@ from apps.accounts.forms import (
     IpRangeForm,
     NetworkFootprintForm,
     LocationsFormSet,
+    LocationStepForm,
 )
 from apps.accounts.models import EvidenceType
 from apps.greencheck import forms as gc_forms
@@ -303,5 +304,34 @@ def test_locations_formset_invalid_with_no_locations():
     }
 
     formset = LocationsFormSet(empty_data)
+    valid = formset.is_valid()
+
     # then our form should be invalid
-    assert not formset.is_valid()
+    assert not valid
+
+
+def test_location_step_form_when_invalid_raises_errors():
+    """
+    Check that non field errors are raised from a formset to a multiform.
+
+    By default, multimodelforms do not seem to correctly raise errors on
+    formsets
+    """
+    # given an empty formset
+    empty_data = {
+        "form-TOTAL_FORMS": "0",
+        "form-INITIAL_FORMS": "0",
+    }
+
+    step_form = LocationStepForm(empty_data)
+
+    # when we try to validate it
+    valid = step_form.is_valid()
+
+    # then our form should not show as valid
+    assert not valid
+
+    # and our error list should show tell us that we are missing the necessary
+    # location sub-form submission
+    assert step_form.errors
+    assert "Please submit at least 1 location." in step_form.errors["locations"]

--- a/apps/accounts/tests/test_form.py
+++ b/apps/accounts/tests/test_form.py
@@ -4,7 +4,12 @@ from ipaddress import ip_address
 import pytest
 from faker import Faker
 
-from apps.accounts.forms import GreenEvidenceForm, IpRangeForm, NetworkFootprintForm
+from apps.accounts.forms import (
+    GreenEvidenceForm,
+    IpRangeForm,
+    NetworkFootprintForm,
+    LocationsFormSet,
+)
 from apps.accounts.models import EvidenceType
 from apps.greencheck import forms as gc_forms
 from apps.greencheck import models as gc_models
@@ -274,3 +279,19 @@ class TestNetworkFootprintForm:
         form_errors = multiform.errors["__all__"]
         assert len(form_errors) > 0
         assert "no_network_no_explanation" in [error.code for error in form_errors]
+
+
+def test_locations_formset_invalid_with_no_locations():
+    """
+    When we have no locations presented, our empty formset
+    should be invalid.
+    """
+    # given an empty payload:
+    empty_data = {
+        "form-TOTAL_FORMS": "0",
+        "form-INITIAL_FORMS": "0",
+    }
+
+    formset = LocationsFormSet(empty_data)
+    # then our form should be invalid
+    assert not formset.is_valid()

--- a/apps/accounts/tests/test_form.py
+++ b/apps/accounts/tests/test_form.py
@@ -148,6 +148,16 @@ def test_green_evidence_form_validation():
     assert not formset.is_valid()
 
 
+def test_green_evidence_formset_invalid_when_empty():
+    formset_data = {
+        # management form data
+        "form-TOTAL_FORMS": "0",
+        "form-INITIAL_FORMS": "0",
+    }
+    formset = GreenEvidenceForm(data=formset_data)
+    assert not formset.is_valid()
+
+
 @pytest.mark.parametrize(
     "form_data",
     [

--- a/apps/accounts/tests/test_form.py
+++ b/apps/accounts/tests/test_form.py
@@ -304,10 +304,9 @@ def test_locations_formset_invalid_with_no_locations():
     }
 
     formset = LocationsFormSet(empty_data)
-    valid = formset.is_valid()
 
     # then our form should be invalid
-    assert not valid
+    assert not formset.is_valid()
 
 
 def test_location_step_form_when_invalid_raises_errors():
@@ -325,13 +324,9 @@ def test_location_step_form_when_invalid_raises_errors():
 
     step_form = LocationStepForm(empty_data)
 
-    # when we try to validate it
-    valid = step_form.is_valid()
-
     # then our form should not show as valid
-    assert not valid
+    assert not step_form.is_valid()
 
     # and our error list should show tell us that we are missing the necessary
     # location sub-form submission
-    assert step_form.errors
-    assert "Please submit at least 1 location." in step_form.errors["locations"]
+    assert "Please submit at least 1 location." in step_form.non_field_errors()

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -50,7 +50,7 @@ def wizard_form_org_location_data():
     """
     return {
         "provider_registration_view-current_step": "1",
-        "locations__1-TOTAL_FORMS": "0",
+        "locations__1-TOTAL_FORMS": "1",
         "locations__1-INITIAL_FORMS": "0",
         "locations__1-0-country": faker.country_code(),
         "locations__1-0-city": faker.city(),


### PR DESCRIPTION
This PR introduces checks at the formset level, to avoid cases where someone is able to work through the wizard form without adding location data or supporting evidence.

Previously, if we didn't have this check, using the django formset factory API, a user could sail through without adding the necessary info.

If we _did_ have the check though, it turned out that the formset errors we not surfaced onto the page, so users would be stuck not understanding why the step could not progress.

This PR introduces logic to add our usual defaults, but also to change the `errors` method logic on our multiform(s), so we display the correct error for the template to render.

Finally, this PR tweaks the error message so it's easier to understand in the template (we change the word 'form' to 'location')

