### PR TITLE
Catch API exception and serve helpful error response

### DIFF
--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from apps.accounts.models import Hostingprovider
+
 from django.views.decorators.cache import cache_page
 from django_countries import countries
 from rest_framework import response
@@ -10,9 +10,14 @@ from rest_framework.decorators import api_view, permission_classes, renderer_cla
 from rest_framework.permissions import AllowAny
 from rest_framework_jsonp.renderers import JSONPRenderer
 
+from ...accounts.models import Hostingprovider
 from ..domain_check import GreenDomainChecker
 from ..models import Greencheck, GreenDomain
 from ..serializers import GreenDomainSerializer
+
+# we import legacy_greencheck_image, to provide one module to import all
+# legacy API views from
+from .legacy_image_view import legacy_greencheck_image  # noqa
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +147,8 @@ def directory_provider(self, id):
         raise exceptions.NotAcceptable(
             (
                 "You need to send a valid numeric ID to identify the "
-                f"provider you are requesting information about. Received ID was: '{id}'"
+                "provider you are requesting information about. "
+                f"Received ID was: '{id}'"
             )
         )
 
@@ -163,7 +169,6 @@ def directory_provider(self, id):
         "energyprovider": None,
         "partner": provider.partner,
         "datacenters": datacenters,
-        "supporting_evidence": supporting_evidence,
     }
     return response.Response([provider_dict])
 

--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from apps.accounts.models import Hostingprovider, Datacenter
+from apps.accounts.models import Hostingprovider
 from django.views.decorators.cache import cache_page
 from django_countries import countries
 from rest_framework import response
@@ -12,8 +12,7 @@ from rest_framework_jsonp.renderers import JSONPRenderer
 
 from ..domain_check import GreenDomainChecker
 from ..models import Greencheck, GreenDomain
-from .legacy_image_view import legacy_greencheck_image
-from ..serializers import GreenDomainSerializer, HostingDocumentSerializer
+from ..serializers import GreenDomainSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -149,9 +148,6 @@ def directory_provider(self, id):
 
     provider = Hostingprovider.objects.get(pk=provider_id)
     datacenters = [dc.legacy_representation() for dc in provider.datacenter.all() if dc]
-    supporting_evidence = HostingDocumentSerializer(
-        provider.public_supporting_evidence(), many=True
-    ).data
 
     # basic case, no datacenters or certificates
     provider_dict = {

--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -144,7 +144,7 @@ def directory_provider(self, id):
         provider_id = int(id)
     except ValueError as ex:
         logger.warning(ex)
-        raise exceptions.NotAcceptable(
+        raise exceptions.ParseError(
             (
                 "You need to send a valid numeric ID to identify the "
                 "provider you are requesting information about. "

--- a/apps/greencheck/tests/test_legacy_directory.py
+++ b/apps/greencheck/tests/test_legacy_directory.py
@@ -270,7 +270,7 @@ class TestGreenWebDirectoryDetail:
         resp = client.get(url_path)
 
         # Then: I should receive a helpful API error response
-        assert resp.status_code == 406
+        assert resp.status_code == 400
 
         # And: with hints about how to fix my request
         error_detail = resp.data["detail"]

--- a/apps/greencheck/tests/test_legacy_directory.py
+++ b/apps/greencheck/tests/test_legacy_directory.py
@@ -276,6 +276,6 @@ class TestGreenWebDirectoryDetail:
         error_detail = resp.data["detail"]
         error_message = str(error_detail)
 
-        assert error_detail.code == "not_acceptable"
+        assert error_detail.code == "parse_error"
         assert "You need to send a valid numeric ID" in error_message
         assert "Received ID was: 'undefined'" in error_message


### PR DESCRIPTION
This PR is intended to solve issue  #459, where we were seeing a lot of invalid API requests causing 500 errors in Sentry.

This was triggered when people use the old directory to look up what information we have about a given provider, and it looks like someone starting hitting that API pretty hard - triggering hundreds of exceptions in the last few days, from the same client.

With this merged in, we instead serve a 406 response, making it clear to consumers how this endpoint is intended to be used.

https://github.com/thegreenwebfoundation/admin-portal/issues/459

This also tidies up the code with Ruff, removing unused variables and so on