### PR TITLE
Catch ASN Parse error more gracefully

### DIFF
--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -23,7 +23,7 @@ import ipwhois
 import tld
 from django.utils import timezone
 from ipwhois.asn import IPASN
-from ipwhois.exceptions import IPDefinedError
+from ipwhois.exceptions import IPDefinedError, ASNParseError
 from ipwhois.net import Net
 
 from .choices import GreenlistChoice
@@ -309,7 +309,10 @@ class GreenDomainChecker:
 
         try:
             asn_result = self.asn_from_ip(ip_address)
-        except IPDefinedError:
+        except (ASNParseError, IPDefinedError) as ex:
+            logger.warning(
+                f"Unable to parse ASN for IP: {ip_address} - error type: {type(ex).__name__} {ex}"
+            )
             return False
         except Exception as err:
             logger.exception(err)


### PR DESCRIPTION
We recently saw a bunch of exceptions when looking up an ASN from IP addresses.

This handles them more gracefully while we investigate what's causing them.

This pull request includes changes to the `apps/greencheck` module to improve error handling and testing. The most important changes involve adding a new exception type to the imports, updating error handling in the `check_for_matching_asn` method, and adding a new test case to ensure the new error handling works as expected.

Improvements to error handling:

* [`apps/greencheck/domain_check.py`](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154L26-R26): Added `ASNParseError` to the list of imported exceptions.
* [`apps/greencheck/domain_check.py`](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154L312-R315): Updated the `check_for_matching_asn` method to handle `ASNParseError` and log a warning message when this exception occurs.

Enhancements to testing:

* [`apps/greencheck/tests/test_domain_checker.py`](diffhunk://#diff-7aaeab869d28717169fc0578f9c18bf920deb7ebeb1634677f2b1690552b3addR107-R120): Added a new test case `test_asn_from_ip_fails_gracefully_with_bad_asn_lookup` to verify that `ASNParseError` is caught and logged correctly.