### PR TITLE
WIP: Hs deploy 1.4

### DIFF
--- a/apps/accounts/models/hosting.py
+++ b/apps/accounts/models/hosting.py
@@ -539,6 +539,9 @@ class Hostingprovider(models.Model):
             notification_subject, notification_email_copy, notification_email_html
         )
 
+    def last_approved_verification_req(self):
+        return self.providerrequest_set.filter(status="Approved").order_by('-modified').first()
+
     class Meta:
         # managed = False
         verbose_name = "Hosting Provider"

--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -57,7 +57,11 @@
 					
 					<div class="md:w-1/2">
 						<p class="my-0">
-							<a class="font-bold" href="{% url 'greenweb_admin:accounts_hostingprovider_change' provider.id %}">{{ provider }}</a>
+							{% if provider.last_approved_verification_req %}
+								<a class="font-bold" href="{% url 'provider_request_detail' provider.last_approved_verification_req.id %}">{{ provider }}</a>
+							{% else %}
+								<span class="font-bold">{{ provider }}</span>
+							{% endif %}
 						</p>
 
 						{% if provider.request and provider.request.approved_at %}
@@ -66,16 +70,14 @@
 					</div>
 
 					<div class="md:w-1/2 text-right">
-	
 						{% flag "edit_provider" %}
 							{% get_obj_perms request.user for provider as "provider_perms" %}
-						
+					
 							{% if "manage_provider" in provider_perms %}
 								<a href="{% url 'provider_edit' provider.id %}" class="btn btn-white text-sm">📝 Update listing</a>
 							{% endif %}
 						{% endflag %}
 					</div>
-
 				</div>
 				{% endfor %}
 			</div>

--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -70,13 +70,11 @@
 					</div>
 
 					<div class="md:w-1/2 text-right">
-						{% flag "edit_provider" %}
-							{% get_obj_perms request.user for provider as "provider_perms" %}
-					
-							{% if "manage_provider" in provider_perms %}
-								<a href="{% url 'provider_edit' provider.id %}" class="btn btn-white text-sm">📝 Update listing</a>
-							{% endif %}
-						{% endflag %}
+						{% get_obj_perms request.user for provider as "provider_perms" %}
+				
+						{% if "manage_provider" in provider_perms %}
+							<a href="{% url 'provider_edit' provider.id %}" class="btn btn-white text-sm">📝 Update listing</a>
+						{% endif %}
 					</div>
 				</div>
 				{% endfor %}

--- a/apps/accounts/templates/provider_portal/request_detail.html
+++ b/apps/accounts/templates/provider_portal/request_detail.html
@@ -150,7 +150,7 @@
 
       </article>
 
-      <a class="btn mb-0" href="{% url 'provider_portal_home' %}">Back to requests home</a>
+      <a class="btn mb-0" href="{% url 'provider_portal_home' %}">Back to portal home</a>
 
     </section>
 {% endblock %}


### PR DESCRIPTION
This branch represents the changes needed to deploy the provider editing features to users. Currently it's hidden behind a flag. 

This picks on scope from two Trello cards:
* https://trello.com/c/JpFDqO3j/308-provider-portal-provider-listing-links-should-link-to-summary-view-not-old-portal
* https://trello.com/c/SlW3wOhe/315-deploy-provider-editing-features-lift-provider-editing-flag

The short version of the changes needed here are:

- [x] When a user has approved listings, and they are in their provider portal home, clicking on the title on the provider should take you to the summary view, not the old style portal.
- [x] Removing the flag check for the provider `edit_provider`