### PR TITLE
Show correct services in verification request admin

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1181,7 +1181,7 @@ class ProviderRequest(ActionInChangeFormMixin, admin.ModelAdmin):
         ProviderRequestASNInline,
         ProviderRequestConsentInline,
     ]
-    formfield_overrides = {TaggableManager: {"widget": LabelWidget}}
+    formfield_overrides = {TaggableManager: {"widget": LabelWidget(model=Service)}}
     empty_value_display = "(empty)"
     list_filter = ("status",)
     readonly_fields = (


### PR DESCRIPTION
This PR introduces a change where we make sure we show the correct services model on the verification request admin screen.

Previously, we were defaulting to showing basic 'Tag' model instances, which we do not want, as we have a dedicated Service model now.