### PR TITLE
Update github actions to use newer runners

### DIFF
--- a/.github/workflows/run-deploy-staging.yml
+++ b/.github/workflows/run-deploy-staging.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use turnstyle to serialise deploys
         uses: softprops/turnstyle@v1

--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use turnstyle to serialise deploys
         uses: softprops/turnstyle@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,10 +40,10 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Set up a cache-key for installations of dependencies, in .venv
         id: cache-pipenv
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./.venv
           key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}


### PR DESCRIPTION
This updates the underlying test runners we use, so we are no longer using an end of life version of node in them.