### PR TITLE
Sort verification requests and hosting providers alphabetically by name on the Provider Portal home page

### DIFF
--- a/apps/accounts/tests/test_provider_portal.py
+++ b/apps/accounts/tests/test_provider_portal.py
@@ -60,3 +60,41 @@ def test_provider_portal_home_view_filters_out_removed_requests(client):
     # then: only the 1 pending verification request is displayed in the page
     assert pending_request in qs["requests"]
     assert removed_request not in qs["requests"]
+
+
+@pytest.mark.django_db
+@override_flag("provider_request", active=True)
+def test_provider_portal_home_view_items_sorted_by_name(client):
+    # given: 3 pending verification requests
+    pr1 = ProviderRequestFactory.create(status=ProviderRequestStatus.PENDING_REVIEW)
+    user = pr1.created_by
+    pr2 = ProviderRequestFactory.create(
+        status=ProviderRequestStatus.PENDING_REVIEW, created_by=user
+    )
+    pr3 = ProviderRequestFactory.create(
+        status=ProviderRequestStatus.PENDING_REVIEW, created_by=user
+    )
+
+    # given: 3 approved verification request
+    pr4 = ProviderRequestFactory.create(created_by=user)
+    pr5 = ProviderRequestFactory.create(created_by=user)
+    pr6 = ProviderRequestFactory.create(created_by=user)
+    # location needs to exist in order to approve a PR
+    ProviderRequestLocationFactory(request=pr4)
+    ProviderRequestLocationFactory(request=pr5)
+    ProviderRequestLocationFactory(request=pr6)
+    hp4 = pr4.approve()
+    hp5 = pr5.approve()
+    hp6 = pr6.approve()
+
+    # when: ProviderPortalHomeView is accessed by the user
+    request = RequestFactory().get(reverse("provider_portal_home"))
+    request.user = user
+    view = ProviderPortalHomeView()
+    view.request = request
+    qs = view.get_queryset()
+
+    # then: verification requests are sorted by name
+    assert list(qs["requests"]) == sorted(qs["requests"], key=lambda item: item.name)
+    # then: hosting providers are sorted by name
+    assert list(qs["providers"]) == sorted(qs["providers"], key=lambda item: item.name)

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -186,15 +186,17 @@ class ProviderPortalHomeView(LoginRequiredMixin, WaffleFlagMixin, ListView):
             only those where object-level permission between the user and the provider was explicitly granted.
         """
         return {
-            "requests": ProviderRequest.objects.filter(
-                created_by=self.request.user
-            ).exclude(
+            "requests": ProviderRequest.objects.filter(created_by=self.request.user)
+            .exclude(
                 status__in=[
                     ProviderRequestStatus.APPROVED,
                     ProviderRequestStatus.REMOVED,
                 ]
+            )
+            .order_by("name"),
+            "providers": self.request.user.hosting_providers_explicit_perms.order_by(
+                "name"
             ),
-            "providers": self.request.user.hosting_providers_explicit_perms,
         }
 
 


### PR DESCRIPTION
Note: this branch is based on `oz-object-level-permissions`. Rebase on `master` before merging!