### PR TITLE
Hs copy tweaks

### DIFF
--- a/apps/accounts/templates/base.html
+++ b/apps/accounts/templates/base.html
@@ -16,20 +16,25 @@
 			<div class="container mx-auto px-2 sm:px-4">
 			
 				{% block nav %}
-				<nav class="flex justify-between items-center bg-white py-6 md:justify-start md:space-x-10 ">
-					<div class="flex-grow">
-						<a href="{% url 'provider_portal_home' %}">
-							<img width="200px" height="48px" src="{% static 'img/TGWF-logo.svg' %}" alt="The Green Web Foundation logo"/>
-						</a>
+				<nav class="flex flex-wrap sm:flex-nowrap justify-between items-center bg-white mt-6 sm:mb-6 md:justify-start md:space-x-10 ">
+					<div class="w-full sm:w-auto sm:flex-grow flex flex-row">
+
+						<div class="logo">
+							<a href="{% url 'provider_portal_home' %}">
+								<img width="200px" height="48px" src="{% static 'img/TGWF-logo.svg' %}" alt="The Green Web Foundation logo"/>
+							</a>
+						</div>
+
+						<div class="subbrand border-l text-medium ml-8 pl-8 h-12 flex items-center">
+							<p class="font-bold">Provider<br/>Portal</p>
+						</div>
 					</div>
 
-					<div class="pl-10 display-block">
+					<div class="w-full sm:w-auto mt-4 sm:mt-0 pb-4 sm:pb-0 sm:pl-10 text-right">
 						{% if request.user.is_authenticated %}
-						<p>
-							Hello {{ request.user.username }}
-							|
-							<a href="{% url 'logout' %}">Log out</a>
-						</p>
+							<span>Hello {{ request.user.username }}</span>
+							<span role="img" aria-label="waving hand">👋</span>
+							<span class="pl-3"><a href="{% url 'logout' %}">Log out</a></span>
 						{% else %}
 							<a href="{% url 'login' %}">Log in</a>
 						{% endif %}

--- a/apps/accounts/templates/provider_portal/before_starting.html
+++ b/apps/accounts/templates/provider_portal/before_starting.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+
+{% load i18n static humanize widget_tweaks tailwind_filters waffle_tags %}
+
+{% block content %}
+
+  <article>
+    <div class="prose mx-auto mt-8">
+      	<h1 class="text-center">Before you start</h1>
+
+		<p>Completing the form will take you between <span class="font-bold">5 and 10 minutes</span> of time.</p>
+
+		<p>Regretfully, you are not able to save a partially completed form and come back it later - yet!</p>
+		
+		<p>Therefore, we recommend you gather the information required before beginning to fill in the form, 
+			and enter it in one uninterrupted session.</p>
+
+		<h3 class="font-bold text-xl uppercase">What information you need</h3>
+		<p class="mt-6">Here's a summary of the key data we ask you to supply via the form.<p>
+      	
+		<ul>
+			<li><span class="font-bold">Basic data</span> about your organisation such as name, main website URL and a paragraph description of what you do.
+			<li><span class="font-bold">Locations</span> for your office headquarters and if applicable the datacenters you own. For each we ask for the country and nearest city. We offer a .csv bulk import option<span class="font-bold">*</span> if you have several to add.</li>
+			<li>The <span class="font-bold">IP or ASN ranges</span> your organisation is responsible for. We offer a few options to automate this for large numbers or evolving records such as one-off .csv bulk import<span class="font-bold">*</span> or automated updating via api.</li>
+			<li><span class="font-bold">Evidence</span>, so we can verify your claims that your services run on green energy or your upstream supplier does. You can provide URLs or upload documents.</li> 
+		</ul>
+
+		<section class="prose border-2 border-neutral-500 rounded-xl my-6 md:mt-10 md:mb-0 p-6 bg-white">
+            <h3 class="text-med text-neutral-600 border-b-2 border-neutral-500">* A note about bulk importing</h3>
+            <p class="text-neutral-600">If you want to use the bulk import option for your locations or IP/ASN ranges, then you do not supply the .csv file as part of this verification form. We will arrange this with you after your verification form is submitted.</p>
+			<p class="text-neutral-600">The same applies to submitting IP/ASN ranges via api.</p> 
+		</section>
+
+		<h3 class="font-bold text-xl uppercase mt-12">Ready?</h3>
+		<a href="{% url 'provider_registration' %}" class="btn font-bold">Begin form</a>
+
+
+	</div>
+
+{% endblock %}

