### PR TITLE
Add support for updating hosting providers when not all forms change in wizard

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -25,6 +25,21 @@ from django.utils.safestring import mark_safe
 
 User = get_user_model()
 
+class AlwaysChangedModelFormMixin:
+    """
+    A mixin for ModelForms that makes sure that a form with this Mixin
+    is always marked as changed in checks like `has_changed()`.
+    Used in form wizards containing formsets, to return true for all forms 
+    in a formset, so that all data is saved at the end of the wizard.
+    """
+
+    def has_changed(self):
+        """
+        Always returns True, so that the form is always marked as changed.
+        """
+        return True
+
+
 
 class CustomUserCreationForm(forms.ModelForm):
     """
@@ -281,7 +296,7 @@ class ServicesForm(forms.ModelForm):
         fields = ["services"]
 
 
-class CredentialForm(forms.ModelForm):
+class CredentialForm(AlwaysChangedModelFormMixin, forms.ModelForm):
     class Meta:
         model = ac_models.ProviderRequestEvidence
         exclude = ["request"]
@@ -419,7 +434,7 @@ class GreenEvidenceForm(
         return ErrorList(error.replace(original_msg, target_msg) for error in errors)
 
 
-class IpRangeForm(forms.ModelForm):
+class IpRangeForm(AlwaysChangedModelFormMixin, forms.ModelForm):
     start = forms.GenericIPAddressField()
     end = forms.GenericIPAddressField()
 
@@ -428,7 +443,7 @@ class IpRangeForm(forms.ModelForm):
         exclude = ["request"]
 
 
-class AsnForm(forms.ModelForm):
+class AsnForm(AlwaysChangedModelFormMixin, forms.ModelForm):
     class Meta:
         model = ac_models.ProviderRequestASN
         exclude = ["request"]
@@ -554,7 +569,7 @@ class NetworkFootprintForm(BetterMultiModelForm):
 
         return self.cleaned_data
 
-
+    
 class ConsentForm(forms.ModelForm):
     """
     Part of multi-step registration form (screen 5).

--- a/apps/accounts/models/provider_request.py
+++ b/apps/accounts/models/provider_request.py
@@ -334,6 +334,7 @@ class ProviderRequestIPRange(models.Model):
         if self.start and self.end:
             validate_ip_range(self.start, self.end)
 
