### PR TITLE
Eco-CI integration

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
 
 defaults:
   run:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,16 +34,43 @@ jobs:
         python-version: [3.11]
 
     steps:
+      - name: Eco CI Energy Estimation - Initialize
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: start-measurement
+          company-uuid: "7f1d34f0-7666-4378-8d8f-d37cced7ccb0"
+          project-uuid: "a9946d61-149b-4757-99e5-aaac24acf289"
+        continue-on-error: true
+
       - uses: actions/checkout@v4
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: get-measurement
+          label: 'checkout'
+        continue-on-error: true
 
       - name: Use Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: get-measurement
+          label: 'setup-python'
+        continue-on-error: true
+
       - name: Install tooling for managing dependencies
         run: |
           python -m pip install --upgrade uv wheel
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: get-measurement
+          label: 'pip install uv wheel'
+        continue-on-error: true
 
       # - name: Set up a cache-key for installations of dependencies, in .venv
       #   id: cache-venv
@@ -59,6 +86,12 @@ jobs:
         run: |
           uv venv
           uv pip install -r requirements/requirements.linux.generated.txt
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: get-measurement
+          label: 'pip install requirements'
+        continue-on-error: true
 
       - name: Run tests
         run: |
@@ -80,3 +113,17 @@ jobs:
           EQUINIX_REMOTE_API_ENDPOINT: ${{ secrets.EQUINIX_REMOTE_API_ENDPOINT }}
           AWS_SHARED_CREDENTIALS_FILE: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: get-measurement
+          label: 'pytest'
+        continue-on-error: true
+
+      - name: Eco CI Energy Estimation - End Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        with:
+          task: display-results
+          pr-comment: true
+          send-data: true
+        continue-on-error: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,8 @@ defaults:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # this allows to show table and charts in PRs
 
     services:
       mariadb:


### PR DESCRIPTION
Hey @mrchrisadams ,

here is the promised Eco-CI integration sample PR!

What I did:
- Integrate Eco-CI initially and initalized it also with CarbonDB. Your runs will then not only show up here in the Eco-CI view, but also in Carbon DB
  - Eco-CI View: 
  - CarbonDB view: https://metrics.green-coding.io/carbondb-lists.html?company_uuid=7f1d34f0-7666-4378-8d8f-d37cced7ccb0
I have assinged the company UUID `7f1d34f0-7666-4378-8d8f-d37cced7ccb0` for your company. Note that you can use any ID. You should just double check that nobody else is using it.

- I integrated a measurement step after every step in the workflow. This way you get a nice granular view of all steps and how they relate in consumption

- I integrated `send-data: true`. This will send data here: https://metrics.green-coding.berlin/ci-index.html
  - In case you do not want that set it to false

- I also activated PR view, which makes a nice comment in the PR. This however needs the permission to write to the PR. If you do not want that please remove it.
  - We typically allow it but set our PRs to only run after they have been approved by a member of the organization. I can recommend that in general if you do not have it active

- Also I added an idea how to reduce unnecessary runs. I added some file exclusions. It will now not run when any changes to Markdown files occur, which I assume are non-functional in your repo?
  - If you do not want it remove the line. But maybe you want to add more even :)   