### PR TITLE
Add conditionals for showing directory results

### DIFF
--- a/apps/greencheck/tests/test_directory.py
+++ b/apps/greencheck/tests/test_directory.py
@@ -15,10 +15,6 @@ def test_directory(client):
 
     # then: we see a successful response
     assert res.status_code == 200
-    # and: we should see the "has directory results" template in our list of
-    # templates in use
-    templates = [tpl.name for tpl in res.templates]
-    assert "greencheck/partials/_directory_results.html" in templates
 
 
 @pytest.mark.django_db
@@ -44,6 +40,28 @@ def test_ordering_of_providers_in_directory(client, hosting_provider_factory):
 
 @pytest.mark.django_db
 @override_flag("directory_listing", active=True)
+def test_templates_in_filter_view(client, hosting_provider_factory):
+    """
+    Check that we include the no_directoru results in our template
+    """
+
+    # given: a hosting provider in Germany
+    hosting_provider_factory.create(country="DE", showonwebsite=True)
+
+    # when: we visit our directory
+    res = client.get(reverse("directory-index"))
+
+    # then: we should get a successful response
+    assert res.status_code == 200
+
+    # and: we should see the "has results" template in our list of templates
+    # in use
+    templates = [tpl.name for tpl in res.templates]
+    assert "greencheck/partials/_directory_results.html" in templates
+
+
+@pytest.mark.django_db
+@override_flag("directory_listing", active=True)
 def test_fallback_when_no_filter_view_has_no_results(client, hosting_provider_factory):
     """
     Check that we include the no_directoru results in our template
@@ -61,4 +79,4 @@ def test_fallback_when_no_filter_view_has_no_results(client, hosting_provider_fa
     # and: we should see the "no results" template in our list of templates
     # in use
     templates = [tpl.name for tpl in res.templates]
-    assert "greencheck/partials/no_directory_results.html" in templates
+    assert "greencheck/partials/_no_directory_results.html" in templates

--- a/apps/greencheck/tests/test_directory.py
+++ b/apps/greencheck/tests/test_directory.py
@@ -15,7 +15,8 @@ def test_directory(client):
 
     # then: we see a successful response
     assert res.status_code == 200
-    # and: we should see the no_results template in our list of templates
+    # and: we should see the "has directory results" template in our list of
+    # templates in use
     templates = [tpl.name for tpl in res.templates]
     assert "greencheck/partials/_directory_results.html" in templates
 
@@ -57,6 +58,7 @@ def test_fallback_when_no_filter_view_has_no_results(client, hosting_provider_fa
     # then: we should get a successful response
     assert res.status_code == 200
 
-    # and: we should see the no_results template in our list of templates
+    # and: we should see the "no results" template in our list of templates
+    # in use
     templates = [tpl.name for tpl in res.templates]
     assert "greencheck/partials/no_directory_results.html" in templates

--- a/apps/theme/templates/greencheck/directory_index.html
+++ b/apps/theme/templates/greencheck/directory_index.html
@@ -16,53 +16,10 @@
         </section>
     </div>
     <section class="main-content container mx-auto">
-        {% regroup ordered_results by country.name as country_list %}
-        {% for country in country_list %}
-            <article class="md:grid md:grid-cols-5 lg:grid-cols-7 md:grid-rows-1 pt-4 pb-8 md:pt-8 md:pb-14">
-                <h2 class="text-2xl mb-2 mt-0">{{ country.grouper }}</h2>
-                <div class="col-span-3 lg:col-span-5">
-                    {% for obj in country.list %}
-                        <div class="border-b-2 border-neutral-200 mb-4">
-                            <h4 class="mb-4 font-bold text-xl" id="{{ obj.id }}">{{ obj.name }}</h4>
-                            <p class="text-neutral-700 mb-8 max-w-prose">
-                                {% if obj.description %}
-                                    {{ obj.description }}
-                                {% else %}
-                                    <small>If we had a description it would go here. So we need some graceful fallback copy to replace this.</small>
-                                {% endif %}
-                                <ul class="mb-4">
-                                    {% if obj.services.names %}
-                                        {% for service in obj.services.all %}<li class="service-label inline-block">{{ service.name }}</li>{% endfor %}
-                                        {% comment %}
-										Every host in our directory used to at least offer shared hosting.
-										Below is a placeholder to see how it would look with live data.
-									{% else %}
-										<li class="service-label inline-block">Compute: Shared Hosting for Websites</li>
-                                        {% endcomment %}
-                                    {% endif %}
-                                </ul>
-                            </p>
-                            {% if obj.public_supporting_evidence %}
-                                <details class="mb-4">
-                                    <summary>
-                                        <span class="">Published supporting evidence</span>
-                                    </summary>
-                                    <ul>
-                                        {% for evidence in obj.public_supporting_evidence %}
-                                            <li class="m-3">
-                                                <a class="py-2"href="{{ evidence.link }}">{{ evidence.title }}</a>
-                                                <div class="description py-2">
-                                                    <small>{{ evidence.description|linebreaks }}</small>
-                                                </div>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                </details>
-                            {% endif %}
-                        </div>
-                    {% endfor %}
-                </div>
-            </article>
-        {% endfor %}
+        {% if not ordered_results %}
+            {% include "greencheck/partials/_no_directory_results.html" %}
+        {% else %}
+            {% include "greencheck/partials/_directory_results.html" %}
+        {% endif %}
     </section>
 {% endblock %}

--- a/apps/theme/templates/greencheck/partials/_directory_results.html
+++ b/apps/theme/templates/greencheck/partials/_directory_results.html
@@ -1,0 +1,48 @@
+{% regroup ordered_results by country.name as country_list %}
+{% for country in country_list %}
+    <article class="md:grid md:grid-cols-5 lg:grid-cols-7 md:grid-rows-1 pt-4 pb-8 md:pt-8 md:pb-14">
+        <h2 class="text-2xl mb-2 mt-0">{{ country.grouper }}</h2>
+        <div class="col-span-3 lg:col-span-5">
+            {% for obj in country.list %}
+                <div class="border-b-2 border-neutral-200 mb-4">
+                    <h4 class="mb-4 font-bold text-xl" id="{{ obj.id }}">{{ obj.name }}</h4>
+                    <p class="text-neutral-700 mb-8 max-w-prose">
+                        {% if obj.description %}
+                            {{ obj.description }}
+                        {% else %}
+                            <small>If we had a description it would go here. So we need some graceful fallback copy to replace this.</small>
+                        {% endif %}
+                        <ul class="mb-4">
+                            {% if obj.services.names %}
+                                {% for service in obj.services.all %}<li class="service-label inline-block">{{ service.name }}</li>{% endfor %}
+                                {% comment %}
+										Every host in our directory used to at least offer shared hosting.
+										Below is a placeholder to see how it would look with live data.
+									{% else %}
+										<li class="service-label inline-block">Compute: Shared Hosting for Websites</li>
+                                {% endcomment %}
+                            {% endif %}
+                        </ul>
+                    </p>
+                    {% if obj.public_supporting_evidence %}
+                        <details class="mb-4">
+                            <summary>
+                                <span class="">Published supporting evidence</span>
+                            </summary>
+                            <ul>
+                                {% for evidence in obj.public_supporting_evidence %}
+                                    <li class="m-3">
+                                        <a class="py-2"href="{{ evidence.link }}">{{ evidence.title }}</a>
+                                        <div class="description py-2">
+                                            <small>{{ evidence.description|linebreaks }}</small>
+                                        </div>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
+    </article>
+{% endfor %}

--- a/apps/theme/templates/greencheck/partials/_no_directory_results.html
+++ b/apps/theme/templates/greencheck/partials/_no_directory_results.html
@@ -1,0 +1,4 @@
+<article class="px-1">
+    <h1 class="text-4xl">Sorry, we couldn't find any results for this filtered view.</h1>
+    <p>Enter copy here to provide an alternative thing to do.</p>
+</article>


### PR DESCRIPTION
This PR introduces a conditional so we show two different templates, depending on whether we have results coming back from our combination of filters in play for the directory.

**Note:** we probably want to revisit where we put all the templates in future, as we currently have three separate folders for them. This is not an urgent priority though.