### PR TITLE
Add support for Via Header and DNS lookups in carbontxt preview

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -47,29 +47,15 @@ class CarbonTxtForm(forms.Form):
         if not submitted_text:
             try:
                 response = self.parser.parse_from_url(url)
-                # response = requests.get(url)
-                # if response.ok:
-                #     submitted_text = response.content
-                # else:
-                #     import ipdb
-
-                #     ipdb.set_trace()
-
-                #     raise forms.ValidationError(
-                #         "Unable to fetch content from url: %(url)s. HTTP response"
-                #         " code: %(response_code)s",
-                #         code="bad_http_lookup",
-                #         params={"url": url, "response_code": response.status_code},
-                #     )
                 self.cleaned_data["preview"] = response
+
+                # return early
                 return
             except Exception as ex:
-                import ipdb
-
-                ipdb.set_trace()
+                logger.exception(ex)
                 # flag up an error about the domain
                 raise forms.ValidationError(
-                    "Unable to fetch content from url: %(url)s",
+                    "Unable to fetch a valid carbon.txt from url: %(url)s",
                     code="bad_http_lookup",
                     params={"url": url},
                 )

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -46,17 +46,27 @@ class CarbonTxtForm(forms.Form):
 
         if not submitted_text:
             try:
-                response = requests.get(url)
-                if response.ok:
-                    submitted_text = response.content
-                else:
-                    raise forms.ValidationError(
-                        "Unable to fetch content from url: %(url)s. HTTP response"
-                        " code: %(response_code)s",
-                        code="bad_http_lookup",
-                        params={"url": url, "response_code": response.status_code},
-                    )
-            except requests.HTTPError:
+                response = self.parser.parse_from_url(url)
+                # response = requests.get(url)
+                # if response.ok:
+                #     submitted_text = response.content
+                # else:
+                #     import ipdb
+
+                #     ipdb.set_trace()
+
+                #     raise forms.ValidationError(
+                #         "Unable to fetch content from url: %(url)s. HTTP response"
+                #         " code: %(response_code)s",
+                #         code="bad_http_lookup",
+                #         params={"url": url, "response_code": response.status_code},
+                #     )
+                self.cleaned_data["preview"] = response
+                return
+            except Exception as ex:
+                import ipdb
+
+                ipdb.set_trace()
                 # flag up an error about the domain
                 raise forms.ValidationError(
                     "Unable to fetch content from url: %(url)s",

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -25,6 +25,12 @@
       display: inline-block;
       min-width: 10rem;
     }
+    pre {
+      background-color: #eee;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+      padding: 1rem;
+    }
   </style>
 
   <form action="{{ form_url }}" method="post" class="try_out">
@@ -53,24 +59,27 @@
 
     {% if preview %}
 
-      {{ preview }}
-
       {% if preview.lookup_sequence %}
 
-        <h3> From the initial location of the carbon.txt file, the following urls we tried in order:</h3>
+        <h3> From the initial location of the carbon.txt file, we tried following urls for the following reasons:</h3>
 
-        <ul>
+        <table>
+          <th>
+            Reason
+          </th>
+          <th>URL</th>
 
+          {% for lookup in preview.lookup_sequence %}
 
-          {% for url in preview.lookup_sequence %}
+            <tr>
 
-            <li>
-              <a href="{{ url }}">{{ url}}</a>
-            </li>
+              <td>{{ lookup.reason}} </td>
+              <td><a href="{{ lookup.url }}">{{ lookup.url}}</a></td>
+            </tr>
 
           {% endfor %}
 
-        </ul>
+        </table>
 
       {% endif %}
 
@@ -107,7 +116,7 @@
 
       {% if preview.not_registered.org %}
 
-        <h3>Sorry, we don't have an an organisation registered for the domain
+        <h3>We don't have an an organisation registered for the domain:
 
           {% for cred in preview.not_registered.org.credentials  %}
 
@@ -118,16 +127,16 @@
 
             {% endif %}
           {% endfor %}
-      {% endif %}
-      </h3>
 
-      <p>This is the information we do have in the carbon.txt file:</p>
+        </h3>
 
-      <pre><code>
+        <p>This is the information we do have in the carbon.txt file for that domain:</p>
+
+        <pre><code>
 {{ preview.not_registered.org.credentials }}
       </code></pre>
 
-
+      {% endif %}
 
       {% if preview.org %}
         <h2>Primary Organisation</h2>
