### PR TITLE
Fix django admin edit bug when a provider has lots of IPs

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -916,11 +916,13 @@ class HostingAdmin(
                     filtered_inlines.append(inline)
             return filtered_inlines
 
-        if obj.ip_range_count > 500:
+        # when we have too many IPs to realistically show on the page
+        # we top trying to show the GreencheckIPs inline, and instead
+        # use a link to the relvevant change list in the template.
+        # see admin/accounts/hostingprovider/change_form.html
+        if obj and obj.ip_range_count > 500:
             if GreencheckIpInline in inlines:
                 inlines.remove(GreencheckIpInline)
-
-            # inlines.remove(GreencheckIpInline)
 
         return inlines
 

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -413,10 +413,10 @@ class HostingAdmin(
     ]
     inlines = [
         HostingProviderSupportingDocumentInline,
-        GreencheckAsnInline,
         GreencheckIpInline,
-        GreencheckAsnApproveInline,
         GreencheckIpApproveInline,
+        GreencheckAsnInline,
+        GreencheckAsnApproveInline,
         HostingProviderNoteInline,
     ]
     search_fields = ("name",)
@@ -915,6 +915,12 @@ class HostingAdmin(
                 if inline not in admin_inlines:
                     filtered_inlines.append(inline)
             return filtered_inlines
+
+        if obj.ip_range_count > 500:
+            if GreencheckIpInline in inlines:
+                inlines.remove(GreencheckIpInline)
+
+            # inlines.remove(GreencheckIpInline)
 
         return inlines
 

--- a/templates/admin/accounts/hostingprovider/change_form.html
+++ b/templates/admin/accounts/hostingprovider/change_form.html
@@ -1,5 +1,4 @@
 {% extends "admin/change_form.html" %}
-
 {% block field_sets %}
     {% for fieldset in adminform %}
         {% if fieldset.name == "Hostingprovider info" %}
@@ -11,24 +10,39 @@
         {% endif %}
     {% endfor %}
 {% endblock %}
-
 {% block inline_field_sets %}
+    {% comment %}
+    Some providers have too many IP ranges to realistically show on the page.
+    So we need some special logic to to handle them. We remove the "green IP" 
+    inline in `get_inlines()` if we have more than 500 IP ranges, and then
+    after removing, we show this information below
+    We need to provide a template that tells users where to see IP ranges 
+
+    This relies on having access to the ip_range_count variable
+    which is set in '_changeform_view'.
+    
+    {% endcomment %}
     {% for inline_admin_formset in inline_admin_formsets %}
         {% comment %}
-    We only want to serve the special inline tabular version
-    of the IP approvals widgets and for IP range widgets,
-    as some providers have massive numbers that stop the page loading
-    properly.
-    The rest we want to serve as using their default inlines.
-  {% endcomment %}
-
+        We only want to serve the special inline tabular version
+        of the IP approvals widgets and for IP range widgets,
+        as some providers have massive numbers that stop the page loading
+        properly.
+        The rest we want to serve as using their default inlines.
+        {% endcomment %}
         {% if inline_admin_formset.opts.verbose_name_plural == "IP approvals" %}
-
+            {% if ip_range_count > 500 %}
+                <fieldset class="module">
+                    <h2>IP Ranges</h2>
+                    <p>
+                        There are {{ ip_range_count }} ip ranges associated with this provider, which is too many to show on this page. Follow this
+                        <a href="{{ bulk_edit_ip_range_link }}">this link to the bulk editing interface, with this provider pre-selected.</a>
+                    </p>
+                </fieldset>
+            {% endif %}
             {% if ip_approval_count > 500 %}
                 <fieldset class="module {{ inline_admin_formset.classes }}">
-                    <h2>
-                        {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
-                    </h2>
+                    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
                     <p>
                         There are {{ ip_approval_count }} ip approval requests associated with this provider, which is too many to show on this page. Follow this
                         <a href="{{ bulk_edit_ip_approval_link }}">
@@ -39,29 +53,6 @@
             {% else %}
                 {% include "admin/accounts/hostingprovider/inline_tabular.html" %}
             {% endif %}
-
-        {% elif inline_admin_formset.opts.verbose_name_plural == "IPs" %}
-
-            {% if ip_range_count > 500 %}
-                <fieldset class="module {{ inline_admin_formset.classes }}">
-                    <h2>
-                        {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
-                    </h2>
-
-                    <p>
-                        There are {{ ip_range_count }} ip ranges associated with this provider, which is too many to show on this page. Follow this
-                        <a href="{{ bulk_edit_ip_range_link }}">
-                            this link to the bulk editing interface, with this provider pre-selected.
-                        </a>
-                    </p>
-                </fieldset>
-            {% else %}
-                <h2>
-                    {{ inline_admin_formset.opts.verbose_name_plural|capfirst }}
-                </h2>
-                {% include "admin/accounts/hostingprovider/inline_tabular.html" %}
-            {% endif %}
-
         {% else %}
             {% include inline_admin_formset.opts.template %}
         {% endif %}


### PR DESCRIPTION
This PR introduces a fix in the admin where if a provider has more than 500 IP Ranges, it wasn't possible to save changes to that provider.


**What was going wrong and the fix I used**

Previously, when we havd more than 500 IPs presented on a provider, instead of showing a massive list of IP addresses to change, we should show a bit of HTML linking to a view of IP ranges scoped to a specific provider, which could be edited in isolation.

The problem was that under the hood, when you are on a provider change form and you see the various inlines for IPs, supporting evidence, ASNs and so on django represents these as a giant form.

Internally each inline has a few hidden inputs that django checks for when processing data, and it raises errors on that specific formset in the templates.

Also, because our earlier implementation only had changes made in the template, a submitted form would be flagged as one that had been tampered with, but because we were not rendering the actual form elements for the editable IP ranges, you couldn't see the error.

This new implementation does two things:

1. **it makes the change at the view level too, not just the template**  - instead of just not rendering the form elements for a given inline, we now remove the green IPs inline formset the change page entirely. This solves the issue about errors being raised for the django inline formset.
2. **it changes what we render in the template** - We now add the extra guidance above on the IP approvals formset template, as a plain html, rather than looping through the inline formset, and swapping in the guidance where we would otherwise be rendering the greencheck ip inline formset. This makes sure we still have the guidance visible on a page with more than 500 IPs. Without this, there would simply be no sign whatsoever of IP ranges as soon as a provider has more than 500 IP ranges registered to them, and they would be.