### PR TITLE
Logo on provider portal links to the portal landing page

### DIFF
--- a/apps/accounts/templates/base.html
+++ b/apps/accounts/templates/base.html
@@ -18,7 +18,7 @@
 				{% block nav %}
 				<nav class="flex justify-between items-center bg-white py-6 md:justify-start md:space-x-10 ">
 					<div class="flex-grow">
-						<a href="{% url 'logout' %}">
+						<a href="{% url 'provider_request_list' %}">
 							<img width="200px" height="48px" src="{% static 'img/TGWF-logo.svg' %}" alt="The Green Web Foundation logo"/>
 						</a>
 					</div>

--- a/apps/accounts/templates/base.html
+++ b/apps/accounts/templates/base.html
@@ -18,7 +18,7 @@
 				{% block nav %}
 				<nav class="flex justify-between items-center bg-white py-6 md:justify-start md:space-x-10 ">
 					<div class="flex-grow">
-						<a href="/">
+						<a href="{% url 'logout' %}">
 							<img width="200px" height="48px" src="{% static 'img/TGWF-logo.svg' %}" alt="The Green Web Foundation logo"/>
 						</a>
 					</div>


### PR DESCRIPTION
Scope:
- move the `base.html` template to a new location (FYI @hanopcan, we discussed it briefly)
- change the hyperlink on the top-left logo to link to the provider portal landing page (`/requests`)