### PR TITLE
Add cronjob via ansible for daily green domain exports

### DIFF
--- a/ansible/setup_cronjobs.yml
+++ b/ansible/setup_cronjobs.yml
@@ -6,7 +6,7 @@
     # there is nothing special about app4 versus the
     # other app serves. We just needed to pick one machine
     # to run these cron jobs on
-    - app4.thegreenwebfoundation.org
+    - app1.thegreenwebfoundation.org
 
   remote_user: deploy
   tasks:

--- a/ansible/setup_cronjobs.yml
+++ b/ansible/setup_cronjobs.yml
@@ -19,12 +19,19 @@
       become: true
       tags: [ip-importers]
 
-    - name: Upload backup script
+    - name: Upload ip import script
       ansible.builtin.template:
         src: import_ips_for_large_providers.sh.j2
         dest: /home/deploy/cronjobs/import_ips_for_large_providers.sh
         mode: "0755"
       tags: [ip-importers]
+
+    - name: Upload green domain export script
+      ansible.builtin.template:
+        src: export_green_domains.sh.j2
+        dest: /home/deploy/cronjobs/export_green_domains.sh
+        mode: "0755"
+      tags: [green-domains-exporter]
 
     - name: Ensure log files exist for /home/deploy/cronjobs
       ansible.builtin.file:
@@ -35,14 +42,22 @@
       become: true
       loop:
         - {
-            name: "STDOUT",
+            name: "ip import STDOUT",
             path: "/var/log/import_ips_for_large_providers.log",
           }
         - {
-            name: "STDERR",
+            name: "ip import STDERR",
             path: "/var/log/import_ips_for_large_providers.error.log",
           }
-      tags: [ip-importers]
+        - {
+            name: "green domains export STDOUT",
+            path: "/var/log/export_green_domains.log",
+          }
+        - {
+            name: "green domains export STDERR",
+            path: "/var/log/export_green_domains.error.log",
+          }
+      tags: [ip-importers, green-domains-exporter]
 
     - name: Ensure job to run IP hyperscaler importers is present
       ansible.builtin.cron:
@@ -56,4 +71,18 @@
           bash /home/deploy/cronjobs/import_ips_for_large_providers.sh 
           >> /var/log/import_ips_for_large_providers.log 
           2>> /var/log/import_ips_for_large_providers.error.log
+      tags: [crontab]
+
+    - name: Ensure job to export green domains is present
+      ansible.builtin.cron:
+        name: "every day at 1:30 export our green domains table"
+        state: present
+        weekday: "*"
+        hour: "1"
+        minute: "30"
+        user: deploy
+        job: >
+          bash /home/deploy/cronjobs/export_green_domains.sh 
+          >> /var/log/export_green_domains.log 
+          2>> /var/log/export_green_domains.error.log
       tags: [crontab]

--- a/ansible/templates/export_green_domains.sh.j2
+++ b/ansible/templates/export_green_domains.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+# Last run: {{ template_run_date }}
+
+# make sure we fail on any error
+set -euo pipefail
+
+# make sure we are in the right directory
+cd {{ project_root }}/current/
+
+# run the domains export and upload to object storage
+python -m pipenv run ./manage.py dump_green_domains --upload

--- a/ansible/templates/import_ips_for_large_providers.sh.j2
+++ b/ansible/templates/import_ips_for_large_providers.sh.j2
@@ -3,10 +3,13 @@
 # {{ ansible_managed }}
 # Last run: {{ template_run_date }}
 
+# make sure we fail on any error
 set -euo pipefail
 
+# make sure we are in the right directory
 cd {{ project_root }}/current/
 
+# run our imports
 python -m pipenv run ./manage.py update_networks_in_db_amazon
 python -m pipenv run ./manage.py update_networks_in_db_google
 python -m pipenv run ./manage.py update_networks_in_db_microsoft

--- a/ansible/templates/import_ips_for_large_providers.sh.j2
+++ b/ansible/templates/import_ips_for_large_providers.sh.j2
@@ -9,7 +9,7 @@ set -euo pipefail
 # make sure we are in the right directory
 cd {{ project_root }}/current/
 
-# run our imports
+# run our ip imports
 python -m pipenv run ./manage.py update_networks_in_db_amazon
 python -m pipenv run ./manage.py update_networks_in_db_google
 python -m pipenv run ./manage.py update_networks_in_db_microsoft

--- a/docs/recurring-tasks.md
+++ b/docs/recurring-tasks.md
@@ -16,9 +16,9 @@ While the Green Web Foundation offers a self-service way to maintain up to date 
 These can be run on the command line using the following commands
 
 ```
-./manage.py update_networks_in_db_amazon
-./manage.py update_networks_in_db_google
-./manage.py update_networks_in_db_microsoft
+pipnev run ./manage.py update_networks_in_db_amazon
+pipnev run ./manage.py update_networks_in_db_google
+pipnev run ./manage.py update_networks_in_db_microsoft
 ```
 
 Look in the `import_ips_for_large_providers.sh.j2` file to see the specific shell script run each week, and the `setup_cronjobs.yml` ansible playbook to see the specific tasks used to set up a a server to run these on a recurring schedule.
@@ -63,4 +63,23 @@ pipenv run ansible-playbook -i ansible/inventories/prod.yml ansible/setup_cronjo
 
 ### Daily Green Domain Exports
 
-TODO: add docs here for this cronjob too.
+In addition to offering the greencheck API, we create regular exports of the green domains table as compressed sqlite files, available in object storage.
+
+These are intended for cases when hitting an external API is either impractical, or in places where privacy is a higher priority, avoiding making network requests that show which domain is being checked.
+
+This export is normally run with the following django management command.
+
+```
+pipenv run ./manage.py dump_green_domains
+```
+
+To upload the database snapshot to object storage, pass long the `--upload` flag.
+
+
+```
+pipenv run ./manage.py dump_green_domains --upload
+```
+
+This is currently set to run every day, but historically, this job not run consistently every single day.
+
+There is ongoing work to backfill these domains for the missing days


### PR DESCRIPTION
This re-introduces via Ansible the daily green domains snapshot we had before.

We run this on the app1 box, because it has more memory than the other app servers (8gb RAM vs 4gb RAM).

