### PR TITLE
Improve directory filtering to exclude archived providers

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -5,7 +5,9 @@
     # - app2.thegreenwebfoundation.org
     # - app3.thegreenwebfoundation.org
     # - app4.thegreenwebfoundation.org
-    - app_servers
+    # - app5.thegreenwebfoundation.org
+
+    # - app_servers
     # api servers are app1, app2, and app4, mainly serving API traffic
     # - api_servers
     # admin server is app3, mainly serving member portal traffic

--- a/ansible/see_command_output.yml
+++ b/ansible/see_command_output.yml
@@ -6,10 +6,11 @@
 
   hosts:
     # - all
-    - app1.thegreenwebfoundation.org
-    - app2.thegreenwebfoundation.org
-    - app3.thegreenwebfoundation.org
-    - app4.thegreenwebfoundation.org
+    # - app1.thegreenwebfoundation.org
+    # - app2.thegreenwebfoundation.org
+    # - app3.thegreenwebfoundation.org
+    # - app4.thegreenwebfoundation.org
+    # - app5.thegreenwebfoundation.org
 
   remote_user: deploy
   vars:

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -12,8 +12,7 @@ from django.core.exceptions import ValidationError
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.views.generic.edit import FormView
-from waffle import flag_is_active
-from waffle.mixins import WaffleFlagMixin
+
 
 from apps.greencheck.views import GreenUrlsView
 
@@ -89,11 +88,10 @@ class CarbonTxtForm(forms.Form):
                     )
 
 
-class CarbonTxtCheckView(LoginRequiredMixin, WaffleFlagMixin, FormView):
+class CarbonTxtCheckView(LoginRequiredMixin, FormView):
     template_name = "carbon_txt_preview.html"
     form_class = CarbonTxtForm
     success_url = "/admin/carbon-txt-preview"
-    waffle_flag = "carbon_txt_preview"
 
     def form_valid(self, form):
         """Show the valid"""

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -238,21 +238,21 @@ class GreenWebAdmin(AdminSite):
         if app_label:
             return app_list
 
