### PR TITLE
Replace 'how to get registered' -> 'how to get verified'

### DIFF
--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -52,7 +52,7 @@
             <p>To become verified, you need to submit a verification request that provides proof that you use green energy for your services. You can prove this if you are avoiding, reducing, or offsetting emissions.</p>
 			<p>Submitting the request will approximately take you 15 minutes and is free of charge.</p>
 			<p>Once submitted, we will review your request and get in touch if further evidence is needed. We are a non-profit organisation, so the verification process is independent.</p>
-			<p><a href="https://www.thegreenwebfoundation.org/what-you-need-to-register/" target="_blank" rel="noreferrer noopener">More information on how to register</a>.</p>
+			<p><a href="https://www.thegreenwebfoundation.org/what-you-need-to-get-verified/" target="_blank" rel="noreferrer noopener">More information on how to get verified</a>.</p>
           </section>
         </div>
       </article>


### PR DESCRIPTION
Fix a hyperlink name and URL on the provider portal page, addressing feedback from Justine.