### PR TITLE
Only display approved verification requests on the provider portal landing page

### DIFF
--- a/apps/accounts/tests/test_provider_portal.py
+++ b/apps/accounts/tests/test_provider_portal.py
@@ -1,0 +1,33 @@
+from ..views import ProviderPortalHomeView
+from ..models import ProviderRequestStatus
+from conftest import ProviderRequestFactory, ProviderRequestLocationFactory
+from django.test import RequestFactory
+from waffle.testutils import override_flag
+
+import pytest
+
+
+@pytest.mark.django_db
+@override_flag("provider_request", active=True)
+def test_provider_portal_home_view_returns_unapproved_requests(client):
+    # given: 1 pending provider request
+    pr1 = ProviderRequestFactory.create(status=ProviderRequestStatus.PENDING_REVIEW)
+    user = pr1.created_by
+
+    # given: 1 approved provider request
+    pr2 = ProviderRequestFactory.create(created_by=user)
+    # location needs to exist in order to approve a PR
+    loc = ProviderRequestLocationFactory(request=pr2)
+    hp = pr2.approve()
+
+    # when: ProviderPortalHomeView is accessed by the user
+    request = RequestFactory().get("/provider-portal/")
+    request.user = user
+    view = ProviderPortalHomeView()
+    view.request = request
+    qs = view.get_queryset()
+
+    # then: 1 unapproved request is rendered
+    assert qs["requests"].get() == pr1
+    # then: 1 hosting provider is rendered
+    assert qs["providers"].get() == hp

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -39,7 +39,7 @@ from .forms import (
     ConsentForm,
     PreviewForm,
 )
-from .models import User, ProviderRequest, Hostingprovider
+from .models import User, ProviderRequest, ProviderRequestStatus, Hostingprovider
 from .utils import send_email
 
 import logging
@@ -176,8 +176,15 @@ class ProviderPortalHomeView(LoginRequiredMixin, WaffleFlagMixin, ListView):
     model = ProviderRequest
 
     def get_queryset(self) -> "dict[str, QuerySet[ProviderRequest]]":
+        """
+        Returns a dictionary with 2 querysets:
+        - unapproved ProviderRequests created by the user,
+        - all HostingProviders assigned to the user
+        """
         return {
-            "requests": ProviderRequest.objects.filter(created_by=self.request.user),
+            "requests": ProviderRequest.objects.filter(
+                created_by=self.request.user
+            ).exclude(status=ProviderRequestStatus.APPROVED),
             # TODO: change this when a user can have multiple providers assigned
             "providers": Hostingprovider.objects.filter(
                 id__in=[self.request.user.hostingprovider_id]


### PR DESCRIPTION
Addresses feedback from https://trello.com/c/wpIzRRsg/165-edit-provider-portal-copy-to-make-the-difference-between-requests-and-providers-clearer.

Scope:
- exclude approved requests from rendering on the provider portal home page,
- add a test to verify the new logic