### PR TITLE
Do not allow registering a new account if email exists in db

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -23,7 +23,10 @@ from django_registration.backends.activation.views import (
     RegistrationView,
 )
 from django_registration.exceptions import ActivationError
-from django_registration.forms import RegistrationFormCaseInsensitive
+from django_registration.forms import (
+    RegistrationFormCaseInsensitive,
+    RegistrationFormUniqueEmail,
+)
 from formtools.wizard.views import SessionWizardView
 
 from .forms import (
@@ -69,7 +72,7 @@ class ProviderAutocompleteView(autocomplete.Select2QuerySetView):
         return qs
 
 
-class RegistrationForm(RegistrationFormCaseInsensitive):
+class RegistrationForm(RegistrationFormCaseInsensitive, RegistrationFormUniqueEmail):
     class Meta(RegistrationFormCaseInsensitive.Meta):
         model = User
 


### PR DESCRIPTION
This is using a built-in validation mechanism from the library `django_registration`: https://django-registration.readthedocs.io/en/3.3/forms.html#django_registration.forms.RegistrationFormUniqueEmail

Result:
![Screenshot 2023-04-21 at 14-19-31 The Green Web Foundation](https://user-images.githubusercontent.com/5598055/233635063-2b1b3711-44a2-4eb3-b01e-6be6e62b3832.png)