+    
 
 class ProviderRequestEvidence(models.Model):
     """

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -30,7 +30,7 @@ from apps.greencheck.factories import (
 from apps.accounts.factories import SupportingEvidenceFactory
 
 from django.conf import settings
-
+import rich
 faker = Faker()
 
 
@@ -1316,3 +1316,280 @@ def test_editing_hp_creates_new_verification_request(
     updated_pr = models.ProviderRequest.objects.get(id=pr_id)
     assert updated_pr.name == overridden_values["name"]
     assert updated_pr.providerrequestlocation_set.count() == 3
+
+
+@pytest.mark.django_db
+@pytest.mark.only
+@override_flag("provider_request", active=True)
+def test_saving_changes_to_hp_with_new_verification_request(
+    client,
+    hosting_provider_with_sample_user,
+    sorted_ips,
+    wizard_form_org_details_data,
+    wizard_form_services_data,
+    wizard_form_evidence_data,
+    wizard_form_network_data,
+    wizard_form_consent,
+    wizard_form_preview,
+):
+    """
+    Support the case where we are making changes to save back to
+    the provider
+    """
+
+
+    # given: URL of the edit view of the existing HP
+    hp = hosting_provider_with_sample_user
+    ev1 = SupportingEvidenceFactory.create(hostingprovider=hp)
+    ev2 = SupportingEvidenceFactory.create(hostingprovider=hp)
+    ip1 = GreenIpFactory.create(
+        ip_start=sorted_ips[0], ip_end=sorted_ips[1], hostingprovider=hp
+    )
+    ip2 = GreenIpFactory.create(
+        ip_start=sorted_ips[1], ip_end=sorted_ips[2], hostingprovider=hp
+    )
+    ip3 = GreenIpFactory.create(
+        ip_start=sorted_ips[2], ip_end=sorted_ips[3], hostingprovider=hp
+    )
+    asn = GreenASNFactory.create(hostingprovider=hp)
+
+    edit_url = urls.reverse("provider_edit", args=[str(hp.id)])
+
+    # when: accessing the edit view by its creator
+    client.force_login(hp.created_by)
+    response = client.get(edit_url)
+
+    # then: ORG_DETAILS form is bound with an instance, initial data is displayed
+    org_details_form = response.context_data["form"]
+    assert org_details_form.initial == {
+        "name": hp.name,
+        "website": hp.website,
+        "description": hp.description,
+    }
+    # when: submitting ORG_DETAILS form with overridden data
+
+    response = client.post(edit_url, wizard_form_org_details_data, follow=True)
+
+    # then: wizard proceeds, LOCATIONS formset is displayed with initial data
+    locations_formset = response.context_data["form"].forms["locations"]
+    assert locations_formset.forms[0].initial == {
+        "city": hp.city,
+        "country": hp.country,
+    }
+
+    # when: submitting LOCATIONS form with overridden data
+    # data to override locations: delete existing location, add 3 new ones
+    wizard_form_org_location_data = {
+        "provider_request_wizard_view-current_step": "1",
+        "locations__1-TOTAL_FORMS": "4",
+        "locations__1-INITIAL_FORMS": "1",
+        "locations__1-0-country": hp.country.code,
+        "locations__1-0-city": "Berlin",
+        "locations__1-0-id": "",
+        "locations__1-0-DELETE": "on",
+        "locations__1-1-country": faker.country_code(),
+        "locations__1-1-city": faker.city(),
+        "locations__1-2-country": faker.country_code(),
+        "locations__1-2-city": faker.city(),
+        "locations__1-3-country": faker.country_code(),
+        "locations__1-3-city": faker.city(),
+        "extra__1-location_import_required": "True",
+    }
+    response = client.post(edit_url, wizard_form_org_location_data, follow=True)
+    # then: wizard proceeds, SERVICES form is displayed with initial data
+    services_form = response.context_data["form"]
+    assert services_form.initial == {"services": []}
+    # when: submitting SERVICES form with overridden data
+    response = client.post(edit_url, wizard_form_services_data, follow=True)
+
+    # then: wizards proceeds, EVIDENCE formset is displayed with initial data
+    evidence_formset = response.context_data["form"]
+    # we strip expected initial data from "file" key for comparison purposes
+    # because {'file': <FieldFile: None>} != {'file': <FieldFile: None>}
+    ev1_initial = {
+        "title": ev1.title,
+        "description": ev1.description,
+        "link": ev1.link,
+        "type": ev1.type,
+        "public": ev1.public,
+    }
+    ev2_initial = {
+        "title": ev2.title,
+        "description": ev2.description,
+        "link": ev2.link,
+        "type": ev2.type,
+        "public": ev2.public,
+    }
+
+    assert ev1_initial.items() <= evidence_formset.forms[0].initial.items()
+    assert ev2_initial.items() <= evidence_formset.forms[1].initial.items()
+
+    # when: submitting EVIDENCE step with overridden data
+    response = client.post(edit_url, wizard_form_evidence_data, follow=True)
+
+    # then: wizard proceeds, NETWORK form is displayed
+    # and child forms/formsets have initial data assigned
+    network_form = response.context_data["form"]
+    ip_formset = network_form.forms["ips"]
+    # GOTCHA: ModelFormSets created with initial data will store that
+    # in initial_extra
+    assert ip_formset.initial_extra == [
+        {"start": ip1.ip_start, "end": ip1.ip_end},
+        {"start": ip2.ip_start, "end": ip2.ip_end},
+        {"start": ip3.ip_start, "end": ip3.ip_end},
+    ]
+
+    asn_formset = network_form.forms["asns"]
+    assert asn_formset.initial_extra == [{"asn": asn.asn}]
+
+    extra_network_form = network_form.forms["extra"]
+    assert extra_network_form.initial == {}
+
+    # when: submitting NETWORK step with overridden data
+
+    # 
+    unchanged_network_data = {
+        "provider_request_wizard_view-current_step": "4",
+        "ips__4-TOTAL_FORMS": "3",
+        "ips__4-INITIAL_FORMS": "0",
+        "ips__4-0-start": ip1.ip_start,
+        "ips__4-0-end": ip1.ip_end,
+        "ips__4-1-start": ip2.ip_start,
+        "ips__4-1-end": ip2.ip_end,
+        "ips__4-2-start": ip3.ip_start,
+        "ips__4-2-end": ip3.ip_end,
+        "asns__4-TOTAL_FORMS": "1",
+        "asns__4-INITIAL_FORMS": "0",
+        "asns__4-0-asn": asn.asn,
+
+    }
+
+    response = client.post(edit_url, unchanged_network_data, follow=True)
+
+    # then: wizard proceeds, CONSENT step is displayed with correct instance/initial data assigned
+    consent_form = response.context_data["form"]
+    # breakpoint()
+    assert consent_form.initial == {}
+
+    # when: submitting CONSENT step with overridden data
+    response = client.post(edit_url, wizard_form_consent, follow=True)
+
+    # then: PREVIEW step is rendered with correct data
+    preview_form_dict = response.context_data["preview_forms"]
+
+    # org_detail preview displays overridden data
+    overridden_values = {
+        "name": wizard_form_org_details_data["0-name"],
+        "description": wizard_form_org_details_data["0-description"],
+        "website": wizard_form_org_details_data["0-website"],
+    }
+    assert overridden_values.items() <= preview_form_dict["0"].initial.items()
+
+    # locations preview displays overridden data
+    location_forms = preview_form_dict["1"].forms["locations"].forms
+    # 4 forms in total are passed, 3 of them not marked as deleted
+    assert len(location_forms) == 4
+    assert len([form for form in location_forms if not form["DELETE"].value()]) == 3
+
+    # when: PREVIEW form is submitted
+    response = client.post(edit_url, wizard_form_preview, follow=True)
+
+    # then: a ProviderRequest object is updated in the db
+    pr_id = response.context_data["providerrequest"].id
+    updated_pr = models.ProviderRequest.objects.get(id=pr_id)
+    assert updated_pr.name == overridden_values["name"]
+    assert updated_pr.providerrequestlocation_set.count() == 3
+
+
+    # fetch the values of the ips, asns and evidence
+    # to check against later
+    
+    prev_green_ip_vals = hp.greencheckip_set.all().values()
+    
+    rich.print("prev_green_ip_vals")
+    rich.inspect(prev_green_ip_vals)
+    assert len(prev_green_ip_vals) == 3
+
+    prev_green_asn_vals = hp.greencheckip_set.all().values()
+
+    prev_supporting_docs_vals = hp.greencheckip_set.all().values()
+    prev_service_vals = hp.services.all().values()
+
+    vf_locations = updated_pr.providerrequestlocation_set.all()
+    vf_greencheck_ip_vals = updated_pr.providerrequestiprange_set.all().values()
+
+    # I am expecting the VF network formset to be empty
+    
+    # breakpoint()
+    
+    rich.print("approving request")
+
+    # but
+    assert len(prev_green_ip_vals) == 3
+    assert len(prev_green_ip_vals) == len(vf_greencheck_ip_vals)
+    
+
+    updated_provider = updated_pr.approve()
+
+    rich.print("prev_green_ip_vals")
+    rich.inspect(prev_green_ip_vals)
+    assert len(prev_green_ip_vals) == 3
+
+
+    
+
+    # check that the values
+    provider_attributes = [key for key in hp.__dict__.keys() if not key.startswith('_')]
+    hp.refresh_from_db()
+
+    rich.print("prev_green_ip_vals")
+    rich.inspect(prev_green_ip_vals)
+    assert len(prev_green_ip_vals) == 3
+
+
+    for attr in provider_attributes:
+        assert getattr(updated_provider, attr) == getattr(hp, attr)
+
+    # given fewer IPs we should see this in the saved provider
+    
+    new_green_ip_vals = hp.greencheckip_set.all().values()
+    
+    rich.print("vf_greencheck_ip_vals")
+    rich.inspect(vf_greencheck_ip_vals)
+
+    rich.print("new_green_ip_vals")
+    rich.inspect(new_green_ip_vals)
+
+    # these should be the same now
+    assert len(prev_green_ip_vals) == len(new_green_ip_vals)
+    
+    # but
+    assert len(prev_green_ip_vals) == 3
+    assert len(prev_green_ip_vals) == len(vf_greencheck_ip_vals)
+    
+
+    for green_ip in prev_green_ip_vals:
+        assert green_ip in new_green_ip_vals
+
+    # breakpoint()
+    pass
+
+
+def test_other_hosting_provider_with_no_city_creates_location(self):
+    """
+    hosting provider with just a country should show the city and country
+    """
+    pass
+
+def test_request_from_hosting_provider_with_loads_of_IP_ranges(self):
+    """
+    hosting provider has loads of IP ranges more than is reasonable
+    to add manually. we dont' want them to appear as NONE on the preview
+    """
+    pass
+
+def test_request_from_host_provider_finishes_in_sensible_time(self):
+    """
+    hosting provider with just a country should show the city and country
+    """
+    pass

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -1783,21 +1783,23 @@ def test_saving_changes_to_hp_with_new_verification_request(client,
     assert pr_first_location.country == updated_hp.country
     assert pr_first_location.city == updated_hp.city
     
-
-def test_other_hosting_provider_with_no_city_creates_location(self):
+@pytest.mark.skip(reason="pending")
+def test_other_hosting_provider_with_no_city_creates_location():
     """
     hosting provider with just a country should show the city and country
     """
     pass
 
-def test_request_from_hosting_provider_with_loads_of_IP_ranges(self):
+@pytest.mark.skip(reason="pending")
+def test_request_from_hosting_provider_with_loads_of_IP_ranges():
     """
     hosting provider has loads of IP ranges more than is reasonable
     to add manually. we dont' want them to appear as NONE on the preview
     """
     pass
 
-def test_request_from_host_provider_finishes_in_sensible_time(self):
+@pytest.mark.skip(reason="pending")
+def test_request_from_host_provider_finishes_in_sensible_time():
     """
     hosting provider with just a country should show the city and country
     """

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -1751,15 +1751,20 @@ def test_saving_changes_to_hp_with_new_verification_request(client,
     for green_as in updated_pr_green_asns:
         assert green_as.asn in [asn.asn for asn in updated_pr_green_asns]
 
-    # and: one piece of evidence from the original provider
+    
     updated_pr_evidence_set = updated_pr.providerrequestevidence_set.all()
     updated_hp_evidence_set = updated_hp.supporting_documents.all()
-
-    # TODO figure out why this test is failing
-    # for ev in updated_hp_evidence_set:
-    #     assert ev.title in [pr_ev.title for pr_ev in updated_pr_evidence_set]
-    #     assert ev.link in [pr_ev.link for pr_ev in updated_pr_evidence_set]
     
+    # and: we have same evidence on the provider as was on the 
+    # verification request
+    for ev in updated_hp_evidence_set:
+        assert ev.title in [pr_ev.title for pr_ev in updated_pr_evidence_set]
+        if not ev.url:
+            pr_file_urls = [pr_ev.file.url for pr_ev in updated_pr_evidence_set if pr_ev.file]
+            assert ev.attachment.url in pr_file_urls
+    
+    # and: one piece of evidence from the original provider remains
+
     # and: ev2, the old piece of evidence is no longer in the updated provider
     assert ev2.title not in [pr_ev.title for pr_ev in updated_pr_evidence_set]
     assert ev2.link not in [pr_ev.link for pr_ev in updated_pr_evidence_set]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -363,7 +363,14 @@ class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWiza
                 instance.request = request
                 instance.save()
             for object_to_delete in formset.deleted_objects:
+                logger.info(f"we have {len(formset.deleted_objects)} objects to delete")
                 object_to_delete.delete()
+            logger.info(f"checking for changed forms: {formset.form}")
+            if formset.changed_objects:
+                logger.info(f"we have {len(formset.changed_objects)} objects to change")
+                pass
+
+            
 
         steps = ProviderRequestWizardView.Steps
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -356,21 +356,25 @@ class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWiza
             """
             Helper function to process the data from ModelFormSets used in this view
             """
-            # TODO: check ModelFormSets weird behavior:
-            # formset.save() with initial data submitted as unchanged returns None
+            logger.info(f"formset: {formset.__class__.__name__}")
+            if formset.__class__.__name__ == 'ProviderRequestIPRangeFormFormSet':
+                for form in formset.forms:
+                    logger.debug(form.__class__.__name__)
+                    logger.debug(f"form.has_changed(): {form.has_changed()}")
+                
             instances = formset.save(commit=False)
             for instance in instances:
                 instance.request = request
                 instance.save()
-            for object_to_delete in formset.deleted_objects:
-                logger.info(f"we have {len(formset.deleted_objects)} objects to delete")
-                object_to_delete.delete()
-            logger.info(f"checking for changed forms: {formset.form}")
-            if formset.changed_objects:
-                logger.info(f"we have {len(formset.changed_objects)} objects to change")
-                pass
 
-            
+            for object_to_delete in formset.deleted_objects:
+                logger.debug(f"we have {len(formset.deleted_objects)} objects to delete")
+                object_to_delete.delete()
+                
+            logger.debug(f"checking for changed forms: {formset.form.__class__.__name__}")
+            if formset.changed_objects:
+                logger.debug(f"we have {len(formset.changed_objects)} objects to change")
+
 
         steps = ProviderRequestWizardView.Steps
 


### PR DESCRIPTION
This PR picks up the earlier work in #522, to address the problems we saw when updating an existing provider using the form wizard.

The problem is detailed in that PR, but the short version is that some data in forms contained within django formsets were not making it through the form wizard, which means when updating a provider request, if there were forms in a formset that had no changes, they were being dropped.

This was a blocker as it meant that on approval, our provider would be updated with incomplete information.

This only seemed to happen when our wizard form contained formsets that contained forms with unchanged data, and after exploring various options, I arrived at the idea of introducing a mixin class for use in forms we use in the form wizard.

All it does is adapt form behaviour to always return `True` when a `has_changed()` method is called on a form.

Because the formset handling code relies on this check when deciding to include a form in the validation steps for a given formset, this will always include the form in the data that is saved by the formset.

When used in a multi stage wizard, this ensures that the all the form wizard stages that contain formsets  also retain information in the forms even if no change has taken place. When the verification request is approved, all the data is saved back to the hosting provider.




