### PR TITLE
Mark more fields as read-only in the ProviderRequest admin

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1171,7 +1171,13 @@ class ProviderRequest(ActionInChangeFormMixin, admin.ModelAdmin):
     formfield_overrides = {TaggableManager: {"widget": LabelWidget}}
     empty_value_display = "(empty)"
     list_filter = ("status",)
-    readonly_fields = ("authorised_by_org", "created_by")
+    readonly_fields = (
+        "authorised_by_org",
+        "created_by",
+        "status",
+        "location_import_required",
+        "missing_network_explanation",
+    )
     actions = [
         "mark_approved",
     ]


### PR DESCRIPTION
The fields: `status`, `location_import_required` and `missing_network_explanation` are now read-only in the admin panel of the `ProviderRequest`. 

The reason for this change is that those fields should not require any change from GWF staff, and additionally the ability to change the `status` field could be confused with executing the action to approve the request.