### PR TITLE
Add support for sentry tracing

### DIFF
--- a/ansible/_set_up_directories.yml
+++ b/ansible/_set_up_directories.yml
@@ -8,6 +8,16 @@
     group: deploy
   become: true
 
+- name: Move .env file to shared directory
+  ansible.builtin.template:
+    src: "templates/dotenv.j2"
+    dest: "{{ project_root }}/shared/.env"
+    mode: "0755"
+    owner: deploy
+    group: deploy
+  become: true
+  when: update_dotenv is true
+
 - name: Link .env to shared directory
   ansible.builtin.file:
     src: "{{ project_root }}/shared/.env"

--- a/ansible/_set_up_directories.yml
+++ b/ansible/_set_up_directories.yml
@@ -16,7 +16,6 @@
     owner: deploy
     group: deploy
   become: true
-  when: update_dotenv is true
 
 - name: Link .env to shared directory
   ansible.builtin.file:

--- a/ansible/_set_up_directories.yml
+++ b/ansible/_set_up_directories.yml
@@ -8,15 +8,6 @@
     group: deploy
   become: true
 
-- name: Move .env file to shared directory
-  ansible.builtin.template:
-    src: "templates/dotenv.j2"
-    dest: "{{ project_root }}/shared/.env"
-    mode: "0755"
-    owner: deploy
-    group: deploy
-  become: true
-
 - name: Link .env to shared directory
   ansible.builtin.file:
     src: "{{ project_root }}/shared/.env"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -29,6 +29,9 @@
     # is a workaround
     update_front_end_deps: true
 
+    # create new dotenv file in shared directory (use when adding new env vars)
+    update_dotenv: true
+
     supervisor_restart: true
     supervisor_user: "deploy"
 

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -56,6 +56,17 @@
       ansible.builtin.include_tasks: "_assemble_deploy_assets.yml"
       when: compile_assets is true
 
+    - name: Template .env file to shared directory
+      ansible.builtin.template:
+        src: "templates/dotenv.j2"
+        dest: "{{ project_root }}/shared/.env"
+        mode: "0755"
+        owner: deploy
+        group: deploy
+      become: true
+      when: update_dotenv is true
+      tags: [dotenv]
+
     - name: Set up process management with supervisor
       ansible.builtin.include_tasks: "_set_up_process_mgmt.yml"
       tags:

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -30,7 +30,7 @@
     update_front_end_deps: true
 
     # create new dotenv file in shared directory (use when adding new env vars)
-    update_dotenv: true
+    update_dotenv: false
 
     supervisor_restart: true
     supervisor_user: "deploy"

--- a/ansible/inventories/prod.yml
+++ b/ansible/inventories/prod.yml
@@ -29,6 +29,7 @@ all:
     supervisor_user: "deploy"
     supervisor_gunicorn_app: "web_{{ tgwf_stage }}"
     supervisor_worker_job: "worker_{{ tgwf_stage }}"
+    port: 9000
 
   # you can set child groups too
   children:

--- a/ansible/inventories/prod.yml
+++ b/ansible/inventories/prod.yml
@@ -5,24 +5,24 @@ all:
       internal_ip: "10.0.0.5"
       dramatiq_threads: 2
       dramatiq_processes: 3
-      sentry_trace_rate: 0
+      sentry_sample_rate: 0
     app2.thegreenwebfoundation.org:
       internal_ip: "10.0.0.4"
       dramatiq_threads: 2
       dramatiq_processes: 3
-      sentry_trace_rate: 0
+      sentry_sample_rate: 0
     # TODO: once we have update the worker process names we can use app3 for serving production traffic
     # letting us decommission some of the older app servers
     app3.thegreenwebfoundation.org:
       internal_ip: "10.0.0.6"
       dramatiq_threads: 1
       dramatiq_processes: 1
-      sentry_trace_rate: 1
+      sentry_sample_rate: 1
     app4.thegreenwebfoundation.org:
       internal_ip: "10.0.0.7"
       dramatiq_threads: 2
       dramatiq_processes: 3
-      sentry_trace_rate: 0
+      sentry_sample_rate: 0
 
   vars:
     tgwf_stage: "prod"
@@ -33,7 +33,7 @@ all:
     supervisor_user: "deploy"
     supervisor_gunicorn_app: "web_{{ tgwf_stage }}"
     supervisor_worker_job: "worker_{{ tgwf_stage }}"
-    port: 9000
+    gunicorn_port: 9000
 
   # you can set child groups too
   children:

--- a/ansible/inventories/prod.yml
+++ b/ansible/inventories/prod.yml
@@ -5,20 +5,24 @@ all:
       internal_ip: "10.0.0.5"
       dramatiq_threads: 2
       dramatiq_processes: 3
+      sentry_trace_rate: 0
     app2.thegreenwebfoundation.org:
       internal_ip: "10.0.0.4"
       dramatiq_threads: 2
       dramatiq_processes: 3
+      sentry_trace_rate: 0
     # TODO: once we have update the worker process names we can use app3 for serving production traffic
     # letting us decommission some of the older app servers
     app3.thegreenwebfoundation.org:
       internal_ip: "10.0.0.6"
       dramatiq_threads: 1
       dramatiq_processes: 1
