### PR TITLE
Make the detail view of verification request always accessible for admins

### DIFF
--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -249,6 +249,21 @@ def test_detail_view_accessible_by_creator(client):
 
 @pytest.mark.django_db
 @override_flag("provider_request", active=True)
+def test_detail_view_accessible_by_admin(client, greenweb_staff_user):
+    # given: provider request exists
+    pr = ProviderRequestFactory.create()
+
+    # when: accessing its detail view by greenweb_staff_user
+    client.force_login(greenweb_staff_user)
+    response = client.get(urls.reverse("provider_request_detail", args=[str(pr.id)]))
+
+    # then: page for the correct provider request is rendered
+    assert response.status_code == 200
+    assert response.context_data["providerrequest"] == pr
+
+
+@pytest.mark.django_db
+@override_flag("provider_request", active=True)
 def test_detail_view_forbidden_for_others(client, user):
     # given: provider request exists
     pr = ProviderRequestFactory.create()

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -213,6 +213,12 @@ class ProviderRequestDetailView(LoginRequiredMixin, WaffleFlagMixin, DetailView)
     model = ProviderRequest
 
     def get_queryset(self) -> "QuerySet[ProviderRequest]":
+        """
+        Admins can retrieve any ProviderRequest object,
+        regular users can only retrieve objects that they created.
+        """
+        if self.request.user.is_admin:
+            return ProviderRequest.objects.all()
         return ProviderRequest.objects.filter(created_by=self.request.user)
 
 


### PR DESCRIPTION
The detail view of verification requests - the page that is rendered when accessing the URL we send in confirmation emails, e.g. https://admin.thegreenwebfoundation.org/requests/35/, was only accessible by users who originally submitted the request. This is caused the link to return 404 when accessed by admins. With these changes, admins are able to access the detail view of all verification requests.