### PR TITLE
Key our results in carbontxt previews by domain

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -20,6 +20,7 @@ from apps.greencheck.views import GreenUrlsView
 from ..greencheck import carbon_txt, domain_check
 from ..greencheck import models as gc_models
 
+
 checker = domain_check.GreenDomainChecker()
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,17 @@ class CarbonTxtForm(forms.Form):
             domain = parsed_url.netloc
 
             if parsed_toml:
-                self.cleaned_data["preview"] = self.parser.parse(domain, submitted_text)
+                try:
+                    self.cleaned_data["preview"] = self.parser.parse(
+                        domain, submitted_text
+                    )
+                except Exception as ex:
+                    logger.warning(f"{ex}")
+
+                    raise forms.ValidationError(
+                        f"The carbon.txt file contained valid TOML, but there was a problem performing lookups with the given info.",
+                        code="carbon_txt_lookup_error",
+                    )
 
 
 class CarbonTxtCheckView(LoginRequiredMixin, WaffleFlagMixin, FormView):

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -84,7 +84,7 @@
       {% endif %}
 
 
-      {{ preview }}
+      {% comment %} {{ preview }} {% endcomment %}
 
       {% if preview.upstream %}
         <h2>Upstream providers</h2>
@@ -163,13 +163,18 @@
       {% if preview.org %}
         <h2>Primary Organisation</h2>
 
-        <p>This is the organisation hosting the carbon.txt file being viewed and processed</p>
+        <p>The organisation hosting the carbon.txt file being viewed and processed</p>
 
-        <h3>
-          <a href="{{ preview.org.admin_url }}">
-            {{ preview.org }}
-          </a>
-        </h3>
+        <ul>
+          {% for domain, provider in preview.org.items %}
+            <li>
+              <h3>
+                {{ domain }} : <a href="{{ provider.admin_url }}">{{ provider }}</a>
+              </h3>
+            </li>
+          {% endfor %}
+
+        </ul>
 
       {% endif %}
 

--- a/apps/accounts/templates/carbon_txt_preview.html
+++ b/apps/accounts/templates/carbon_txt_preview.html
@@ -84,6 +84,8 @@
       {% endif %}
 
 
+      {{ preview }}
+
       {% if preview.upstream %}
         <h2>Upstream providers</h2>
 
@@ -98,10 +100,10 @@
         {% endif %}
 
         <ul>
-          {% for provider in preview.upstream %}
+          {% for domain, provider in preview.upstream.items %}
 
             <li>
-              <h3>
+              <h3>{{domain}} :
                 <a href="{{ provider.admin_url }}">
                   {{ provider.name}}
                 </a>
@@ -112,6 +114,26 @@
           {% endfor %}
 
         </ul>
+
+        {% if preview.not_registered.providers %}
+
+          <p>The following upstream providers are not currently registered in the green web database:</p>
+
+          <ul>
+            {% for domain, provider in preview.not_registered.providers.items %}
+
+              <li>
+                <h3>{{ domain }} : {{ provider }}</h3>
+
+                {% comment %} Add the supporting evidence here {% endcomment %}
+              </li>
+            {% endfor %}
+
+          </ul>
+
+        {% endif %}
+
+
       {% endif %}
 
       {% if preview.not_registered.org %}

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -111,7 +111,8 @@ class CarbonTxtParser:
         # this is checking the link, but not the type as well, as
         # not every piece of uploaded evidence has a type allocated
         for prov in provider_dicts:
-            if prov["url"] not in evidence_links:
+            provider_url = prov.get("url")
+            if provider_url not in evidence_links:
                 new_evidence.append(prov)
 
         return new_evidence
@@ -215,7 +216,7 @@ class CarbonTxtParser:
         parsed_txt = toml.loads(carbon_txt)
 
         unregistered_evidence = []
-        results = {"org": None, "upstream": [], "not_registered": {}}
+        results = {"org": None, "upstream": {}, "not_registered": {}}
 
         org = parsed_txt.get("org")
 
