### PR TITLE
Add provider name to email submission

### DIFF
--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -386,7 +386,8 @@ def test_wizard_sends_email_on_submission(
     assert "support@thegreenwebfoundation.org" in eml.cc
 
     # then: and our email has the subject and copy we were expecting
-    assert eml.subject == "Your verification request for the Green Web Database"
+    assert "Your verification request for the Green Web Database" in eml.subject
+
     assert (
         "Thank you for taking the time to complete a verification request"
         in msg_body_txt
@@ -408,6 +409,7 @@ def test_wizard_sends_email_on_submission(
 
     link_to_verification_request = f"http://testserver{request_path}"
 
+    assert provider_name in eml.subject
     assert link_to_verification_request in msg_body_txt
     assert link_to_verification_request in msg_body_html
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -421,7 +421,7 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
             address=user.email,
             subject=(
                 f"Your verification request for the Green Web Database: "
-                f"{provider_request.name}"
+                f"{mark_safe(provider_request.name)}"
             ),
             context=ctx,
             template_html="emails/verification-request-notify.html",

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -416,9 +416,13 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
             "status": provider_request.status,
             "link_to_verification_request": link_to_verification_request,
         }
+
         send_email(
             address=user.email,
-            subject="Your verification request for the Green Web Database",
+            subject=(
+                f"Your verification request for the Green Web Database: "
+                f"{provider_request.name}"
+            ),
             context=ctx,
             template_html="emails/verification-request-notify.html",
             template_txt="emails/verification-request-notify.txt",


### PR DESCRIPTION
As requested in feedback when adding the the bcc to a mail-to-board listing in trello