### PR TITLE
Update how domain hash checks work

### DIFF
--- a/apps/accounts/models/test_models.py
+++ b/apps/accounts/models/test_models.py
@@ -62,7 +62,6 @@ class TestHostingProvider:
 
         assert datacenter.model == accounting_model
 
-    @pytest.mark.only
     def test_archive(
         self, db, hosting_provider_factory, green_ip_factory, green_asn_factory
     ):

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -408,7 +408,7 @@ class CarbonTxtParser:
                 "We found valid TOML, but we could not parse the contents."
             )
 
-        # TODO check if we are delegating via an HTTP header, as a final fallbac
+        # TODO check if we are delegating via an HTTP header, as a final fallback
         try:
             res, lookup_sequence = self._check_for_carbon_txt_via_header(
                 res, lookup_sequence

--- a/apps/greencheck/carbon_txt.py
+++ b/apps/greencheck/carbon_txt.py
@@ -2,7 +2,6 @@ import logging
 import typing
 from typing import Dict, List, Set, Union
 from urllib import parse
-import hashlib
 import dns.resolver
 import requests
 import toml
@@ -332,6 +331,7 @@ class CarbonTxtParser:
 
         via_header_payload = res.headers["via"].split(" ")
 
+        # check for delegation via HTTP header with no domain hash
         if len(via_header_payload) == 2:
             protocol, via_url = via_header_payload
             lookup_sequence.append(
@@ -339,6 +339,7 @@ class CarbonTxtParser:
             )
             res = requests.get(via_url)
 
+        # check for delegation via HTTP header *with* domain hash
         if len(via_header_payload) == 3:
             protocol, via_url, domain_hash = via_header_payload
             lookup_sequence.append(
@@ -407,14 +408,13 @@ class CarbonTxtParser:
                 "We found valid TOML, but we could not parse the contents."
             )
 
-        # TODO check if we are delegating via an HTTP header, as a final fallback
-
+        # TODO check if we are delegating via an HTTP header, as a final fallbac
         try:
             res, lookup_sequence = self._check_for_carbon_txt_via_header(
                 res, lookup_sequence
             )
         except Exception as ex:
-            breakpoint()
+            logger.exception(ex)
             pass
 
         try:

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -380,7 +380,11 @@ class TestCarbonTxtParser:
         assert result["lookup_sequence"][1]["url"] == via_domain
 
     def test_mark_dns_text_override_green_with_domain_hash(
-        self, db, hosting_provider_factory, green_domain_factory, minimal_carbon_txt_org
+        self,
+        db,
+        hosting_provider_factory,
+        green_domain_factory,
+        minimal_carbon_txt_org,
     ):
         # given a provider, at one domain serving files on behalf of another on a
         # separate domain
@@ -426,12 +430,13 @@ class TestCarbonTxtParser:
     def test_mark_http_via_override_green_with_domain_hash(
         self, db, hosting_provider_factory, green_domain_factory
     ):
-        # given a provider at one domain serving files on behalf of another org
+
+        # Given: a provider at one domain serving files on behalf of another org
         # on a different domain
         hosted_domain = "https://hosted.carbontxt.org/carbon.txt"
         via_domain = "https://managed-service.carbontxt.org/carbon.txt"
 
-        # and: there is an organisation, Org B who operate managed-service.carbontxt.org
+        # and: there is an organisation, Org B who operates managed-service.carbontxt.org
         carbon_txt_provider = hosting_provider_factory.create(
             website="https://managed-service.carbontxt.org"
         )
@@ -440,7 +445,7 @@ class TestCarbonTxtParser:
             url="managed-service.carbontxt.org", hosted_by=carbon_txt_provider
         )
 
-        # and: a shaed secret set up for our provider
+        # and: a shared secret set up for our provider
         ac_models.ProviderSharedSecret.objects.create(
             provider=carbon_txt_provider, body=SAMPLE_SECRET_BODY
         )
@@ -465,7 +470,6 @@ class TestCarbonTxtParser:
         assert result["lookup_sequence"][0]["url"] == hosted_domain
         assert result["lookup_sequence"][1]["url"] == via_domain
 
-    @pytest.mark.only
     def test_domain_hash_with_shared_secret_and_existing_domain(
         self, db, hosting_provider_factory
     ):
@@ -491,7 +495,6 @@ class TestCarbonTxtParser:
 
         assert check_result is True
 
-    @pytest.mark.only
     def test_domain_hash_with_shared_secret_and_new_domain_for_existing_provider(
         self, db, hosting_provider_factory
     ):
@@ -518,7 +521,6 @@ class TestCarbonTxtParser:
 
         assert check_result is True
 
-    @pytest.mark.only
     def test_adding_a_new_domain_is_impossible_without_access_to_shared_secret(
         self, db, hosting_provider_factory
     ):
@@ -535,9 +537,12 @@ class TestCarbonTxtParser:
         provider = hosting_provider_factory.create()
         provider.refresh_shared_secret()
 
+        # And: two domains we want to check, as if a carbon.txt file was being parsed
+        # from each domain
         new_good_domain = "new_website.com"
         new_bad_domain = "bad_website.com"
 
+        # When: we create a hash of the new domain and the shared secret and check it
         good_hash_obj = hashlib.sha256(
             f"{new_good_domain}{provider.shared_secret.body}".encode("utf-8")
         )
@@ -545,28 +550,25 @@ class TestCarbonTxtParser:
         good_check_result = carb._check_domain_hash_against_provider(
             good_hash_text, provider, new_good_domain
         )
+
         # Then the check should work fine
         assert good_check_result is True
 