@@ -252,7 +253,7 @@ class CarbonTxtParser:
         upstream = parsed_txt.get("upstream")
         if upstream:
             upstream_providers = upstream.get("providers")
-            unregistered_providers = []
+            unregistered_providers = {}
 
             for provider in upstream_providers:
                 found_provider = self._fetch_provider(provider)
@@ -262,9 +263,25 @@ class CarbonTxtParser:
                     if new_evidence:
                         unregistered_evidence.extend(new_evidence)
 
-                    results["upstream"].append(found_provider)
+                    # import ipdb
+
+                    # ipdb.set_trace()
+                    import rich
+
+                    rich.print(provider)
+                    rich.print(found_provider)
+
+                    if isinstance(provider, str):
+                        results["upstream"][provider] = found_provider
+                    if isinstance(provider, dict):
+                        results["upstream"][provider["domain"]] = found_provider
+
                 else:
-                    unregistered_providers.append(provider)
+                    if isinstance(provider, str):
+                        unregistered_providers[provider] = provider
+
+                    if isinstance(provider, dict):
+                        unregistered_providers[provider["domain"]] = provider
 
             if unregistered_evidence:
                 results["not_registered"]["evidence"] = unregistered_evidence

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -409,6 +409,7 @@ class CarbonTxtParser:
         except toml.TomlDecodeError:
             logger.warning(f"Unable to parse carbon.txt file at {res.url}")
         except Exception as ex:
