### PR TITLE
Put the carbon-txt-preview route behind a flag

### DIFF
--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from django.shortcuts import render
 from django.urls import path, reverse
 from django.views.generic.edit import FormView
-
+from waffle.mixins import WaffleFlagMixin
 
 from apps.greencheck.views import GreenUrlsView
 
@@ -88,10 +88,11 @@ class CarbonTxtForm(forms.Form):
                     )
 
 
-class CarbonTxtCheckView(LoginRequiredMixin, FormView):
+class CarbonTxtCheckView(WaffleFlagMixin, LoginRequiredMixin, FormView):
     template_name = "carbon_txt_preview.html"
     form_class = CarbonTxtForm
     success_url = "/admin/carbon-txt-preview"
+    waffle_flag = "carbon-txt-preview"
 
     def form_valid(self, form):
         """Show the valid"""
@@ -238,7 +239,6 @@ class GreenWebAdmin(AdminSite):
         if app_label:
             return app_list
 
-        
         verification_request_item = {
             "name": "New provider portal",
             "app_label": "greencheck",

--- a/apps/accounts/admin_site.py
+++ b/apps/accounts/admin_site.py
@@ -92,7 +92,7 @@ class CarbonTxtCheckView(WaffleFlagMixin, LoginRequiredMixin, FormView):
     template_name = "carbon_txt_preview.html"
     form_class = CarbonTxtForm
     success_url = "/admin/carbon-txt-preview"
-    waffle_flag = "carbon-txt-preview"
+    waffle_flag = "carbon_txt_preview"
 
     def form_valid(self, form):
         """Show the valid"""

--- a/apps/greencheck/tests/views/test_api_carbon_txt.py
+++ b/apps/greencheck/tests/views/test_api_carbon_txt.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 rf = APIRequestFactory()
 
+from waffle.testutils import override_flag
+
 
 @pytest.fixture
 def carbon_txt_string():
@@ -83,6 +85,18 @@ class TestCarbonTxtAPI:
         response = view_func(request)
 
         assert response.status_code == 200
+
+    @pytest.mark.parametrize("active,status_code", [(True, 200), (False, 404)])
+    def test_carbon_txt_preview_behind_flag(
+        self, db, settings, client, active, status_code
+    ):
+        """
+        Check that our preview is now behind a flag
+        """
+        with override_flag("carbon-txt-preview", active=active):
+            url_path = reverse("greenweb_admin:carbon_txt_preview")
+            response = client.get(url_path, follow=True)
+            assert response.status_code == status_code
 
 
 class TestProviderSharedSecretAPI:

--- a/apps/greencheck/tests/views/test_api_carbon_txt.py
+++ b/apps/greencheck/tests/views/test_api_carbon_txt.py
@@ -93,7 +93,7 @@ class TestCarbonTxtAPI:
         """
         Check that our preview is now behind a flag
         """
-        with override_flag("carbon-txt-preview", active=active):
+        with override_flag("carbon_txt_preview", active=active):
             url_path = reverse("greenweb_admin:carbon_txt_preview")
             response = client.get(url_path, follow=True)
             assert response.status_code == status_code


### PR DESCRIPTION
This pull request introduces the use of feature flags to control access to the CarbonTxt preview functionality. It adds the `WaffleFlagMixin` to the `CarbonTxtCheckView` class and includes tests to ensure the feature flag works as expected.

Feature flag implementation:

* [`apps/accounts/admin_site.py`](diffhunk://#diff-b831cb223efc314cdde38f09df715e010ce7f38af3a9d55b59810e01472ac979L15-R15): Added `WaffleFlagMixin` to `CarbonTxtCheckView` and set `waffle_flag` to "carbon-txt-preview". [[1]](diffhunk://#diff-b831cb223efc314cdde38f09df715e010ce7f38af3a9d55b59810e01472ac979L15-R15) [[2]](diffhunk://#diff-b831cb223efc314cdde38f09df715e010ce7f38af3a9d55b59810e01472ac979L91-R95)

Testing enhancements:

* [`apps/greencheck/tests/views/test_api_carbon_txt.py`](diffhunk://#diff-a82d34405ceea36496850c72d87601881c07c0ffcf225574d0a6f2719f8afb23R20-R21): Added `override_flag` import and a new test method `test_carbon_txt_preview_behind_flag` to verify the behavior of the CarbonTxt preview behind the feature flag. [[1]](diffhunk://#diff-a82d34405ceea36496850c72d87601881c07c0ffcf225574d0a6f2719f8afb23R20-R21) [[2]](diffhunk://#diff-a82d34405ceea36496850c72d87601881c07c0ffcf225574d0a6f2719f8afb23R89-R100)

Minor cleanup:

* [`apps/accounts/admin_site.py`](diffhunk://#diff-b831cb223efc314cdde38f09df715e010ce7f38af3a9d55b59810e01472ac979L241): Removed unnecessary whitespace in `get_app_list` method.