-        # And When someone tries to add a new domain, reusing the existing
-        # domain hash, the result should how as false
+        # And: when someone tries to add a new domain, reusing the existing
+        # domain hash, the result should show as false
         bad_check_result = carb._check_domain_hash_against_provider(
             good_hash_text, provider, new_bad_domain
         )
 
         assert bad_check_result is False
 
-    @pytest.mark.only
     def test_checking_a_domain_hash_is_only_possible_if_a_provider_has_created_a_shared_secret(
         self, db, hosting_provider_factory
     ):
         carb = carbon_txt.CarbonTxtParser()
         provider = hosting_provider_factory.create()
 
-        hash_obj = hashlib.sha256(
-            f"{provider.website}{provider.shared_secret.body}".encode("utf-8")
-        )
-        hash_text = hash_obj.hexdigest()
+        hash_text = "20f745d77773a3a910dc5a864373e5ff00a5f783b51fcadf2b3e706a1d42478a"
 
         from apps.greencheck.exceptions import NoSharedSecret
 

--- a/apps/greencheck/tests/test_carbon_txt.py
+++ b/apps/greencheck/tests/test_carbon_txt.py
@@ -9,8 +9,6 @@ from ...accounts import models as ac_models
 from .. import carbon_txt, choices, workers
 from .. import models as gc_models
 
-#
-# hashlib.sha256(f"{domain} {shared_secret.body}".encode("utf-8"))
 SAMPLE_SECRET_BODY = "9b77e6f009dee68ae5307f2e54f4f36bc25d6d0dc65c86714784ad33a5480a64"
 
 
@@ -474,13 +472,13 @@ class TestCarbonTxtParser:
         self, db, hosting_provider_factory
     ):
         """
-        Check that for a provider with a shared secret, we can check its domain
-        against the hash of the domain and its shared secret.
+        Check that for a provider with a shared secret, we can check its
+        domain against the hash of the domain and its shared secret.
         This simulates the process of checking a domain hash for a provider's
         own website.
         """
 
-        carb = carbon_txt.CarbonTxtParser()
+        psr = carbon_txt.CarbonTxtParser()
         provider = hosting_provider_factory.create()
         provider.refresh_shared_secret()
 
@@ -489,7 +487,7 @@ class TestCarbonTxtParser:
         )
         hash_text = hash_obj.hexdigest()
 
-        check_result = carb._check_domain_hash_against_provider(
+        check_result = psr._check_domain_hash_against_provider(
             hash_text, provider, provider.website
         )
 
@@ -499,13 +497,14 @@ class TestCarbonTxtParser:
         self, db, hosting_provider_factory
     ):
         """
-        Check that for provider with a shared secret, we can check new domain can be
-        added by passing a hash of the new domain and the shared secret.
-        This simulates adding a new domain to a provider's list of green domains, by
-        linking to the carbon.txt on a verified provider, and passing the hash of the
-        new domain to be added in the DNS record or HTTP header
+        Check that for a provider with a shared secret, we can check new domain
+        can be added by passing a hash of the new domain and the shared secret.
+
+        This simulates adding a new domain to a provider's list of green domains
+        by linking to the carbon.txt on a verified provider, and passing the
+        hash of the new domain to be added in the DNS record or HTTP header.
         """
-        carb = carbon_txt.CarbonTxtParser()
+        psr = carbon_txt.CarbonTxtParser()
         provider = hosting_provider_factory.create()
         provider.refresh_shared_secret()
 
@@ -515,7 +514,7 @@ class TestCarbonTxtParser:
             f"{new_domain}{provider.shared_secret.body}".encode("utf-8")
         )
         hash_text = hash_obj.hexdigest()
-        check_result = carb._check_domain_hash_against_provider(
+        check_result = psr._check_domain_hash_against_provider(
             hash_text, provider, new_domain
         )
 
@@ -525,11 +524,13 @@ class TestCarbonTxtParser:
         self, db, hosting_provider_factory
     ):
         """
-        Check that for provider with a shared secret, we are unable to add a new domain
-        that is simply reusing a domain hash form an existing domain.
-        This simulates someone trying to add a new domain to a provider's list of
-        green domains, when they do not have access to the provider's shared secret to
-        make the required domain hash.
+        Check that for provider with a shared secret, we are unable
+        to add a new domain that is simply reusing a domain hash from
+        an existing domain.
+
+        This simulates someone trying to add a new domain to a provider's
+        list of green domains when they do not have access to the provider's
+        shared secret to make a new domain hash.
         """
 
         # Given a provider with a shared secret, and a carbontxt parser


### PR DESCRIPTION
This PR introduces a few changes to how carbon.txt lookup delegation works, to make it clearer how domain hashes work when verifying that someone is able to link a new domain to a verified provider.

A quick summary

- **Add a `domain_hash_for_domain` method on a hosting provider** - this uses the shared secret added to the provider to generate a domain hash
- **Update the ` _check_domain_hash_against_provider` method on the carbontxt parser** - this now uses the `domain_hash_for_domain` method, and has a different method signature that emphasises the role the provider plays
- **Update `_check_for_carbon_txt_via_header` and ` _check_for_carbon_txt_dns_record`** methods - the method signatures are fleshed out, and the flow should be clearer now
- **Add tests to demonstrate the new domain check code** - These tests are intended to show what you can and can't do with a given domain hash in terms of adding domains.

For more info, check [Change platform Trello card 341](https://trello.com/c/5Q14SoLk/341-double-check-carbontxt-logic-in-greencheck), and [Green Web Studio Trello card 239](https://trello.com/c/PSzCpygq/239-carbontxt-technical-review).