### PR TITLE
Add check for valid domains on the multi check endpoint

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -354,6 +354,7 @@ class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWiza
             Helper function to process the data from ModelFormSets used in this view
             """
             logger.info(f"formset: {formset.__class__.__name__}")
+            logger.debug(f"formset: {formset.__class__.__name__}")
             if formset.__class__.__name__ == "ProviderRequestIPRangeFormFormSet":
                 for form in formset.forms:
                     logger.debug(form.__class__.__name__)

--- a/apps/greencheck/api/legacy_views.py
+++ b/apps/greencheck/api/legacy_views.py
@@ -189,6 +189,10 @@ def tiered_lookup(domain: str) -> GreenDomain:
     fallback to doing a slower, full lookup, returning a
     "Greendomain" lookup.
     """
+    # catch anything that clearly is not a domain
+    if not checker.validate_domain(domain):
+        return
+
     if res := GreenDomain.objects.filter(url__in=domain):
         return res.first()
 

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -66,7 +66,7 @@ class CarbonTxtParser:
                 valid_from=timezone.now(),
                 valid_to=timezone.now() + relativedelta.relativedelta(years=1),
             )
-            logger.info(f"New supporting doc {doc} for {prov}")
+            logger.debug(f"New supporting doc {doc} for {prov}")
 
         # rich.inspect({"provider": prov, "provider_set": provider_set})
 

--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -40,7 +40,7 @@ class GreenDomainChecker:
     matching SiteCheck result, that we might log.
     """
 
-    def validate_domain(self, url) -> typing.Union[str | None]:
+    def validate_domain(self, url) -> typing.Union[str, None]:
         """
         Attempt to clean the provided url, and pull
         return the domain, or ip address

--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -46,10 +46,15 @@ class GreenDomainChecker:
         return the domain, or ip address
         """
 
-        is_valid_tld = tld.is_tld(url)
+        try:
+            fetched_tld = tld.get_tld(url, fix_protocol=True)
+            has_valid_tld = tld.is_tld(fetched_tld)
+        except tld.exceptions.TldDomainNotFound:
+            return ""
 
         # looks like a domain
-        if is_valid_tld:
+        if has_valid_tld:
+            # note: we fetch this "as an object" this time
             res = tld.get_tld(url, fix_protocol=True, as_object=True)
             return res.parsed_url.netloc
 
@@ -58,7 +63,7 @@ class GreenDomainChecker:
             ipaddress.ip_address(url)
         except ValueError:
             # not an ip address either, return an empty result
-            return
+            return ""
 
         parsed_url = urllib.parse.urlparse(url)
         if not parsed_url.netloc:

--- a/apps/greencheck/tests/test_importer_csv.py
+++ b/apps/greencheck/tests/test_importer_csv.py
@@ -107,7 +107,6 @@ class TestCSVImporter:
         assert len(preview["green_ips"]) == 2
         assert len(preview["green_asns"]) == 1
 
-    @pytest.mark.only
     def test_view_processed_imports(
         self, sample_data_raw, hosting_provider: Hostingprovider
     ):


### PR DESCRIPTION
This PR adds validation of values that might not be domains to our legacy multicheck at the following endpoint.

```
/v2/greencheckmulti/{url_list}
```

Previously we didn't validate each entry, so this now filters out values which are not domains