-        if flag_is_active(request, "provider_request"):
-            verification_request_item = {
-                "name": "New provider portal",
-                "app_label": "greencheck",
-                "app_url": reverse("provider_portal_home"),
-                "models": [
-                    {
-                        "name": "Move to a new version of provider portal",
-                        "object_name": "greencheck_url",
-                        "admin_url": reverse("provider_portal_home"),
-                        "view_only": True,
-                    }
-                ],
-            }
-            app_list.insert(0, verification_request_item)
+        
+        verification_request_item = {
+            "name": "New provider portal",
+            "app_label": "greencheck",
+            "app_url": reverse("provider_portal_home"),
+            "models": [
+                {
+                    "name": "Move to a new version of provider portal",
+                    "object_name": "greencheck_url",
+                    "admin_url": reverse("provider_portal_home"),
+                    "view_only": True,
+                }
+            ],
+        }
+        app_list.insert(0, verification_request_item)
 
         app_list += [
             {

--- a/apps/accounts/templates/emails/verification-request-notify.html
+++ b/apps/accounts/templates/emails/verification-request-notify.html
@@ -19,15 +19,15 @@
 </p>
 <h4>What happens next?</h4>
 <p>
-    We aim to review every
+    We review
     {% if provider %}
         {% comment %} If it's an update to an existing provider. {% endcomment %}
-        update
+        provider updates
     {% else %}
         {% comment %} If it's a new provider request. {% endcomment %}
-        new verification request
+        new verification requests
     {% endif %}
-    within 3 working days. Once we have reviewed the verification request, we will contact you by email to let you know that it is approved, or that we need more information from you.
+    on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
 </p>
 <p>
     If you have further questions, or need to edit your verification request,  please contact <a href="mailto:support@thegreenwebfoundation.org">support@thegreenwebfoundation.org</a>.

--- a/apps/accounts/templates/emails/verification-request-notify.txt
+++ b/apps/accounts/templates/emails/verification-request-notify.txt
@@ -9,7 +9,7 @@ Thank you for taking the time to {% if provider %}update the listing for {{ prov
 {% endif %}
 {{ link_to_verification_request }}
 What happens next?
-We aim to review every {% if provider %}update{% else %} new verification request{% endif %} within 3 working days. Once we have reviewed the verification request, we will contact you by email to let you know that it is approved, or that we need more information from you.
+We review {% if provider %}provider updates{% else %}new verification requests{% endif %} on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
 If you have further questions, or need to edit your verification request,  please contact support@thegreenwebfoundation.org.
 Many thanks,
 Green Web Foundation

--- a/apps/accounts/templates/provider_portal/before_starting.html
+++ b/apps/accounts/templates/provider_portal/before_starting.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load i18n static humanize widget_tweaks tailwind_filters waffle_tags %}
+{% load i18n static humanize widget_tweaks tailwind_filters %}
 
 {% block content %}
 

--- a/apps/accounts/templates/provider_portal/request_detail.html
+++ b/apps/accounts/templates/provider_portal/request_detail.html
@@ -29,7 +29,8 @@
         {% endif %}
 
         {% if object.status|lower == "pending review" %}
-          We are currently reviewing this request. If you want to update the information relating to this provider, please get in touch using <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/support-form/">our support form</a>.
+          We are currently reviewing this request. All verification requests and updates are reviewed by a member of our team on Tuesday each week. <br/>
+          If you want to update the information relating to this provider, please get in touch using <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/support-form/">our support form</a>.
         {% endif %}
 
           

--- a/apps/accounts/tests/test_provider_portal.py
+++ b/apps/accounts/tests/test_provider_portal.py
@@ -3,13 +3,12 @@ from ..models import ProviderRequestStatus
 from ..factories import ProviderRequestFactory, ProviderRequestLocationFactory
 from django.test import RequestFactory
 from django.urls import reverse
-from waffle.testutils import override_flag
+
 
 import pytest
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_portal_home_view_displays_only_authored_requests(client):
     # given: 3 provider requests exist, created by different users
     pr1 = ProviderRequestFactory.create()
@@ -30,7 +29,6 @@ def test_provider_portal_home_view_displays_only_authored_requests(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_portal_home_view_returns_only_unapproved_requests(client):
     # given: 1 pending verification request
     pr1 = ProviderRequestFactory.create(status=ProviderRequestStatus.PENDING_REVIEW)
@@ -56,7 +54,6 @@ def test_provider_portal_home_view_returns_only_unapproved_requests(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_portal_home_view_filters_out_removed_requests(client):
     # given: 1 removed verification request
     removed_request = ProviderRequestFactory.create(
@@ -84,7 +81,6 @@ def test_provider_portal_home_view_filters_out_removed_requests(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_portal_home_view_items_sorted_by_name(client):
     # given: 3 pending verification requests
     pr1 = ProviderRequestFactory.create(status=ProviderRequestStatus.PENDING_REVIEW)

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -254,7 +254,6 @@ def test_staff_can_access_admin(greenweb_staff_user, client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_detail_view_accessible_by_creator(client):
     # given: provider request exists
     pr = ProviderRequestFactory.create()
@@ -269,7 +268,6 @@ def test_detail_view_accessible_by_creator(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_detail_view_accessible_by_admin(client, greenweb_staff_user):
     # given: provider request exists
     pr = ProviderRequestFactory.create()
@@ -284,7 +282,6 @@ def test_detail_view_accessible_by_admin(client, greenweb_staff_user):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_detail_view_forbidden_for_others(client, user):
     # given: provider request exists
     pr = ProviderRequestFactory.create()
@@ -298,7 +295,6 @@ def test_detail_view_forbidden_for_others(client, user):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_wizard_view_happy_path(
     user,
     client,
@@ -364,7 +360,6 @@ def _create_provider_request(client, form_data) -> HttpResponse:
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_wizard_sends_email_on_submission(
     user,
     client,
@@ -940,7 +935,6 @@ def test_approve_skips_duplicate_evidence_when_existing_evidence_updated(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_wizard_view_with_just_network_explanation(
     user,
     client,
@@ -983,7 +977,6 @@ def test_wizard_view_with_just_network_explanation(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_wizard_records_if_location_import_needed(
     user,
     client,
@@ -1025,7 +1018,6 @@ def test_wizard_records_if_location_import_needed(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_new_submission_doesnt_modify_available_services(
     user,
     client,
@@ -1065,7 +1057,6 @@ def test_new_submission_doesnt_modify_available_services(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_edit_view_accessible_by_creator(client):
     # given: an open provider request
     pr = ProviderRequestFactory.create()
@@ -1079,7 +1070,6 @@ def test_edit_view_accessible_by_creator(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_edit_view_accessible_by_admin(client, greenweb_staff_user):
     # given: an open provider request
     pr = ProviderRequestFactory.create()
@@ -1093,7 +1083,6 @@ def test_edit_view_accessible_by_admin(client, greenweb_staff_user):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_edit_view_inaccessible_by_other_users(client, user):
     # given: an open provider request
     pr = ProviderRequestFactory.create()
@@ -1107,7 +1096,6 @@ def test_edit_view_inaccessible_by_other_users(client, user):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 @pytest.mark.parametrize(
     "request_status,status_code",
     [
@@ -1130,7 +1118,6 @@ def test_edit_view_accessible_for_given_status(client, request_status, status_co
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_edit_view_displays_form_with_prepopulated_data(client):
     # given: an open provider request
     pr = ProviderRequestFactory.create()
@@ -1154,7 +1141,6 @@ def test_edit_view_displays_form_with_prepopulated_data(client):
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_editing_pr_updates_original_submission(
     client,
     wizard_form_org_details_data,
@@ -1339,7 +1325,6 @@ def test_editing_pr_updates_original_submission(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_edit_view_accessible_by_user_with_required_perms(
     client, hosting_provider_with_sample_user, sample_hoster_user
 ):
@@ -1355,7 +1340,6 @@ def test_provider_edit_view_accessible_by_user_with_required_perms(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_edit_view_accessible_by_admins(
     client, hosting_provider_with_sample_user, greenweb_staff_user
 ):
@@ -1371,7 +1355,6 @@ def test_provider_edit_view_accessible_by_admins(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_provider_edit_view_inaccessible_by_unauthorized_users(
     client, hosting_provider_with_sample_user
 ):
@@ -1390,7 +1373,6 @@ def test_provider_edit_view_inaccessible_by_unauthorized_users(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_edit_view_inaccessible_for_nonexistent_provider(client, greenweb_staff_user):
     client.force_login(greenweb_staff_user)
     response = client.get(urls.reverse("provider_edit", args=[str(123456)]))
@@ -1400,7 +1382,6 @@ def test_edit_view_inaccessible_for_nonexistent_provider(client, greenweb_staff_
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_editing_hp_creates_new_verification_request(
     client,
     hosting_provider_with_sample_user,
@@ -1578,7 +1559,6 @@ def test_editing_hp_creates_new_verification_request(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_saving_changes_to_verification_request_from_hp_via_wizard(
     client,
     hosting_provider_with_sample_user,
@@ -1795,7 +1775,6 @@ def test_saving_changes_to_verification_request_from_hp_via_wizard(
 
 
 @pytest.mark.django_db
-@override_flag("provider_request", active=True)
 def test_saving_changes_to_hp_with_new_verification_request(
     client,
     hosting_provider_with_sample_user,
@@ -2090,7 +2069,6 @@ def test_request_from_host_provider_finishes_in_sensible_time():
         ),
     ),
 )
-@override_flag("provider_request", active=True)
 def test_email_sent_on_approval(
     hosting_provider_with_sample_user,
     greenweb_staff_user,
@@ -2175,7 +2153,6 @@ def test_email_sent_on_approval(
         ),
     ),
 )
-@override_flag("provider_request", active=True)
 def test_email_request_email_confirmation_is_sent(
     hosting_provider_with_sample_user,
     greenweb_staff_user,
@@ -2252,7 +2229,6 @@ def test_email_request_email_confirmation_is_sent(
         ("open", "Changes Requested"),
     ),
 )
-@override_flag("provider_request", active=True)
 def test_staff_review_is_logged(
     hosting_provider_with_sample_user,
     greenweb_staff_user,

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,7 +1,6 @@
 import logging
 from enum import Enum
 
-import waffle
 from dal import autocomplete
 from django.conf import settings
 from django.contrib import messages
@@ -31,7 +30,6 @@ from django_registration.forms import (
     RegistrationFormUniqueEmail,
 )
 from formtools.wizard.views import SessionWizardView
-from waffle.mixins import WaffleFlagMixin
 
 from .forms import (
     ConsentForm,
@@ -62,13 +60,6 @@ logger = logging.getLogger(__name__)
 
 class DashboardView(TemplateView):
     template_name = "dashboard.html"
-
-    def get(self, request, *args, **kwargs):
-        if waffle.flag_is_active(request, "dashboard"):
-            return super().get(request, args, kwargs)
-        else:
-            return HttpResponseRedirect(reverse("provider_portal_home"))
-
 
 class ProviderAutocompleteView(autocomplete.Select2QuerySetView):
     def get_queryset(self):
@@ -176,7 +167,7 @@ class UserUpdateView(UpdateView):
         return super().get(request, args, kwargs)
 
 
-class ProviderPortalHomeView(LoginRequiredMixin, WaffleFlagMixin, ListView):
+class ProviderPortalHomeView(LoginRequiredMixin, ListView):
     """
     Home page of the Provider Portal:
     - used by external (non-staff) users to access a list of requests they submitted,
@@ -185,7 +176,6 @@ class ProviderPortalHomeView(LoginRequiredMixin, WaffleFlagMixin, ListView):
     """
 
     template_name = "provider_portal/home.html"
-    waffle_flag = "provider_request"
     model = ProviderRequest
 
     def get_queryset(self) -> "dict[str, QuerySet[ProviderRequest]]":
@@ -211,7 +201,7 @@ class ProviderPortalHomeView(LoginRequiredMixin, WaffleFlagMixin, ListView):
         }
 
 
-class ProviderRequestDetailView(LoginRequiredMixin, WaffleFlagMixin, DetailView):
+class ProviderRequestDetailView(LoginRequiredMixin, DetailView):
     """
     Detail view for ProviderRequests:
     - used by external (non-staff) users to view a summary of a single request they submitted,
@@ -220,7 +210,6 @@ class ProviderRequestDetailView(LoginRequiredMixin, WaffleFlagMixin, DetailView)
     """  # noqa
 
     template_name = "provider_portal/request_detail.html"
-    waffle_flag = "provider_request"
     model = ProviderRequest
 
     def get_queryset(self) -> "QuerySet[ProviderRequest]":
@@ -233,7 +222,7 @@ class ProviderRequestDetailView(LoginRequiredMixin, WaffleFlagMixin, DetailView)
         return ProviderRequest.objects.filter(created_by=self.request.user)
 
 
-class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWizardView):
+class ProviderRequestWizardView(LoginRequiredMixin, SessionWizardView):
     """
     Multi-step registration for providers.
     - uses `django-formtools` SessionWizardView to display
@@ -241,8 +230,6 @@ class ProviderRequestWizardView(LoginRequiredMixin, WaffleFlagMixin, SessionWiza
     - requires the flag `provider_request` enabled to access the view,
 
     """
-
-    waffle_flag = "provider_request"
     file_storage = DefaultStorage()
 
     class Steps(Enum):

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -59,7 +59,17 @@ logger = logging.getLogger(__name__)
 
 
 class DashboardView(TemplateView):
+    """
+    This dashboard view was what people would see when signing into the admin.
+    We currently redirect to the provider portal home page as at present,we 
+    only really logged in activity by users who work for the providers in our system.
+    """
     template_name = "dashboard.html"
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseRedirect(reverse("provider_portal_home"))
+        
+    
 
 class ProviderAutocompleteView(autocomplete.Select2QuerySetView):
     def get_queryset(self):

--- a/apps/greencheck/tests/models/test_greencheck_stats.py
+++ b/apps/greencheck/tests/models/test_greencheck_stats.py
@@ -13,7 +13,6 @@ from django import urls
 from django.core import management
 from django.utils import timezone
 from dramatiq.brokers import stub
-from waffle.testutils import override_flag
 
 from ....accounts import models as ac_models
 from ... import choices as gc_choices

--- a/apps/greencheck/tests/test_directory.py
+++ b/apps/greencheck/tests/test_directory.py
@@ -5,7 +5,6 @@ import pytest
 
 
 @pytest.mark.django_db
-@override_flag("directory_listing", active=True)
 def test_directory(client):
     """
     Confirm that the directory view is accessible when our flag is active
@@ -18,7 +17,6 @@ def test_directory(client):
 
 
 @pytest.mark.django_db
-@override_flag("directory_listing", active=True)
 def test_ordering_of_providers_in_directory(client, hosting_provider_factory):
     """
     Check that providers are listed in order of the name of their
@@ -39,7 +37,6 @@ def test_ordering_of_providers_in_directory(client, hosting_provider_factory):
 
 
 @pytest.mark.django_db
-@override_flag("directory_listing", active=True)
 def test_templates_in_filter_view(client, hosting_provider_factory):
     """
     Check that we include the no_directoru results in our template
@@ -61,7 +58,6 @@ def test_templates_in_filter_view(client, hosting_provider_factory):
 
 
 @pytest.mark.django_db
-@override_flag("directory_listing", active=True)
 def test_fallback_when_no_filter_view_has_no_results(client, hosting_provider_factory):
     """
     Check that we include the no_directoru results in our template

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -2,7 +2,6 @@ import collections
 import typing
 from datetime import date, timedelta
 
-import waffle
 from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 from django.http import HttpResponseRedirect
@@ -14,7 +13,6 @@ from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView
 
 import django_filters
-from waffle.mixins import WaffleFlagMixin
 
 from apps.accounts.models.hosting import Hostingprovider
 from apps.greencheck.models.checks import GreenDomain
@@ -61,9 +59,8 @@ class GreenUrlsView(TemplateView):
         return context
 
 
-class GreencheckStatsView(WaffleFlagMixin, TemplateView):
+class GreencheckStatsView(TemplateView):
     template_name = "greencheck/stats_index.html"
-    waffle_flag = "greencheck-stats"
 
     def _get_headline_counts(self, daily_stat_queryset=None):
         """
@@ -235,13 +232,12 @@ class ProviderFilter(django_filters.FilterSet):
         fields = ["services", "country"]
 
 
-class DirectoryView(WaffleFlagMixin, TemplateView):
+class DirectoryView(TemplateView):
     """
     A view for filtering our list of providers by various criteria
     """
 
     template_name = "greencheck/directory_index.html"
-    waffle_flag = "directory_listing"
 
     def get_context_data(self, *args, **kwargs):
         """

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -248,7 +248,10 @@ class DirectoryView(TemplateView):
         of providers
         """
 
-        queryset = Hostingprovider.objects.filter(showonwebsite=True).prefetch_related(
+        queryset = Hostingprovider.objects.filter(
+            showonwebsite=True,
+            archived=False
+        ).prefetch_related(
             "services"
         )
 

--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -14,6 +14,8 @@ from django.views.generic.base import TemplateView
 
 import django_filters
 
+from waffle.mixins import WaffleFlagMixin
+
 from apps.accounts.models.hosting import Hostingprovider
 from apps.greencheck.models.checks import GreenDomain
 from apps.greencheck.models.stats import DailyStat
@@ -59,8 +61,9 @@ class GreenUrlsView(TemplateView):
         return context
 
 
-class GreencheckStatsView(TemplateView):
+class GreencheckStatsView(WaffleFlagMixin, TemplateView):
     template_name = "greencheck/stats_index.html"
+    waffle_flag = "greencheck-stats"
 
     def _get_headline_counts(self, daily_stat_queryset=None):
         """

--- a/apps/theme/templates/greencheck/partials/_directory_beta-msg.html
+++ b/apps/theme/templates/greencheck/partials/_directory_beta-msg.html
@@ -1,8 +1,7 @@
 <div class="flex items-center grow justify-end gap-2 text-right min-[520px]:block min-[520px]:grow-0 min-[520px]:text-center">
 
-	<p class="text-xs min-[520px]:mb-2">Be kind, we're still in</p>
+	<p class="text-xs min-[530px]:mb-2">🙏 Be kind, we're still in</p>
 	<p class="uppercase py-2 px-5 border-2 border-black rounded-3xl text-sm font-bold">beta</p>
-	<p class="text-xs min-[520px]:mt-2"><a href="https://www.thegreenwebfoundation.org/directory/">Previous Directory</a></p>
 
 </div>
 

--- a/apps/theme/templates/greencheck/partials/_directory_results.html
+++ b/apps/theme/templates/greencheck/partials/_directory_results.html
@@ -53,13 +53,6 @@
                             {% for service in obj.services.all %}
                                 <li class="service-label inline-block">{{ service.name }}</li>
                             {% endfor %}
-
-                            {% comment %}
-									Every host in our directory used to at least offer shared hosting.
-									Below is a placeholder to see how it would look with live data.
-									{% else %}
-									<li class="service-label inline-block">Compute: Shared Hosting for Websites</li>
-								{% endcomment %}
                         </ul>
                     {% endif %}
 
@@ -87,27 +80,28 @@
 
                 </div>
 
-                {% if not obj.public_supporting_evidence and not obj.description %}
-                    <details class="">
-                        <summary class="text-right text-sm text-neutral-400">Help improve this listing</summary>
+                <details class="">
+                    <summary class="text-right text-sm text-neutral-400">Think this data could be improved?</summary>
 
-                        <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
-                            Once a hosting provider gets verified with us, we ask them to keep
-                            their listing up to date and refresh their evidence at least annually.</p>
+                    <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
+                        We work with hosting providers to ensure the data shown here is correct 
+                        on submission, refreshed at least annually and made public. But like any dataset, 
+                        this data requires tending. 
+                         <a target="_blank" rel="noopener noreferrer" 
+                         href="https://www.thegreenwebfoundation.org/support/i-think-theres-an-error-in-the-green-web-dataset-what-can-i-do/">
+                         It can become incorrect</a> over time. That's when a little people power makes all the difference!</p>
 
-                        <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
-                            <span class="text-neutral-500">Are you a customer of this provider?</span> We find
-                            it helps most providers act more quickly if they receive a friendly prompt
-                            from you reminding them of the importance of this open data. Use our
-                            <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/sample-emails/">
-                                sample emails</a> to start a conversation.</p>
+                    <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
+                        <span class="text-neutral-500">Customers of this provider</span> - 
+                        a request coming from a customer to update the information visible here usually carries more weight than one coming from us.
+                        Use our
+                        <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/sample-emails/">
+                            sample emails</a> to start a conversation.</p>
 
-                        <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
-                            <span class="text-neutral-500">Do you work for this provider?</span>
-                            <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/support-form/?wpf2192_9=Update a listing in the Green Web Directory">
-                                Submit a correction</a> now.</p>
-
-                {% endif %}
+                    <p class="max-w-xs md:max-w-md text-sm text-justify ml-auto mr-0 mt-2 text-neutral-400">
+                        <span class="text-neutral-500">Provider staff</span> - 
+                        <a target="_blank" rel="noopener noreferrer" href="https://www.thegreenwebfoundation.org/support-form/?wpf2192_9=Update a listing in the Green Web Directory">
+                            submit a correction</a>.</p>
 
             </article>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,12 +16,11 @@ This site also provides a summary of the other main libraries maintained by the 
 [co2js]: https://github.com/thegreenwebfoundation/co2.js
 [grid-intensity-libraries]: https://github.com/thegreenwebfoundation?q=grid-intensity&type=all&language=&sort=
 
-### Getting started
+## Getting started
 
 Need to get going quickly? Start with [installation steps](installation.md), see [the answers to common questions](how-to.md), and if you need to push changes for review visit the [deployment instructions](deployment.md).
 
 ```{toctree}
-general.md
 installation.md
 how-to.md
 deployment.md
@@ -33,4 +32,7 @@ understanding-the flow-of-a-greencheck.md
 importers.md
 other-greenweb-software.md
 working-with-greenweb-datasets.md
+working-with-docker.md
+recurring-tasks.md
+troubleshooting.md
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 -i https://pypi.org/simple
-myst-parser==0.18.0
-furo==2022.6.21
-sphinxcontrib-mermaid==0.7.1
+myst-parser
+furo
+sphinxcontrib-mermaid

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+This page provides guidance about the various tooling we have for troubleshooting and debugging issues in the behaviour of our platform.
+
+The first things you need to know about are listed below
+
+
+- Our runbook
+- Running a django instance connected to production and staging environments
+- Sentry
+
+## Our runbook - steps to follow when dealing with a live issue in production
+
+We maintain a run book for troubleshooting live issues. It is listed in the private github repository used for maintaining our server infrastructure. If you're allowed to deploy to production, you should have access to this runbook, as well as the services it lists, like Loki/Grafna  for log aggregation, Sentry for exception tracking.
+
+See [the runbook](https://github.com/thegreenwebfoundation/infra/blob/master/docs/runbook.md)
+
+## Connecting a django instance to production / staging
+
+It is possible to connect a local development instance, or a hosted one on gitpod, to either the staging environment, or in some special cases to the production environment for reproducing and fixing issues.
+
+Use `dotenv`, passing in the path to the correct `dotenv` file, like `.env.prod` or `.env.staging` to run a command with different environment variables set - like connecting to a specific database, use a special DJANGO_SETTINGS config file, and so on.
+
+For example, if you are running a local dev environment, and you have a `.env` file called .`env.staging.local`, running the code below would run the basic django command, connected to the servers outlined in .`env.staging.local`. This would use whatever django settings file is specified in that file, i.e. a file at `greenweb/settings/staging.py`.
+
+```
+dotenv -f .env.prod.local run -- ./manage.py
+```
+
+
+## Sentry
+
+Sentry is set up to catch all uncaught exceptions in our software. In some cases, exceptions raised in dependencies are not caught, but handled in other error handling code that recovers from the error gracefully with a retry, but still shows up in our notification.
+
+This means that if there is an error visible in Sentry, it doesn't automatically mean a human  has seen a page fail to load, or an API has returned a 500.
+
+https://greenweb.sentry.io/issues/
+
+Still, exceptions where possible should be caught, to that isn't unsuably noisy.
+
+Where possible, we aim to follow the guidance in the Octopus Energy Style guide listed below
+
+https://github.com/octoenergy/public-conventions/blob/master/conventions/python.md#catching-exceptions
+
+### See also:
+
+
+https://www.loggly.com/blog/exceptional-logging-of-exceptions-in-python/

--- a/requirements/requirements.dev.in
+++ b/requirements/requirements.dev.in
@@ -21,8 +21,8 @@ sphinx-autobuild
 sphinxcontrib-mermaid
 # furo, myst-parser need to be pinned because
 # an underlying dependency, docutils needs a specific version of sphinx
-furo==2022.4.7
-myst-parser==0.18.0
+furo
+myst-parser
 ansible-lint
 django-browser-reload
 marimo


### PR DESCRIPTION
This tiny PR improves the filtering of providers when the Directory list is rendered.

The previous logic would only exclude providers who were marked as `showOnWebsite=false`. This exposed an edge case where providers might be archived (`archived=true`) however might still have the showOnWebsite variable set to true (`showOnWebsite=true`). In this case the provider would incorrectly be shown on the Directory even though they are archived.

This PR fixes that.