### PR TITLE
Ignore archived providers in Directory

### DIFF
--- a/apps/greencheck/views.py
+++ b/apps/greencheck/views.py
@@ -248,7 +248,10 @@ class DirectoryView(TemplateView):
         of providers
         """
 
-        queryset = Hostingprovider.objects.filter(showonwebsite=True).prefetch_related(
+        queryset = Hostingprovider.objects.filter(
+            showonwebsite=True,
+            archived=False
+        ).prefetch_related(
             "services"
         )
 


### PR DESCRIPTION
This update improves the filtering applied when generating the list of providers to show in the Directory.

It adds a condition to ignore all archived providers.