### PR TITLE
Add flag to hide admin and add ancillary links

### DIFF
--- a/apps/accounts/templates/provider_portal/home.html
+++ b/apps/accounts/templates/provider_portal/home.html
@@ -95,7 +95,20 @@
 
 		{% endif %}
 
+		{% flag "hide_old_admin" %}
+		<h3 class="text-xl pt-10">Other actions</h3>
+		
+		<p class="text-neutral-500 mt-8"><a href="{% url 'greenweb_admin:password_change' %}" class="text-neutral-500">Update your password</a></p>
+
+		<p class="text-neutral-500 mt-8"><a href="{% url 'green_urls_redirect' %}" class="text-neutral-500">See our list of downloadable green domain dataset snapshots</a></p>
+
+		<p class="text-neutral-500 mt-8"><a href="{% url 'greenweb_admin:check_url' %}" class="text-neutral-500">Try an extended green check for troubleshooting with support staff</a></p>
+
+		{% else %}
+
 		<p class="text-neutral-500 mt-8">Looking for the <a href="{% url 'greenweb_admin:index' %}" class="text-neutral-500">old style admin screens</a>?</p>
+
+		{% endflag %}
 
 	</div>
 


### PR DESCRIPTION
This PR adds a flag that removes links to the old style django admin, and in places adds a number of links to the last actions that non-staff users might have needed the old admin for.