### PR TITLE
Add regrouping of providers in directory

### DIFF
--- a/apps/greencheck/tests/test_directory.py
+++ b/apps/greencheck/tests/test_directory.py
@@ -1,4 +1,3 @@
-from django.test import RequestFactory
 from django.urls import reverse
 from waffle.testutils import override_flag
 
@@ -8,6 +7,9 @@ import pytest
 @pytest.mark.django_db
 @override_flag("directory_listing", active=True)
 def test_directory(client):
+    """
+    Confirm that the directory view is accessible when our flag is active
+    """
     # when: the directory is accessed with an active flag
     res = client.get(reverse("directory-index"))
 

--- a/apps/greencheck/tests/test_directory.py
+++ b/apps/greencheck/tests/test_directory.py
@@ -1,0 +1,36 @@
+from django.test import RequestFactory
+from django.urls import reverse
+from waffle.testutils import override_flag
+
+import pytest
+
+
+@pytest.mark.django_db
+@override_flag("directory_listing", active=True)
+def test_directory(client):
+    # when: the directory is accessed with an active flag
+    res = client.get(reverse("directory-index"))
+
+    # then: we see a successful response
+    assert res.status_code == 200
+
+
+@pytest.mark.django_db
+@override_flag("directory_listing", active=True)
+def test_ordering_of_providers_in_directory(client, hosting_provider_factory):
+    """
+    Check that providers are listed in order of the name of their
+    country, to allow for grouping by country in templates
+    """
+    german_provider = hosting_provider_factory.create(country="DE", showonwebsite=True)
+    danish_provider = hosting_provider_factory.create(country="DK", showonwebsite=True)
+
+    # when: the directory is accessed with an active flag
+    res = client.get(reverse("directory-index"))
+
+    # then: we see a successful response
+    assert res.status_code == 200
+
+    # and: the providers are listed in order of their country name
+    assert res.context["ordered_results"][0] == danish_provider
+    assert res.context["ordered_results"][1] == german_provider

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -273,6 +273,11 @@ class DirectoryView(WaffleFlagMixin, TemplateView):
             else:
                 return "Unknown"
 
+        # we include the filter in our context to allow the template to render
+        # the filter form, even if we display the results using `ordered_results`
+        # variable
+        ctx["filter"] = filter_results
+
         # filter by country, and then within each country, filter by alphabetical order
         ordered_results_qs = filter_results.qs.order_by("country", "name")
         # now filter the top level country results by written country name

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -4,65 +4,65 @@
 {% load widget_tweaks %}
 {% load tailwind_filters %}
 {% block content %}
-  <div class="full-width bg-neutral-900 relative -top-6 md:-top-8">
-    <section class="container mx-auto text-white px-2 sm:px-4 p-12">
-      <p class="uppercase text-green">Green Web Directory</p>
-      <h1 class="text-disp-sm mt-12 pb-4">I am looking for</h1>
-      <form method="get"
-        class="form__directory mt-4 grid grid-cols-1 md:grid-cols-3 grid-rows-3 md:grid-rows-1 gap-8">
-        {{ filter.form.as_p }}
-        <input type="submit" class="btn p-4 mt-4 mb-4" value="Find" />
-      </form>
-    </section>
-  </div>
-  <section class="main-content container mx-auto">
-    {% regroup ordered_results by country.name as country_list %}
-    {% for country in country_list %}
-      <article class="md:grid md:grid-cols-5 lg:grid-cols-7 md:grid-rows-1 pt-4 pb-8 md:pt-8 md:pb-14">
-        <h2 class="text-2xl mb-2 mt-0">{{ country.grouper }}</h2>
-        <div class="col-span-3 lg:col-span-5">
-          {% for obj in country.list %}
-            <div class="border-b-2 border-neutral-200 mb-4">
-              <h4 class="mb-4 font-bold text-xl" id="{{ obj.id }}">{{ obj.name }}</h4>
-              <p class="text-neutral-700 mb-8 max-w-prose">
-                {% if obj.description %}
-                  {{ obj.description }}
-                {% else %}
-                  <small>If we had a description it would go here. So we need some graceful fallback copy to replace this.</small>
-                {% endif %}
-                <ul class="mb-4">
-                  {% if obj.services.names %}
-                    {% for service in obj.services.all %}<li class="service-label inline-block">{{ service.name }}</li>{% endfor %}
-                    {% comment %}
+    <div class="full-width bg-neutral-900 relative -top-6 md:-top-8">
+        <section class="container mx-auto text-white px-2 sm:px-4 p-12">
+            <p class="uppercase text-green">Green Web Directory</p>
+            <h1 class="text-disp-sm mt-12 pb-4">I am looking for</h1>
+            <form method="get"
+                class="form__directory mt-4 grid grid-cols-1 md:grid-cols-3 grid-rows-3 md:grid-rows-1 gap-8">
+                {{ filter.form.as_p }}
+                <input type="submit" class="btn p-4 mt-4 mb-4" value="Find" />
+            </form>
+        </section>
+    </div>
+    <section class="main-content container mx-auto">
+        {% regroup ordered_results by country.name as country_list %}
+        {% for country in country_list %}
+            <article class="md:grid md:grid-cols-5 lg:grid-cols-7 md:grid-rows-1 pt-4 pb-8 md:pt-8 md:pb-14">
+                <h2 class="text-2xl mb-2 mt-0">{{ country.grouper }}</h2>
+                <div class="col-span-3 lg:col-span-5">
+                    {% for obj in country.list %}
+                        <div class="border-b-2 border-neutral-200 mb-4">
+                            <h4 class="mb-4 font-bold text-xl" id="{{ obj.id }}">{{ obj.name }}</h4>
+                            <p class="text-neutral-700 mb-8 max-w-prose">
+                                {% if obj.description %}
+                                    {{ obj.description }}
+                                {% else %}
+                                    <small>If we had a description it would go here. So we need some graceful fallback copy to replace this.</small>
+                                {% endif %}
+                                <ul class="mb-4">
+                                    {% if obj.services.names %}
+                                        {% for service in obj.services.all %}<li class="service-label inline-block">{{ service.name }}</li>{% endfor %}
+                                        {% comment %}
 										Every host in our directory used to at least offer shared hosting.
 										Below is a placeholder to see how it would look with live data.
 									{% else %}
