### PR TITLE
Add way to explicitly set the API_URL for swagger

### DIFF
--- a/.env.gitpod
+++ b/.env.gitpod
@@ -36,3 +36,6 @@ EQUINIX_REMOTE_API_ENDPOINT = "https://tgwf-web-app-live.s3.nl-ams.scw.cloud/dat
 
 AMAZON_PROVIDER_ID = 696
 AMAZON_REMOTE_API_ENDPOINT = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+
+# Uncomment this to set an explicit API URL for the api-docs page
+# API_URL = "https://domain.starting-with-https.com"

--- a/.github/workflows/run-deploy-staging.yml
+++ b/.github/workflows/run-deploy-staging.yml
@@ -67,3 +67,4 @@ jobs:
           MAXMIND_LICENCE_KEY: ${{ secrets.MAXMIND_LICENCE_KEY }}
           AWS_SHARED_CREDENTIALS_FILE: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
+          API_URL: ${{ secrets.API_URL }}

--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -64,3 +64,4 @@ jobs:
           MAXMIND_LICENCE_KEY: ${{ secrets.MAXMIND_LICENCE_KEY }}
           AWS_SHARED_CREDENTIALS_FILE: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
+          API_URL: ${{ secrets.API_URL }}

--- a/ansible/templates/dotenv.j2
+++ b/ansible/templates/dotenv.j2
@@ -33,3 +33,4 @@ MAXMIND_LICENCE_KEY = "{{ lookup('env', 'MAXMIND_LICENCE_KEY') }}"
 
 AWS_SHARED_CREDENTIALS_FILE = "{{ lookup('env', 'AWS_SHARED_CREDENTIALS_FILE') }}"
 AWS_CONFIG_FILE = "{{ lookup('env', 'AWS_CONFIG_FILE') }}"
+API_URL = "{{ lookup('env', 'API_URL') }}"

--- a/apps/greencheck/swagger.py
+++ b/apps/greencheck/swagger.py
@@ -33,7 +33,7 @@ schema_view = get_schema_view(
             "background": "#000000",
         },
     ),
-    url=settings.API_URL
+    url=settings.API_URL,
     public=False,
     permission_classes=(permissions.AllowAny,),
 )

--- a/apps/greencheck/swagger.py
+++ b/apps/greencheck/swagger.py
@@ -6,6 +6,8 @@ This module contains the code needed to adapt swagger to:
 3. Expose the necessary class based views for use in our url conf
 """
 
+from django.conf import settings
+
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view, SPEC_RENDERERS
 from drf_yasg.renderers import SwaggerUIRenderer
@@ -31,6 +33,7 @@ schema_view = get_schema_view(
             "background": "#000000",
         },
     ),
+    url=settings.API_URL
     public=False,
     permission_classes=(permissions.AllowAny,),
 )
@@ -57,7 +60,6 @@ class TGWFSwaggerView(schema_view):
 
     @classmethod
     def with_ui(cls, renderer="swagger", cache_timeout=0, cache_kwargs=None):
-
         renderer_classes = (TGWFSwaggerUIRenderer,) + _spec_renderers
         return cls.as_cached_view(
             cache_timeout, cache_kwargs, renderer_classes=renderer_classes

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -36,6 +36,7 @@ env = environ.Env(
     BASICAUTH_DISABLE=(bool, True),
     BASICAUTH_USER=(str, "staging_user"),
     BASICAUTH_PASSWORD=(str, "strong_password"),
+    API_URL=(str, os.getenv("API_URL")),
 )
 
 environ.Env.read_env(".env")  # Read .env
@@ -289,6 +290,10 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
 }
+
+# Set the API URL, to force HTTPS when using the /api-docs API test
+# https://drf-yasg.readthedocs.io/en/stable/openapi.html#custom-spec-base-url
+API_URL = env("API_URL")
 
 
 DRAMATIQ_BROKER = {


### PR DESCRIPTION
This PR adds a new API_URL environment variable, designed to fix an issue where making API requests at the /api-doc path stop working because they are defaulting to use HTTP, not HTTPS when constructing API requests in staging and production.