### PR TITLE
Add the redirect to the provider portal again

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -59,7 +59,17 @@ logger = logging.getLogger(__name__)
 
 
 class DashboardView(TemplateView):
+    """
+    This dashboard view was what people would see when signing into the admin.
+    We currently redirect to the provider portal home page as at present,we 
+    only really logged in activity by users who work for the providers in our system.
+    """
     template_name = "dashboard.html"
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseRedirect(reverse("provider_portal_home"))
+        
+    
 
 class ProviderAutocompleteView(autocomplete.Select2QuerySetView):
     def get_queryset(self):


### PR DESCRIPTION
When removing the unused flags, the last PR related to this work, #610 (i.e. Remove old, unneeded flags), was a tad overzealous, and removed a flag called called "dashboard" from three years ago. 

This was the flag that hid some of the older involved charts we never released, and users who visited the the application root, at `/` could either be able to see the new stats, or be redirect to the shiny new provider portal.

This had the effect of showing the screen below that would only be showed when the dashboard flag was active:

![Screenshot 2024-07-09 at 13 28 35](https://github.com/thegreenwebfoundation/admin-portal/assets/17906/3d25a4fe-d910-4660-8191-f74328f087e3)

This PR redirects user to the provider portal view, restoring the previous behaviour, so visiting `/` when authenticated shows you something like this again:

![Screenshot 2024-07-09 at 13 30 39](https://github.com/thegreenwebfoundation/admin-portal/assets/17906/f12d1e93-1917-4ce3-bd6e-15177995c0b1)

