### PR TITLE
Add the missing info for the network wizard

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -721,10 +721,10 @@ class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWiza
                 ],
             }
             if hp_provider_request:
-                network_dict["missing_network_explanation"] = (
-                    hp_provider_request.missing_network_explanation
-                )
-
+                network_dict["extra"] = {
+                    "network_import_required": hp_provider_request.network_import_required,
+                    "missing_network_explanation": hp_provider_request.missing_network_explanation,
+                }
             return network_dict
 
         try:


### PR DESCRIPTION
This PR pulls in what I think is the final piece of info for missing from reverification if we have a previously filled out verification request.

Before when a provider had filled in a reason for why they were not submitting IP ranges or AS numbers (for examaple if they were going to share an CSV file full of IP ranges etc), this info was not prepopulated with the data we had.

This was because the the `NetworkFootprintForm` form in use was really a _multi-model form_, comprised of three different kinds of forms, and to populate it correctly, we needed to match each a form object with a corresponding dictionary data structure.

In the final case we were just passing a value, rather than passing a dictionary containing the values we needed.

Phew!