### PR TITLE
Make the error message clear when users are accessing another user admin page

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,11 +1,9 @@
-from typing import Optional
 from django.db import models
 from django.core.mail import send_mail
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
 from django.contrib import messages
 from django.contrib import admin
-from django.http.request import HttpRequest
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.contrib.auth.admin import UserAdmin, GroupAdmin, Group

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -526,6 +526,16 @@ class TestUserAdmin:
         assert hosting_provider.name in user_admin.managed_providers(sample_hoster_user)
         assert datacenter.name in user_admin.managed_datacenters(sample_hoster_user)
 
+    def test_user_cannot_access_another_user_change_view(
+        self, db, sample_hoster_user, greenweb_staff_user
+    ):
+        user_admin = ac_admin.CustomUserAdmin(ac_models.User, admin_site.greenweb_admin)
+        request = MagicMock()
+        request.user = sample_hoster_user
+        response = user_admin.change_view(request, str(greenweb_staff_user.id))
+        assert response.status_code == 302
+        assert response.url == "/admin/"
+
 
 def test_provider_request_accessible_by_admin(
     db,

--- a/apps/accounts/tests/test_admin.py
+++ b/apps/accounts/tests/test_admin.py
@@ -527,14 +527,25 @@ class TestUserAdmin:
         assert datacenter.name in user_admin.managed_datacenters(sample_hoster_user)
 
     def test_user_cannot_access_another_user_change_view(
-        self, db, sample_hoster_user, greenweb_staff_user
+        self, db, client, sample_hoster_user, greenweb_staff_user
     ):
-        user_admin = ac_admin.CustomUserAdmin(ac_models.User, admin_site.greenweb_admin)
-        request = MagicMock()
-        request.user = sample_hoster_user
-        response = user_admin.change_view(request, str(greenweb_staff_user.id))
+        client.force_login(sample_hoster_user)
+        change_user_url = urls.reverse(
+            "greenweb_admin:accounts_user_change", args=[greenweb_staff_user.id]
+        )
+        response = client.get(change_user_url)
         assert response.status_code == 302
         assert response.url == "/admin/"
+
+    def test_staff_can_access_another_user_change_view(
+        self, db, client, sample_hoster_user, greenweb_staff_user
+    ):
+        client.force_login(greenweb_staff_user)
+        change_user_url = urls.reverse(
+            "greenweb_admin:accounts_user_change", args=[sample_hoster_user.id]
+        )
+        response = client.get(change_user_url)
+        assert response.status_code == 200
 
 
 def test_provider_request_accessible_by_admin(


### PR DESCRIPTION
As a regular user, when I go to a hosting provider change view in the admin panel, I can see other users who can manage that provider. If I click on one of the usernames that is not mine, I'm getting redirected to the main admin page and I see a message: "User with ID XXX doesn't exist. Perhaps it was deleted?". The default message is somewhat confusing and indicates that the user could have been deleted. This is because for non-admin users we filter the queryset to only include their own object - which makes Django deduct that the user with given ID does not exist.