@@ -142,7 +151,20 @@
 
       {% endif %}
 
+      {% if preview.original_string %}
 
+        <h3>Parsed carbontxt body content</h3>
+
+        <p>The raw code the carbontxt parser read in the end is below:</p>
+
+        <pre><code>
+{{ preview.original_string }}
+</code></pre>
+
+      {% endif %}
+
+
+      {% comment %} end if preview {% endcomment %}
     {% endif %}
 
 

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -2,32 +2,32 @@
 {% load i18n static %}
 
 {% block title %}
-    The Green Web Foundation Member portal: Carbon text preview
+  The Green Web Foundation Member portal: Carbon text preview
 {% endblock %}
 
 
 {% block pretitle %}
-<h1>Preview how your carbon.txt would be parsed</h1>
+  <h1>Preview how your carbon.txt would be parsed</h1>
 {% endblock %}
 
 {% block content %}
 
-<style>
+  <style>
     form div {
       margin-top:1rem;
       margin-bottom:1rem;
     }
     form input[type='url'],
     form textarea {
-        min-width:30rem;
+      min-width:30rem;
     }
     form div label {
       display: inline-block;
       min-width: 10rem;
     }
-</style>
+  </style>
 
-<form action="{{ form_url }}" method="post" class="try_out">
+  <form action="{{ form_url }}" method="post" class="try_out">
     {% csrf_token %}
 
     {{ form.non_field_errors }}
@@ -35,7 +35,7 @@
     {{ form.url.errors }}
     <div>
       <label for="{{ form.url.id_for_label }}">Url: </label>
-    {{ form.url }}
+      {{ form.url }}
     </div>
 
     <div>
@@ -44,64 +44,109 @@
     </div>
 
     <input type="submit" value="Submit"
-        style="margin-top: 0px; padding: 6px 15px">
-</form>
+      style="margin-top: 0px; padding: 6px 15px">
+  </form>
 
-<hr />
+  <hr />
 
-<section>
+  <section>
 
-{% if preview %}
+    {% if preview %}
 
-  {% if preview.upstream %}
-    <h2>Upstream providers</h2>
+      {{ preview }}
 
-    {% if preview.upstream %}
-      <p>
-        We were able to find the following upstream providers in the green web database
-      </p>
-    {% else %}
-      <p>
-        Sorry, we could not find any of the named upstream providers in the green web database.
-      </p>
-    {% endif %}
+      {% if preview.lookup_sequence %}
 
-    <ul>
-    {% for provider in preview.upstream %}
+        <h3> From the initial location of the carbon.txt file, the following urls we tried in order:</h3>
 
-      <li>
+        <ul>
+
+
+          {% for url in preview.lookup_sequence %}
+
+            <li>
+              <a href="{{ url }}">{{ url}}</a>
+            </li>
+
+          {% endfor %}
+
+        </ul>
+
+      {% endif %}
+
+
+      {% if preview.upstream %}
+        <h2>Upstream providers</h2>
+
+        {% if preview.upstream %}
+          <p>
+            We were able to find the following upstream providers in the green web database
+          </p>
+        {% else %}
+          <p>
+            Sorry, we could not find any of the named upstream providers in the green web database.
+          </p>
+        {% endif %}
+
+        <ul>
+          {% for provider in preview.upstream %}
+
+            <li>
+              <h3>
+                <a href="{{ provider.admin_url }}">
+                  {{ provider.name}}
+                </a>
+              </h3>
+
+              {% comment %} Add the supporting evidence here {% endcomment %}
+            </li>
+          {% endfor %}
+
+        </ul>
+      {% endif %}
+
+      {% if preview.not_registered.org %}
+
+        <h3>Sorry, we don't have an an organisation registered for the domain
+
+          {% for cred in preview.not_registered.org.credentials  %}
+
+
+            {% if forloop.first %}
+
+              <code>{{ cred.domain }}</code> yet
+
+            {% endif %}
+          {% endfor %}
+      {% endif %}
+      </h3>
+
+      <p>This is the information we do have in the carbon.txt file:</p>
+
+      <pre><code>
+{{ preview.not_registered.org.credentials }}
+      </code></pre>
+
+
+
+      {% if preview.org %}
+        <h2>Primary Organisation</h2>
+
+        <p>This is the organisation hosting the carbon.txt file being viewed and processed</p>
+
         <h3>
