### PR TITLE
Update server deployment and process management scripts

### DIFF
--- a/ansible/_add_system_dependencies.yml
+++ b/ansible/_add_system_dependencies.yml
@@ -6,17 +6,18 @@
       - libmariadb-dev
       - libmariadbclient-dev
       - libmariadb3
-      - mariadb-client-10.3
-      - mariadb-client-core-10.3
+      - mariadb-client
+      # - mariadb-client-core
       - mariadb-common
-      - mariadb-server-10.3
-      - mariadb-server-core-10.3
+      # - mariadb-server-10.3
+      # - mariadb-server-core-10.3
       # - redis-server
       # - redis-tools
     state: present
     update_cache: true
   become: true
   when: install_system_reqs is true
+  tags: [wip]
 
 - name: Install nginx for reverse proxying and serving static files
   ansible.builtin.apt:

--- a/ansible/_set_up_process_mgmt.yml
+++ b/ansible/_set_up_process_mgmt.yml
@@ -1,0 +1,44 @@
+---
+# shared steps for provisioning boxes, deploying and controlling
+# how web workers and queue workers are scaled
+- name: Set up script for running workers and gunicorn, via supervisor in project
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: deploy
+    group: deploy
+    mode: "0755"
+  loop:
+    - {
+        src: "run_worker.sh.j2",
+        dest: "{{ project_root }}/current/run_worker.sh",
+      }
+    - {
+        src: "run_gunicorn.sh.j2",
+        dest: "{{ project_root }}/current/run_gunicorn.sh",
+      }
+  become: true
+  tags:
+    - supervisor
+    - config
+
+- name: Set up supervisor entries for workers and web
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: deploy
+    group: deploy
+    mode: "0755"
+  loop:
+    - {
+        src: "supervisor.gunicorn.conf.j2",
+        dest: "/etc/supervisor/conf.d/{{ supervisor_gunicorn_app }}.conf",
+      }
+    - {
+        src: "supervisor.worker.conf.j2",
+        dest: "/etc/supervisor/conf.d/{{ supervisor_worker_job }}.conf",
+      }
+  become: true
+  tags:
+    - supervisor
+    - config

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,10 +1,11 @@
 ---
 - name: Deploy the TGWF django admin
   hosts:
-    - app_servers
+    # - app_servers
     # - app1.thegreenwebfoundation.org
     # - app2.thegreenwebfoundation.org
     # - app3.thegreenwebfoundation.org
+    - app4.thegreenwebfoundation.org
     # - hel1.thegreenwebfoundation.org
   remote_user: "deploy"
   become: false

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -2,11 +2,11 @@
 - name: Deploy the TGWF django admin
   hosts:
     # - app_servers
-    # - app1.thegreenwebfoundation.org
-    # - app2.thegreenwebfoundation.org
-    # - app3.thegreenwebfoundation.org
+    - app1.thegreenwebfoundation.org
+    - app2.thegreenwebfoundation.org
+    - app3.thegreenwebfoundation.org
     - app4.thegreenwebfoundation.org
-    # - hel1.thegreenwebfoundation.org
+
   remote_user: "deploy"
   become: false
 
@@ -53,43 +53,8 @@
       ansible.builtin.include_tasks: "_assemble_deploy_assets.yml"
       when: compile_assets is true
 
