### PR TITLE
WIP: add uploads in wizard forms

### DIFF
--- a/apps/accounts/templates/provider_registration/partials/_preview.html
+++ b/apps/accounts/templates/provider_registration/partials/_preview.html
@@ -1,31 +1,31 @@
 {% load preview_extras %}
 {% load countries %}
-
 <div class="bg-neutral-50 rounded-xl my-6 p-4">
-	{% for field in form|exclude_preview_fields %}
-	<div class="mb-4 last-of-type:mb-0">
-		<p class="font-bold m-0">{{ field.label }}</p>
-		{% if field.label|lower == "which services does your organisation offer?" %}
-			{% comment %}
+    {% for field in form|exclude_preview_fields %}
+        <div class="mb-4 last-of-type:mb-0">
+            <p class="font-bold m-0">{{ field.label }}</p>
+            {% if field.label|lower == "which services does your organisation offer?" %}
+                {% comment %}
 				Expand services slugs to their full names (e.g. "paas" -> "Platform as a service")
 				using custom template tag
-			{% endcomment %}
-			<p class="m-0">{{ field.value|render_as_services|conditional_yesno:"Yes,No,-" }}</p>
-		{% elif field.label|lower == "country" %}
-			{% comment %}
+                {% endcomment %}
+                <p class="m-0">{{ field.value|render_as_services|conditional_yesno:"Yes,No,-" }}</p>
+            {% elif field.label|lower == "country" %}
+                {% comment %}
 				Expand country code to country name (e.g. "DE" -> "Germany")
 				using template tag provided by django_countries: https://pypi.org/project/django-countries/#template-tags
 				with a fallback on original value if no country could be matched
-			{% endcomment %}
-			{% get_country field.value as country %}
-			{% if country.name %}
-				<p class="m-0">{{ country.name }}</p>
-			{% else %}
-				<p class="m-0">{{ field.value }}</p>
-			{% endif %}
-		{% else %}
-			<p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
-		{% endif %}
-	</div>
-	{% endfor %}
+                {% endcomment %}
+                {% get_country field.value as country %}
+                {% if country.name %}
+                    <p class="m-0">{{ country.name }}</p>
+                {% else %}
+                    <p class="m-0">{{ field.value }}</p>
+                {% endif %}
+            {% else %}
+                <p class="m-0">{{ field.value|conditional_yesno:"Yes,No,-" }}</p>
+            {% endif %}
+            {% if field.lable|lower == "file upload" %}{{ field.value.url }}{% endif %}
+        </div>
+    {% endfor %}
 </div>

--- a/apps/greencheck/object_storage.py
+++ b/apps/greencheck/object_storage.py
@@ -2,11 +2,12 @@
 We use scaleway as a AWS S3 API compatible provider of object storage.
 Below is the wrapper around it for working with the objects.
 """
-import boto3
-from django.conf import settings
-from botocore.exceptions import ClientError
 import logging
 import typing
+
+import boto3
+from botocore.exceptions import ClientError
+from django.conf import settings
 
 
 def object_storage_bucket(bucket_name: str):
@@ -80,5 +81,4 @@ def create_presigned_url(
         logging.error(e)
         return None
 
-    # The response contains the presigned URL
     return response

--- a/apps/greencheck/object_storage.py
+++ b/apps/greencheck/object_storage.py
@@ -4,6 +4,9 @@ Below is the wrapper around it for working with the objects.
 """
 import boto3
 from django.conf import settings
+from botocore.exceptions import ClientError
+import logging
+import typing
 
 
 def object_storage_bucket(bucket_name: str):
@@ -19,6 +22,17 @@ def object_storage_bucket(bucket_name: str):
         aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
     )
     return object_storage.Bucket(bucket_name)
+
+
+def object_storage_client():
+    session = boto3.Session(region_name=settings.OBJECT_STORAGE_REGION)
+    object_storage = session.resource(
+        "s3",
+        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+    )
+    return object_storage.meta.client
 
 
 def green_domains_bucket():
@@ -37,3 +51,34 @@ def public_url(bucket: str, key: str) -> str:
     """
     region = settings.OBJECT_STORAGE_REGION
     return f"https://{bucket}.s3.{region}.scw.cloud/{key}"
+
+
+def create_presigned_url(
+    bucket_name: str, object_name: str, expiration=60 * 60
+) -> typing.Union[str, None]:
+    """
+    Generate a presigned URL to share an S3 object
+
+    :param bucket_name: name of the bucket
+    :param object_name: the name of the object key in the bucket
+    :param expiration: Time in seconds for the presigned URL to remain valid
+    :return: Presigned URL as string. If error, returns None.
+
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html
+    """
+
+    # Generate a presigned URL for the S3 object
+    s3_client = object_storage_client()
+
+    try:
+        response = s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket_name, "Key": object_name},
+            ExpiresIn=expiration,
+        )
+    except ClientError as e:
+        logging.error(e)
+        return None
+
+    # The response contains the presigned URL
+    return response


### PR DESCRIPTION
This PR supports the creation of temporary links for previewing uploaded files in the verification request form wizard.

The code in this PR now creates the temporary presigned links we need to show on the preview, but we haven't yet figured out how to fit this into the preview datastructure. 

This is because our form preview relies on iterating through various fields in unbound django forms prepopulated with initial data , and we don't have an obvious place to these presigned urls yet for them to show up where we'd like them to.

- [ ] figure out how to generate the presigned urls for previews
- [ ] figure out 
- [ ] implement this in the view
- [ ] implement in the template
- [ ] write tests
- [ ] document flow 
