### PR TITLE
Hide the reference to directory evidence for now in email confirmations

### DIFF
--- a/apps/accounts/templates/emails/verification_request_approved.html
+++ b/apps/accounts/templates/emails/verification_request_approved.html
@@ -6,7 +6,7 @@
 
 <p>Any checks against sites hosted by you will now show as green on the basis of the ASN/IP ranges you provided.</p>
 
-<p>If you have publicly shared links to documents or websites to support any sustainability claims, these will also be available in the Green Web Directory: <a href="https://www.thegreenwebfoundation.org/directory/">https://www.thegreenwebfoundation.org/directory/</a>.</p>
+{% comment %} <p>If you have publicly shared links to documents or websites to support any sustainability claims, these will also be available in the Green Web Directory: <a href="https://www.thegreenwebfoundation.org/directory/">https://www.thegreenwebfoundation.org/directory/</a>.</p> {% endcomment %}
 
 <p>If there are any changes in your ASN or IP ranges for your green domains in the future, you are required to update your listing accordingly. Our Green Web Checker is only able to recognize the sustainably hosted domains of you and your customers when they resolve to an IP address that has been entered in the Green Web Database.</p>
 

--- a/apps/accounts/templates/emails/verification_request_approved.txt
+++ b/apps/accounts/templates/emails/verification_request_approved.txt
@@ -6,7 +6,7 @@ The information you provided has been checked and approved.
 
 Any checks against sites hosted by you will now show as green on the basis of the ASN/IP ranges you provided. 
 
-If you have publicly shared links to documents or websites to support any sustainability claims, these will also be available in the Green Web Directory: https://www.thegreenwebfoundation.org/directory/.
+{% comment %} If you have publicly shared links to documents or websites to support any sustainability claims, these will also be available in the Green Web Directory: https://www.thegreenwebfoundation.org/directory/. {% endcomment %}
 
 If there are any changes in your ASN or IP ranges for your green domains in the future, you are required to update your listing accordingly. Our Green Web Checker is only able to recognize the sustainably hosted domains of you and your customers when they resolve to an IP address that has been entered in the Green Web Database.
 


### PR DESCRIPTION
This PR comments out references to listing public evidence in our directory.

We intend to have this in the new directory, but in the directory profile views that display the evidence are coming later.

In the meantime, the old directory currently does not list supporting evidence that is uploaded , so it's best to not mention this until it's visible.