--- a/apps/accounts/templates/provider_portal/before_starting.html
+++ b/apps/accounts/templates/provider_portal/before_starting.html
@@ -32,6 +32,7 @@
 		</section>
 
 		<h3 class="font-bold text-xl uppercase mt-12">Ready?</h3>
+		<p>After submission of your request, you can expect to hear from us within a few days.</p>
 		<a href="{% url 'provider_registration' %}" class="btn font-bold">Begin form</a>
 
 

--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -21,6 +21,8 @@
 		{% endfor %}
 
 		{% endif %}
+
+		<p class="text-neutral-500 mt-8">Looking for the <a href="{% url 'greenweb_admin:index' %}" class="text-neutral-500">old style admin screens</a>?</p>
 		
 		<h3 class="text-xl pt-10">Your submitted verification requests</h3>
 
@@ -31,10 +33,6 @@
 		  <p>You haven't submitted any verification requests yet. <a href="{% url 'provider_registration' %}">Get started.</a>
 
 		{% endfor %}
-
-		<h3 class="text-xl pt-6">Previous admin interface</h3>
-
-		<p>Looking for the previous admin screens? <a href="{% url 'greenweb_admin:index' %}">Log into our old admin</a>.</p>
 
 
 	</div>

--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -11,7 +11,7 @@
 		<p>Do you want to become part of the Green Web Dataset as a verified green hosting provider? 
 		Do you want to keep your submitted information up-to-date? Get started here.</p>
 
-		<p class="mt-8"><a href="{% url 'provider_registration' %}" class="btn">Submit a new verification request</a></p>
+		<p class="mt-8"><a href="{% url 'before-starting' %}" class="btn">Submit a new verification request</a></p>
 		
 		{% if object_list.providers %}
 		<h3 class="text-xl pt-10">Your verified providers</h3>

--- a/apps/accounts/templates/provider_portal/request_detail.html
+++ b/apps/accounts/templates/provider_portal/request_detail.html
@@ -6,7 +6,7 @@
 
 <section class="prose mx-auto">
 
-`	<header class="">
+	<header class="">
 		<p class="mb-6 text-sm text-green"><a href="{% url 'provider_portal_home' %}" class="text-neutral-500">< Back to requests home</a></p>
 
 		<h1 class="text-6xl mb-0"><span class="uppercase">Summary of request</h1>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -22,7 +22,7 @@
 
       <div>
         <section class="my-10">
-            <h1>Your verification request</h1>
+            <h1>Final check of your data</h1>
 
           <div class="alert__warning">
             <p>Please check your data is correct before you submit your request.</p>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 from django.views.generic import RedirectView
+from django.views.generic.base import TemplateView
 
 from apps.accounts.admin_site import greenweb_admin as admin
 from apps.accounts.views import (
@@ -123,5 +124,10 @@ urlpatterns = [
         "provider-autocomplete/",
         ProviderAutocompleteView.as_view(),
         name="provider-autocomplete",
+    ),
+	path(
+        "before-starting/",
+        TemplateView.as_view(template_name="provider_portal/before_starting.html"),
+        name="before-starting",
     ),
 ]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -349,7 +349,8 @@ class ProviderRegistrationView(LoginRequiredMixin, WaffleFlagMixin, SessionWizar
             Thank you!
 
             Your verification request was submitted successfully.
-            We are now reviewing your request - we'll be in touch.
+            We have sent you an email with confirmation and a link that summarises your submitted info.
+            We are now reviewing your request - we'll be in touch soon.
             """,
         )
         return redirect(pr)


### PR DESCRIPTION
This addresses a few smallish requests as documented here: https://trello.com/c/jXbmbWuf/177-add-copy-tweaks-from-first-round-of-usability-observations

Specifically:

1. It adds the "provider portal" subbrand to the header
2. It inserts a new page between the provider home and start of verification form to set expectations about what info to prepare and what to expect
3. It retitles the preview page
4. It amends the success message displayed on final summary page
5. I have moved the link to the old admin interface to a more intuititive position on the page and removed the title.

For step 2 please code review carefully. I set up a new URL path and pointed it to a new html template. No idea if I have done this in the best way but it's highly likely I won't have (stack overflow was involved, eek!). I'd be grateful for some reassurance I haven't damaged other URLs that I don't know about thanks.