+      sentry_trace_rate: 1
     app4.thegreenwebfoundation.org:
       internal_ip: "10.0.0.7"
       dramatiq_threads: 2
       dramatiq_processes: 3
+      sentry_trace_rate: 0
 
   vars:
     tgwf_stage: "prod"

--- a/ansible/inventories/staging.yml
+++ b/ansible/inventories/staging.yml
@@ -3,9 +3,10 @@ all:
   hosts:
     app3.thegreenwebfoundation.org:
       internal_ip: "10.0.0.6"
+      gunicorn_port: 10000
       dramatiq_threads: 1
       dramatiq_processes: 1
-
+      sentry_trace_rate: 1
   vars:
     tgwf_stage: "staging"
     tgwf_domain_name: "admin-staging"

--- a/ansible/templates/dotenv.j2
+++ b/ansible/templates/dotenv.j2
@@ -13,7 +13,7 @@ RABBITMQ_URL="{{ lookup('env', "RABBITMQ_URL") }}"
 
 SENTRY_DSN="{{ lookup('env', "SENTRY_DSN") }}"
 SENTRY_ENVIRONMENT="{{ lookup('env', "SENTRY_ENVIRONMENT") }}"
-{% if sentry_sample_rate %}
+{% if sentry_sample_rate is defined %}
 SENTRY_SAMPLE_RATE = {{ sentry_sample_rate }}
 {% endif %}
 

--- a/ansible/templates/dotenv.j2
+++ b/ansible/templates/dotenv.j2
@@ -9,8 +9,13 @@ EXPLORER_TOKEN="{{ lookup('env','EXPLORER_TOKEN') }}"
 SECRET_KEY="{{ lookup('env','SECRET_KEY') }}"
 DJANGO_SETTINGS_MODULE="{{ lookup('env','DJANGO_SETTINGS_MODULE') }}"
 RABBITMQ_URL="{{ lookup('env', "RABBITMQ_URL") }}"
+
+
 SENTRY_DSN="{{ lookup('env', "SENTRY_DSN") }}"
 SENTRY_ENVIRONMENT="{{ lookup('env', "SENTRY_ENVIRONMENT") }}"
+{% if sentry_sample_rate %}
+SENTRY_SAMPLE_RATE = {{ sentry_sample_rate }}
+{% endif %}
 
 DOMAIN_SNAPSHOT_BUCKET = "{{ lookup('env', 'DOMAIN_SNAPSHOT_BUCKET') }}"
 OBJECT_STORAGE_ENDPOINT = "{{ lookup('env', 'OBJECT_STORAGE_ENDPOINT') }}"

--- a/ansible/templates/run_gunicorn.sh.j2
+++ b/ansible/templates/run_gunicorn.sh.j2
@@ -1,4 +1,4 @@
 # supervisor can only control processes it started itself.
 # So we need to use exec to replace the parent shell script process
 # that starts pipenv
-exec python -m pipenv run gunicorn greenweb.wsgi -b {{ internal_ip }}:$PORT -t 300 -c gunicorn.conf.py --statsd-host=10.0.0.2:9125 --statsd-prefix=member.app
+exec python -m pipenv run gunicorn greenweb.wsgi -b {{ internal_ip }}:{{ gunicorn_port }} -t 300 -c gunicorn.conf.py --statsd-host=10.0.0.2:9125 --statsd-prefix=member.app

--- a/ansible/templates/supervisor.gunicorn.conf.j2
+++ b/ansible/templates/supervisor.gunicorn.conf.j2
@@ -1,19 +1,15 @@
 # {{ ansible_managed }}
 # Last run: {{ template_run_date }}
-
 [supervisord]
 environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
-
 [program:{{ supervisor_gunicorn_app }}]
 directory=/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org/current/
 numprocs=1
 command=bash ./run_gunicorn.sh
 process_name=%(process_num)02d
-environment=PORT=90%(process_num)02d
 autostart=true
 autorestart=true
 stopsignal=QUIT
 user={{ supervisor_user }}
-
 stdout_logfile=%(program_name)s_%(process_num)02d_.log
 stderr_logfile=%(program_name)s_%(process_num)02d_.error.log

--- a/greenweb/settings/production.py
+++ b/greenweb/settings/production.py
@@ -54,7 +54,7 @@ if sentry_dsn:
         # set our identifying credentials
         dsn=sentry_dsn,
         # Set traces_sample_rate.
-        traces_sample_rate=sentry_sample_rate,
+        traces_sample_rate=float(sentry_sample_rate),
         # activate the django specific integrations for sentry
         integrations=[DjangoIntegration()],
         # We assume that is a user is logged in, we want to be able


### PR DESCRIPTION
This PR allows us to set Sentry's tracing on our apps on a per machine basis, so we can get an idea of where performance bottlenecks lie. 

Previously we had api.TGWF and admin.TGWF running on the same server, but since expanding to more machines, this allows us to serve admin.TGWF (which receives like.. 1000x less traffic) with sentry tracing on the app3 server, where we could run the tracing without blowing through our quota, and api.TGWF on the other machines, where we do not.

This also supports sampling on the API servers, but because admin.TGWF still gets some API traffic, this is currently assumed to be less of a priority.