-    - name: Set up script for running workers and gunicorn, via supervisor
-      ansible.builtin.template:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: deploy
-        group: deploy
-        mode: "0755"
-      loop:
-        - {
-            src: "run_worker.sh.j2",
-            dest: "{{ project_root }}/current/run_worker.sh",
-          }
-        - {
-            src: "run_gunicorn.sh.j2",
-            dest: "{{ project_root }}/current/run_gunicorn.sh",
-          }
-      become: true
-      tags:
-        - supervisor
-
-    - name: Set up supervisor entries for workers and web
-      ansible.builtin.template:
-        src: "{{ item.src }}"
-        dest: "{{ item.dest }}"
-        owner: deploy
-        group: deploy
-        mode: "0755"
-      loop:
-        - {
-            src: "supervisor.gunicorn.conf.j2",
-            dest: "/etc/supervisor/conf.d/{{ tgwf_domain_name }}_web.conf",
-          }
-        - {
-            src: "supervisor.worker.conf.j2",
-            dest: "/etc/supervisor/conf.d/{{ tgwf_domain_name }}_worker.conf",
-          }
-      become: true
+    - name: Set up process management with supervisor
+      ansible.builtin.include_tasks: "_set_up_process_mgmt.yml"
       tags:
         - supervisor
 
@@ -99,6 +64,8 @@
         state: restarted
       become: true
       when: supervisor_restart is true
+      tags:
+        - supervisor
 
     - name: Reload nginx
       ansible.builtin.service:

--- a/ansible/inventories/prod.yml
+++ b/ansible/inventories/prod.yml
@@ -9,22 +9,26 @@ all:
       internal_ip: "10.0.0.4"
       dramatiq_threads: 2
       dramatiq_processes: 3
+    # TODO: once we have update the worker process names we can use app3 for serving production traffic
+    # letting us decommission some of the older app servers
+    app3.thegreenwebfoundation.org:
+      internal_ip: "10.0.0.6"
+      dramatiq_threads: 1
+      dramatiq_processes: 1
     app4.thegreenwebfoundation.org:
       internal_ip: "10.0.0.7"
       dramatiq_threads: 2
       dramatiq_processes: 3
 
-    hel1.thegreenwebfoundation.org:
-      internal_ip: "10.0.0.3"
-
   vars:
+    tgwf_stage: "prod"
+    tgwf_domain_name: "admin"
     project_root: "/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org"
     project_deploy_branch: "master"
-    tgwf_stage: "prod"
-    tgwf_domain_name: admin
-    ansible_user: deploy
-    supervisor_gunicorn_app: "admin_web"
-    supervisor_worker_job: "admin_worker"
+    ansible_user: "deploy"
+    supervisor_user: "deploy"
+    supervisor_gunicorn_app: "web_{{ tgwf_stage }}"
+    supervisor_worker_job: "worker_{{ tgwf_stage }}"
 
   # you can set child groups too
   children:
@@ -34,6 +38,7 @@ all:
       hosts:
         app1.thegreenwebfoundation.org:
         app2.thegreenwebfoundation.org:
+        app3.thegreenwebfoundation.org:
         app4.thegreenwebfoundation.org:
       # within the child group can define new vars which take
       # precedence over the ones further 'upstream'

--- a/ansible/inventories/prod.yml
+++ b/ansible/inventories/prod.yml
@@ -9,6 +9,11 @@ all:
       internal_ip: "10.0.0.4"
       dramatiq_threads: 2
       dramatiq_processes: 3
+    app4.thegreenwebfoundation.org:
+      internal_ip: "10.0.0.7"
+      dramatiq_threads: 2
+      dramatiq_processes: 3
+
     hel1.thegreenwebfoundation.org:
       internal_ip: "10.0.0.3"
 
@@ -29,6 +34,7 @@ all:
       hosts:
         app1.thegreenwebfoundation.org:
         app2.thegreenwebfoundation.org:
+        app4.thegreenwebfoundation.org:
       # within the child group can define new vars which take
       # precedence over the ones further 'upstream'
       # vars:

--- a/ansible/inventories/staging.yml
+++ b/ansible/inventories/staging.yml
@@ -7,13 +7,13 @@ all:
       dramatiq_processes: 1
 
   vars:
-    project_root: "/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org"
-    project_deploy_branch: "staging"
     tgwf_stage: "staging"
     tgwf_domain_name: "admin-staging"
+    project_root: "/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org"
+    project_deploy_branch: "staging"
     ansible_user: "deploy"