-          <a href="{{ provider.admin_url }}">
-            {{ provider.name}}
+          <a href="{{ preview.org.admin_url }}">
+            {{ preview.org }}
           </a>
         </h3>
 
-          {% comment %} Add the supporting evidence here {% endcomment %}
-      </li>
-      {% endfor %}
-
-    </ul>
-  {% endif %}
+      {% endif %}
 
 
-  {% if preview.org %}
-    <h2>Primary Organisation</h2>
-
-    <p>This is the organisation hosting the carbon.txt file being viewed and processed</p>
-
-    <h3>
-      <a href="{{ preview.org.admin_url }}">
-      {{ preview.org }}
-      </a>
-    </h3>
-
-{% endif %}
+    {% endif %}
 
 
-{% endif %}
-
-
-</section>
+  </section>
 
 
 {% endblock content %}

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -383,6 +383,7 @@ class CarbonTxtParser:
             parsed_txt = toml.loads(carbon_txt_string)
             parsed_carbon_txt = self.parse(url_domain, carbon_txt_string)
             parsed_carbon_txt["lookup_sequence"] = lookup_sequence
+            parsed_carbon_txt["original_string"] = carbon_txt_string
             return parsed_carbon_txt
         except toml.TomlDecodeError:
             logger.warning(f"Unable to parse carbon.txt file at {res.url}")
@@ -401,6 +402,7 @@ class CarbonTxtParser:
             carbon_txt_string = res.content.decode("utf-8")
             parsed_carbon_txt = self.parse(url_domain, carbon_txt_string)
             parsed_carbon_txt["lookup_sequence"] = lookup_sequence
+            parsed_carbon_txt["original_string"] = carbon_txt_string
             return parsed_carbon_txt
         except Exception as ex:
             logger.exception(ex)

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -331,8 +331,8 @@ class TestCarbonTxtParser:
         # and: the sequence of lookups is recorded for debugging / tracing purposes
         assert "lookup_sequence" in result.keys()
 
-        assert result["lookup_sequence"][0] == delegating_path
-        assert result["lookup_sequence"][1] == txt_record_path
+        assert result["lookup_sequence"][0]["url"] == delegating_path
+        assert result["lookup_sequence"][1]["url"] == txt_record_path
 
     def test_delegate_domain_lookup_with_http_via_header(
         self, db, hosting_provider_factory, green_domain_factory
@@ -367,8 +367,8 @@ class TestCarbonTxtParser:
         result["org"].name == carbon_txt_provider.name
 
         # and the lookup sequence should show the the order the lookups took place
-        assert result["lookup_sequence"][0] == hosted_domain
-        assert result["lookup_sequence"][1] == via_domain
+        assert result["lookup_sequence"][0]["url"] == hosted_domain
+        assert result["lookup_sequence"][1]["url"] == via_domain
 
     def test_mark_dns_text_override_green_with_domain_hash(
         self, db, hosting_provider_factory, green_domain_factory, minimal_carbon_txt_org
@@ -407,8 +407,8 @@ class TestCarbonTxtParser:
         result["org"].name == carbon_txt_provider.name
 
         # and the lookup sequence should show the the order the lookups took place
-        assert result["lookup_sequence"][0] == delegating_path
-        assert result["lookup_sequence"][1] == txt_record_path
+        assert result["lookup_sequence"][0]["url"] == delegating_path
+        assert result["lookup_sequence"][1]["url"] == txt_record_path
 
     def test_mark_http_via_override_green_with_domain_hash(
         self, db, hosting_provider_factory, green_domain_factory
@@ -446,8 +446,8 @@ class TestCarbonTxtParser:
         result["org"].name == carbon_txt_provider.name
 
         # and the lookup sequence should show the the order the lookups took place
-        assert result["lookup_sequence"][0] == hosted_domain
-        assert result["lookup_sequence"][1] == via_domain
+        assert result["lookup_sequence"][0]["url"] == hosted_domain
+        assert result["lookup_sequence"][1]["url"] == via_domain
 
     def test_check_with_domain_aliases(self, db, carbon_txt_string):
         """


### PR DESCRIPTION
This PR adds support for debugging carbontxt files.

When you add just an url, the parser preview now follows header `Via` information, as well as looking for DNS TXT records on a given domain.

This makes it possible to see where a chain of lookups will follow when testing your own carbon.txt file at a given url, as well as test which domains already ready return information for a given url.