+            logger.warning(f"ex")
             logger.warning(
                 f"Unable to parse carbon.txt file at {res.url}. "
                 "We found valid TOML, but we could not parse the contents."

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -242,7 +242,11 @@ class CarbonTxtParser:
                 if new_org_evidence:
                     unregistered_evidence.extend(new_org_evidence)
 
-                results["org"] = org_provider
+                primary_domain = primary_creds.get("domain")
+                if primary_domain:
+                    results["org"] = {primary_domain: org_provider}
+                else:
+                    results["org"] = {domain: org_provider}
             # either list as known provider, or add to the list
             # of new entities we do not have in our system yet
 

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -263,14 +263,6 @@ class CarbonTxtParser:
                     if new_evidence:
                         unregistered_evidence.extend(new_evidence)
 
-                    # import ipdb
-
-                    # ipdb.set_trace()
-                    import rich
-
-                    rich.print(provider)
-                    rich.print(found_provider)
-
                     if isinstance(provider, str):
                         results["upstream"][provider] = found_provider
                     if isinstance(provider, dict):

--- a/apps/greencheck/serializers.py
+++ b/apps/greencheck/serializers.py
@@ -221,7 +221,7 @@ class CO2IntensitySerializer(serializers.ModelSerializer):
 
 
 class CarbonTxtSerializer(serializers.Serializer):
-    org = HostingProviderSerializer()
+    org = serializers.DictField(child=HostingProviderSerializer())
     upstream = serializers.DictField(child=HostingProviderSerializer())
     not_registered = serializers.DictField(required=False)
 

--- a/apps/greencheck/serializers.py
+++ b/apps/greencheck/serializers.py
@@ -222,7 +222,7 @@ class CO2IntensitySerializer(serializers.ModelSerializer):
 
 class CarbonTxtSerializer(serializers.Serializer):
     org = HostingProviderSerializer()
-    upstream = HostingProviderSerializer(many=True)
+    upstream = serializers.DictField(child=HostingProviderSerializer())
     not_registered = serializers.DictField(required=False)
 
 

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -145,12 +145,14 @@ class TestCarbonTxtParser:
 
         # is our cdn provider upstream?
         parsed_cdn = [
-            upstream for upstream in upstream_providers if upstream.name == "cdn.com"
+            upstream
+            for upstream in upstream_providers.values()
+            if upstream.name == "cdn.com"
         ][0]
         # is our hosting provider upstream?
         parsed_systen = [
             upstream
-            for upstream in upstream_providers
+            for upstream in upstream_providers.values()
             if upstream.name == "sys-ten.com"
         ][0]
 
@@ -204,7 +206,7 @@ class TestCarbonTxtParser:
         # is first member of providers in our 'not registered' list the
         # provider as listed in the carbon.txt file?
         assert len(unregistered_providers) == 1
-        parsed_sys_ten, *rest = unregistered_providers
+        parsed_sys_ten, *rest = unregistered_providers.values()
         assert parsed_sys_ten["domain"] == "sys-ten.com"
         assert (
             parsed_sys_ten["url"]
@@ -510,8 +512,8 @@ class TestCarbonTxtParser:
             url="www.hillbob.de"
         ).hosting_provider
 
-        assert sys_ten in parsed_result["upstream"]
-        assert cdn_com in parsed_result["upstream"]
+        assert sys_ten in parsed_result["upstream"].values()
+        assert cdn_com in parsed_result["upstream"].values()
         assert parsed_result["org"] == hillbob
 
 

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -134,8 +134,10 @@ class TestCarbonTxtParser:
         psr = carbon_txt.CarbonTxtParser()
         result = psr.parse("www.hillbob.de", carbon_txt_string)
 
-        org = result.get("org")
+        org, *_ = result.get("org").values()
+        org_domain, *_ = result.get("org").keys()
         assert org
+        assert org_domain == "www.hillbob.de"
         assert org.website == provider.website
         assert org.supporting_documents.first().url == sustainablity_page.url
 
@@ -328,7 +330,10 @@ class TestCarbonTxtParser:
 
         # then: the contents of the carbon.txt file at the domain and path specified
         # in the TXT record is used instead
-        assert result["org"].name == carbon_txt_provider.name
+        org, *_ = result["org"].values()
+        org_domain, *_ = result["org"].keys()
+        assert org.name == carbon_txt_provider.name
+        assert org_domain == "used-in-tests.carbontxt.org"
 
         # and: the sequence of lookups is recorded for debugging / tracing purposes
         assert "lookup_sequence" in result.keys()
@@ -366,7 +371,10 @@ class TestCarbonTxtParser:
 
         # Then: the result should show the contents of the carbon.txt file served by
         # the managed service, on behalf of the original domain
-        result["org"].name == carbon_txt_provider.name
+        org, *_ = result["org"].values()
+        org_domain, *_ = result["org"].keys()
+        assert org.name == carbon_txt_provider.name
+        assert org_domain == "managed-service.carbontxt.org"
 
         # and the lookup sequence should show the the order the lookups took place
         assert result["lookup_sequence"][0]["url"] == hosted_domain
@@ -406,7 +414,11 @@ class TestCarbonTxtParser:
 
         # and: we should see our provider in our results without needing to have
         # its domain added in any manual process
-        result["org"].name == carbon_txt_provider.name
+        org, *_ = result["org"].values()
+        org_domain, *_ = result["org"].keys()
+        assert org.name == carbon_txt_provider.name
+        # TODO - should this be the case?
+        assert org_domain == "used-in-tests.carbontxt.org"
 
         # and the lookup sequence should show the the order the lookups took place
         assert result["lookup_sequence"][0]["url"] == delegating_path
@@ -445,7 +457,10 @@ class TestCarbonTxtParser:
 
         # and: we should see our provider in our results without needing to have
         # its domain added in any manual process
-        result["org"].name == carbon_txt_provider.name
+        org, *_ = result["org"].values()
+        org_domain, *_ = result["org"].keys()
+        assert org.name == carbon_txt_provider.name
+        assert org_domain == "managed-service.carbontxt.org"
 
         # and the lookup sequence should show the the order the lookups took place
         assert result["lookup_sequence"][0]["url"] == hosted_domain
@@ -514,7 +529,8 @@ class TestCarbonTxtParser:
 
         assert sys_ten in parsed_result["upstream"].values()
         assert cdn_com in parsed_result["upstream"].values()
-        assert parsed_result["org"] == hillbob
+        org, *_ = parsed_result["org"].values()
+        assert org == hillbob
 
 
 class TestLogCarbonTxtCheck:


### PR DESCRIPTION
This changes the carbontxt preview to screen to show the results of each domain lookup keyed to the domain used. This makes it clearer what provider we found when doing a lookup