### PR TITLE
Add updated supervisor config files for clearer logging

### DIFF
--- a/ansible/templates/supervisor.gunicorn.conf.j2
+++ b/ansible/templates/supervisor.gunicorn.conf.j2
@@ -1,15 +1,16 @@
 # {{ ansible_managed }}
 # Last run: {{ template_run_date }}
+
 [supervisord]
 environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
+
 [program:{{ supervisor_gunicorn_app }}]
 directory=/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org/current/
 numprocs=1
 command=bash ./run_gunicorn.sh
-process_name=%(process_num)02d
 autostart=true
 autorestart=true
 stopsignal=QUIT
 user={{ supervisor_user }}
-stdout_logfile=%(program_name)s_%(process_num)02d_.log
-stderr_logfile=%(program_name)s_%(process_num)02d_.error.log
+stdout_logfile=/var/log/supervisor/%(program_name)s_%(process_num)02d.log
+stderr_logfile=/var/log/supervisor/%(program_name)s_%(process_num)02d.error.log

--- a/ansible/templates/supervisor.worker.conf.j2
+++ b/ansible/templates/supervisor.worker.conf.j2
@@ -1,12 +1,15 @@
 # {{ ansible_managed }}
 # Last run: {{ template_run_date }}
+
 [supervisord]
 environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
+
 [program:{{ supervisor_worker_job }}]
 directory=/var/www/{{ tgwf_domain_name }}.thegreenwebfoundation.org/current/
 command=bash ./run_worker.sh
-process_name=%(process_num)02d
 autostart=true
 autorestart=true
 stopsignal=TERM
 user={{ supervisor_user }}
+stdout_logfile=/var/log/supervisor/%(program_name)s_%(process_num)02d.log
+stderr_logfile=/var/log/supervisor/%(program_name)s_%(process_num)02d.error.log

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -248,3 +248,14 @@ These playbooks template out new scripts that supervisor the installed process m
 
 1. [The dramatiq guide](https://dramatiq.io/guide.html)
 2. [Django Dramatiq, the pacakge we use for interfacing with dramatiq](https://github.com/Bogdanp/django_dramatiq)
+
+
+## Logging
+
+As mentioned before, we use supervisor to run our both our workers and web server processes. This means processes are restarted automatically for us, and logs are rotated for us.
+
+##  Gunicorn logging
+
+By default, gunicorn, our web server logs at the `INFO` level. This means successful requests are not logged, and only errors (with the status code 5xx) or not found requests (4xx)  show up in logs.
+
+The logs on each app server are sent to our the Loki server on our monitoring node, accessible at https://grafana.greenweb.org. This allow for centralised querying of logs.

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,7 +1,6 @@
-import logging
 import os
 
 # increasing workers uses more RAM, but provides a simple model for scaling up resources
 workers = os.getenv("GUNICORN_WORKERS", default=8)
 # increasing threads saves RAM at the cost of using more CPU
-threads = 1
+threads = os.getenv("GUNICORN_THREADS", default=1)


### PR DESCRIPTION
This PR updates some of the internal config to make it much easier to track the logs from our application, and aggregate them in our centralised logging server.

More specifically, it creates files like so, that are easy to pick up and read with our log forwarders

**For the web servers**

Logs go to the following files.

/var/log/web_prod_00.log
/var/log/web_prod_00.error.log

We rely on gunicorn's native handling of multiple processes rather than supervisor' support.

This means that supervisor watches one main gunicorn process, which forks other workers, and all _their_ logs are aggregated and fed into the following two files.

**For the background worker processes**

Logs for the workers using dramatiq go to the following files:

/var/log/worker_00.log
/var/log/worker_00.error.log

Just like gunicorn, we really on dramatiq's own handling of subprocesses, that rather than supervisord.