### PR TITLE
Remove "provider" from admin view for verification request approvals

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1378,6 +1378,7 @@ class ProviderRequest(ActionInChangeFormMixin, admin.ModelAdmin):
         "missing_network_explanation",
         "newsletter_opt_in",
         "data_processing_opt_in",
+        "provider",
     )
     actions = ["mark_approved", "mark_open", "mark_rejected", "mark_removed"]
     change_form_template = "admin/provider_request/change_form.html"


### PR DESCRIPTION
This is used internally, for handing updates, but should probably not be exposed in the django admin like this, as it can lead to unintended destructive data updates to an existing provider.

