### PR TITLE
Add reference to 5th app server for running ansible commands

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -5,7 +5,9 @@
     # - app2.thegreenwebfoundation.org
     # - app3.thegreenwebfoundation.org
     # - app4.thegreenwebfoundation.org
-    - app_servers
+    # - app5.thegreenwebfoundation.org
+
+    # - app_servers
     # api servers are app1, app2, and app4, mainly serving API traffic
     # - api_servers
     # admin server is app3, mainly serving member portal traffic

--- a/ansible/see_command_output.yml
+++ b/ansible/see_command_output.yml
@@ -6,10 +6,11 @@
 
   hosts:
     # - all
-    - app1.thegreenwebfoundation.org
-    - app2.thegreenwebfoundation.org
-    - app3.thegreenwebfoundation.org
-    - app4.thegreenwebfoundation.org
+    # - app1.thegreenwebfoundation.org
+    # - app2.thegreenwebfoundation.org
+    # - app3.thegreenwebfoundation.org
+    # - app4.thegreenwebfoundation.org
+    # - app5.thegreenwebfoundation.org
 
   remote_user: deploy
   vars:


### PR DESCRIPTION
This PR adds the 5th app server we use in our system, so we can refer to it explicitly when running commands against it with `see_command_output.yml` or in focussed deploys.

We used it when switching from making an external DNS lookup to reach our database server i.e. looking up `db2.greenweb.org` to the private IP address that all the app servers can reach whilst on the same shared private network with Hetzner.

Previously we were seeing connectivity issues as the app servers would sometimes be unable to resolve db2.greenweb.org to the public IP address. 

The change isn't visible here, but we have also updated our database connection string to use the private IP address instead of the public domain name and public IP address too.

We do the same with our Rabbit MQ connection, as we have seen similar intermittent connectivity issues there too.

