### PR TITLE
Fix ipv6 support in domain lookups

### DIFF
--- a/apps/greencheck/tests/test_domain_checker.py
+++ b/apps/greencheck/tests/test_domain_checker.py
@@ -33,16 +33,37 @@ class TestDomainChecker:
         assert res.ip in (green_ip.ip_start, green_ip.ip_end)
 
     @pytest.mark.parametrize(
-        "domain", ["ipv6.api.mythic-beasts.com", "ipv4.api.mythic-beasts.com"]
+        "domain",
+        [
+            "ipv6.api.mythic-beasts.com",
+            "ipv4.api.mythic-beasts.com",
+        ],
     )
     def test_domain_to_ip_supports_ipv4_and_ipv6(self, checker, domain):
         """
         When we check a a domain that resolves to an IPv6 address
         Do we get the appropriate response back?
         """
-        res = checker.check_domain(domain)
+        res = checker.convert_domain_to_ip(domain)
 
-        assert res.ip is not None and res.ip != "None"
+        assert isinstance(res, ipaddress.IPv6Address) or isinstance(
+            res, ipaddress.IPv4Address
+        )
+
+    @pytest.mark.parametrize(
+        "domain",
+        ["defintelynotavaliddomain", "defintelynotavaliddomain.com"],
+    )
+    def test_domain_to_ip_does_not_fail_silently(self, checker, domain):
+        """
+        When we check a domain that does resolve, are we notified so we
+        can catch exception appropriately?
+        """
+        import ipaddress
+        import socket
+
+        with pytest.raises((ipaddress.AddressValueError, socket.gaierror)):
+            checker.convert_domain_to_ip(domain)
 
     def test_with_green_domain_by_asn(self, green_asn, checker):
         """

--- a/apps/greencheck/tests/test_domain_checker.py
+++ b/apps/greencheck/tests/test_domain_checker.py
@@ -32,6 +32,18 @@ class TestDomainChecker:
         assert isinstance(res, legacy_workers.SiteCheck)
         assert res.ip in (green_ip.ip_start, green_ip.ip_end)
 
+    @pytest.mark.parametrize(
+        "domain", ["ipv6.api.mythic-beasts.com", "ipv4.api.mythic-beasts.com"]
+    )
+    def test_domain_to_ip_supports_ipv4_and_ipv6(self, checker, domain):
+        """
+        When we check a a domain that resolves to an IPv6 address
+        Do we get the appropriate response back?
+        """
+        res = checker.check_domain(domain)
+
+        assert res.ip is not None and res.ip != "None"
+
     def test_with_green_domain_by_asn(self, green_asn, checker):
         """
         Given a matching ASN, do we return a green sitecheck?


### PR DESCRIPTION
This PR is intended to resolve #573 , which came up when we realised that domain lookups that resolve to an ipv6 address were not working properly.

It covers both cases, and lays the path for a updating this to check ALL ip addresses a domain might resolve to in future, not just the first one. 

We don't immediately moved to checking every domain, as I'm not sure of the performance implications, and there are a few places that expect just one ip address to be returned - we'd need to make quite a few changes elsewhere.