-    supervisor_gunicorn_app: "web-staging"
-    supervisor_worker_job: "worker-staging"
+    supervisor_gunicorn_app: "web_{{ tgwf_stage }}"
+    supervisor_worker_job: "worker_{{ tgwf_stage }}"
 
   # you can set child groups too
   children:

--- a/ansible/inventories/staging.yml
+++ b/ansible/inventories/staging.yml
@@ -12,8 +12,8 @@ all:
     tgwf_stage: "staging"
     tgwf_domain_name: "admin-staging"
     ansible_user: "deploy"
-    supervisor_gunicorn_app: "admin_web"
-    supervisor_worker_job: "admin_worker"
+    supervisor_gunicorn_app: "web-staging"
+    supervisor_worker_job: "worker-staging"
 
   # you can set child groups too
   children:

--- a/ansible/provision_app.yml
+++ b/ansible/provision_app.yml
@@ -2,7 +2,11 @@
 - name: Provision the TGWF django web-app server
   hosts:
     # - app_servers
-    - app4.thegreenwebfoundation.org
+    # - app1.thegreenwebfoundation.org
+    # - app2.thegreenwebfoundation.org
+    # - app3.thegreenwebfoundation.org
+    # - app4.thegreenwebfoundation.org
+
   remote_user: "deploy"
   become: false
 

--- a/ansible/provision_app.yml
+++ b/ansible/provision_app.yml
@@ -1,7 +1,8 @@
 ---
 - name: Provision the TGWF django web-app server
   hosts:
-    - app_servers
+    # - app_servers
+    - app4.thegreenwebfoundation.org
   remote_user: "deploy"
   become: false
 
@@ -22,7 +23,6 @@
     setup_nginx: false
 
   tasks:
-
     - name: Set up most recent timestamps directories
       ansible.builtin.include_tasks: "_create_deployment_directories.yml"
       when: create_deployment_dirs is true

--- a/ansible/scale_processes.yml
+++ b/ansible/scale_processes.yml
@@ -1,0 +1,28 @@
+---
+- name: Control how many processes we are running without redeploying the TGWF django apps
+  hosts:
+    # - app1.thegreenwebfoundation.org
+    # - app2.thegreenwebfoundation.org
+    - app3.thegreenwebfoundation.org
+    - app4.thegreenwebfoundation.org
+  remote_user: "deploy"
+  become: false
+
+  vars:
+    # see vars in the inventory yaml files
+    # use one of: started, restarted, stopped
+    preferred_state: started
+
+  tasks:
+    - name: Set up process management with supervisor
+      ansible.builtin.include_tasks: "_set_up_process_mgmt.yml"
+      tags:
+        - supervisor
+
+    - name: Update django apps using supervisor
+      ansible.builtin.supervisorctl:
+        name: "{{ supervisor_gunicorn_app }}:"
+        state: "{{ preferred_state }}"
+      become: true
+      tags:
+        - supervisor

--- a/ansible/templates/supervisor.gunicorn.conf.j2
+++ b/ansible/templates/supervisor.gunicorn.conf.j2
@@ -4,7 +4,7 @@
 [supervisord]
 environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
 
-[program:admin_web]
+[program:{{ supervisor_gunicorn_app }}]
 directory=/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org/current/
 numprocs=1
 command=bash ./run_gunicorn.sh

--- a/ansible/templates/supervisor.worker.conf.j2
+++ b/ansible/templates/supervisor.worker.conf.j2
@@ -1,10 +1,8 @@
 # {{ ansible_managed }}
 # Last run: {{ template_run_date }}
-
 [supervisord]
 environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
-
-[program:admin_worker]
+[program:{{ supervisor_worker_job }}]
 directory=/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org/current/
 command=bash ./run_worker.sh
 process_name=%(process_num)02d


### PR DESCRIPTION
This PR updates our deploy scripts to reflect the use of the new app servers, along with a refactor to allow for updating how many gunicorn or dramatiq processes are working on each server without going through the full deploy process