-                                        <li class="service-label inline-block">Computed: Shared Hosting for Websites</li>
+										<li class="service-label inline-block">Compute: Shared Hosting for Websites</li>
                                         {% endcomment %}
-                  {% endif %}
-                </ul>
-              </p>
-              {% if obj.public_supporting_evidence %}
-                <details class="mb-4">
-                  <summary>
-                    <span class="">Published supporting evidence</span>
-                  </summary>
-                  <ul>
-                    {% for evidence in obj.public_supporting_evidence %}
-                      <li class="m-3">
-                        <a class="py-2"href="{{ evidence.link }}">{{ evidence.title }}</a>
-                        <div class="description py-2">
-                          <small>{{ evidence.description|linebreaks }}</small>
+                                    {% endif %}
+                                </ul>
+                            </p>
+                            {% if obj.public_supporting_evidence %}
+                                <details class="mb-4">
+                                    <summary>
+                                        <span class="">Published supporting evidence</span>
+                                    </summary>
+                                    <ul>
+                                        {% for evidence in obj.public_supporting_evidence %}
+                                            <li class="m-3">
+                                                <a class="py-2"href="{{ evidence.link }}">{{ evidence.title }}</a>
+                                                <div class="description py-2">
+                                                    <small>{{ evidence.description|linebreaks }}</small>
+                                                </div>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </details>
+                            {% endif %}
                         </div>
-                      </li>
                     {% endfor %}
-                  </ul>
-                </details>
-              {% endif %}
-            </div>
-          {% endfor %}
-        </div>
-      </article>
-    {% endfor %}
-  </section>
+                </div>
+            </article>
+        {% endfor %}
+    </section>
 {% endblock %}

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -28,11 +28,17 @@
                 {% if obj.description %}
                   {{ obj.description }}
                 {% else %}
-                  If we had a description it would go here. So we need some graceful fallback copy to replace this.
+                  <small>If we had a description it would go here. So we need some graceful fallback copy to replace this.</small>
                 {% endif %}
                 <ul class="mb-4">
                   {% if obj.services.names %}
                     {% for service in obj.services.all %}<li class="service-label inline-block">{{ service.name }}</li>{% endfor %}
+                    {% comment %}
+										Every host in our directory used to at least offer shared hosting.
+										Below is a placeholder to see how it would look with live data.
+									{% else %}
+                                        <li class="service-label inline-block">Computed: Shared Hosting for Websites</li>
+                                        {% endcomment %}
                   {% endif %}
                 </ul>
               </p>
@@ -45,7 +51,9 @@
                     {% for evidence in obj.public_supporting_evidence %}
                       <li class="m-3">
                         <a class="py-2"href="{{ evidence.link }}">{{ evidence.title }}</a>
-                        <div class="description py-2">{{ evidence.description|linebreaks }}</div>
+                        <div class="description py-2">
+                          <small>{{ evidence.description|linebreaks }}</small>
+                        </div>
                       </li>
                     {% endfor %}
                   </ul>


### PR DESCRIPTION
This PR introduces our list of providers grouped by country, as outlined in the Trello card below:

https://trello.com/c/zfA4swmo/183-directory-output-list-of-providers-by-country

It also introduces a couple of simple tests.

The first is a sanity check that requests sent to `/directory` work.

The second is a check that when we have our list of providers we are ordering them by country name. We use django's built in [#regroup](https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#regroup) template tag to reorder the providers in the template, because this makes it easier to understand what's going on when Han is working at the template layer, and because implementing out own regrouping logic seemed to replicate what django offers us already. 

The main consideration was that becuase we use a specific country model from django-countries, we can't rely on a ORM query to order our providers by country name using the database - this is why we use sorted, and our own sorting function.

WIthout this, Germany (DE) is placed ahead of Denmark (DK) in our grouping, leading to a confusing ordering of providers of results.

It's likely that we'll want to make further changes to the appearance in the directory, but given we have card 182 about showing the details about the providers in more detail, I figure it would be easier to address this one first, and then make a separata PR once we've made a few more decisions about what we show in the listings there.

https://trello.com/c/f8TkBAAE/182-directory-output-additional-details-on-list-of-providers