### PR TITLE
Moving to v4.0-rc3 and added machine-uuid

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,16 +41,17 @@ jobs:
 
     steps:
       - name: Eco CI Energy Estimation - Initialize
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: start-measurement
           company-uuid: "7f1d34f0-7666-4378-8d8f-d37cced7ccb0"
           project-uuid: "a9946d61-149b-4757-99e5-aaac24acf289"
+          machine-uuid: "90a9ec92-0884-43bc-8b98-9a7885864307"
         continue-on-error: true
 
       - uses: actions/checkout@v4
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: get-measurement
           label: 'checkout'
@@ -62,7 +63,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: get-measurement
           label: 'setup-python'
@@ -72,7 +73,7 @@ jobs:
         run: |
           python -m pip install --upgrade uv wheel
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: get-measurement
           label: 'pip install uv wheel'
@@ -93,7 +94,7 @@ jobs:
           uv venv
           uv pip install -r requirements/requirements.linux.generated.txt
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: get-measurement
           label: 'pip install requirements'
@@ -120,14 +121,14 @@ jobs:
           AWS_SHARED_CREDENTIALS_FILE: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: get-measurement
           label: 'pytest'
         continue-on-error: true
 
       - name: Eco CI Energy Estimation - End Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@main
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
         with:
           task: display-results
           pr-comment: true


### PR DESCRIPTION
Hey @mrchrisadams ,

we have massively slimmed our Eco-CI tool and wanted to bring you the lastest update via PR.

## What I changed in your workflow
- Moving from `@main` inclusion to `@VERSION`. This will instruct Dependabot to also make PRs automatically in the future in case we update Eco-CI.
- Using the newest super slim v4.0-rc3 version. Find all details like a 100x improvement here: https://github.com/green-coding-solutions/eco-ci-energy-estimation/releases/tag/v4.0-rc3
- We now require `machine-uuid` to be set. I generated a random one for you that you can then find in your CarbonDB view: https://metrics.green-coding.io/carbondb-lists.html?company_uuid=7f1d34f0-7666-4378-8d8f-d37cced7ccb0
  - Note there: They way this was defined in the PR was sadly incorrect. Probably my bad. But Eco-CI did not pick up the CarbonDB integration. It should now!

Also we have done some improvements to the SCI calculation and are now showing more granular data.

In essence though the speed gain should be the biggest win. We went down from ~30 seconds to ~1-2 seconds of overhead for a typical 5-7 step workflow.

## PR-Comments

Somehow the PR comments are not showing correctly for you. I am not sure why that is. For every PR you should get a comment like that: 
<img width="826" alt="Screenshot 2024-06-18 at 2 49 59 PM" src="https://github.com/thegreenwebfoundation/admin-portal/assets/250671/f00961d5-4696-40f9-bc2f-58596f01ffb7">



I have a feeling some general setting on the repo is more restrictive than we expect it to be. I will look into that once a workflow for this PR has run