### PR TITLE
Verification request form: fixes after 1st round of user testing

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -271,7 +271,7 @@ class ServicesForm(forms.Form):
     services = forms.MultipleChoiceField(
         choices=ProviderRequest.get_service_choices,
         widget=forms.CheckboxSelectMultiple,
-        label="Which hosting services do you offer?",
+        label="Which services does your organisation offer?",
         help_text=mark_safe(
             'Choose all the services that your organisation offers. <a href="https://www.thegreenwebfoundation.org/directory/services-offered/" target="_blank" rel="noopener noreferrer">More information on our services</a>.'  # noqa
         ),

--- a/apps/accounts/templates/provider_registration/locations.html
+++ b/apps/accounts/templates/provider_registration/locations.html
@@ -33,9 +33,9 @@
 
 		<p>We collect this information to help people find hosting services by country or region.</p>
 
-		<p>Start by telling us the main headquaters of your organisation.</p>
+		<p>Start by telling us the main headquarters of your organisation.</p>
 		<p>Next, if you run services from specific data centres, tell us the country and city (or closest city) for each one.</p>
-		<p>Finally, if you sell services to other countries or regions that you haven't yet listed, please list them. For the city, you 
+		<p>Finally, if you sell services in other countries or regions that you haven't yet listed, please list them. For the city, you 
 			can give an office location if you have one, or the capital city if you don't. 
 			Please use the location name field to help your potential customers understand your relationship to the city.</p>
 

--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -1,10 +1,28 @@
 {% load preview_extras %}
+{% load countries %}
+
 <div class="bg-neutral-50 rounded-xl my-6 p-4">
 	{% for field in form %}
 	<div class="mb-4 last-of-type:mb-0">
 		<p class="font-bold m-0">{{ field.label }}</p>
-		{% if render_services %}
+		{% if field.label|lower == "which services does your organisation offer?" %}
+			{% comment %}
+				Expand services slugs to their full names (e.g. "paas" -> "Platform as a service")
+				using custom template tag
+			{% endcomment %}
 			<p class="m-0">{{ field.value|render_as_services|conditional_yesno:"Yes,No,-" }}</p>
+		{% elif field.label|lower == "country" %}
+			{% comment %}
+				Expand country code to country name (e.g. "DE" -> "Germany")
+				using template tag provided by django_countries: https://pypi.org/project/django-countries/#template-tags
+				with a fallback on original value if no country could be matched
+			{% endcomment %}
+			{% get_country field.value as country %}
+			{% if country.name %}
+				<p class="m-0">{{ country.name }}</p>
+			{% else %}
+				<p class="m-0">{{ field.value }}</p>
+			{% endif %}
 		{% else %}
 			<p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
 		{% endif %}

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -48,7 +48,7 @@
 
         <section class="my-10">
           <h3>Services provided by your organisation</h3>
-          {% include "provider_registration/partials/_preview.html" with form=preview_forms.2 render_services=True %}
+          {% include "provider_registration/partials/_preview.html" with form=preview_forms.2 %}
         </section>
 
         <section class="my-10">

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -90,6 +90,7 @@ INSTALLED_APPS = [
     "formtools",
     "convenient_formsets",
     "file_resubmit",
+    "django_countries",
     # UI
     "tailwind",
     "crispy_forms",


### PR DESCRIPTION
Scope:
- minor fixes to help text on the verification request form
- expanding country codes to names on the preview page, by utilizing `django_countries` template tag
- custom logic (expanding country codes to names, expanding service slugs to service list) on the preview page is now done based on the field label -> this will ensure that random user input on unrelated fields is not transformed