### PR TITLE
Add richer set of errors caught

### DIFF
--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -23,7 +23,13 @@ import ipwhois
 import tld
 from django.utils import timezone
 from ipwhois.asn import IPASN
-from ipwhois.exceptions import IPDefinedError, ASNParseError
+from ipwhois.exceptions import (
+    IPDefinedError,
+    ASNParseError,
+    ASNRegistryError,
+    ASNOriginLookupError,
+    ASNLookupError,
+)
 from ipwhois.net import Net
 
 from .choices import GreenlistChoice
@@ -309,7 +315,14 @@ class GreenDomainChecker:
 
         try:
             asn_result = self.asn_from_ip(ip_address)
-        except (ASNParseError, IPDefinedError) as ex:
+
+        except (
+            ASNLookupError,
+            ASNParseError,
+            ASNRegistryError,
+            ASNOriginLookupError,
+            IPDefinedError,
+        ) as ex:
             logger.warning(
                 f"Unable to parse ASN for IP: {ip_address} - error type: {type(ex).__name__} {ex}"
             )

--- a/apps/greencheck/tests/test_domain_checker.py
+++ b/apps/greencheck/tests/test_domain_checker.py
@@ -104,19 +104,32 @@ class TestDomainChecker:
         assert isinstance(res, legacy_workers.SiteCheck)
         assert res.hosting_provider_id == green_asn.hostingprovider.id
 
-    def test_asn_from_ip_fails_gracefully_with_bad_asn_lookup(self, checker, caplog):
+    @pytest.mark.parametrize(
+        "error_type",
+        (
+            domain_check.ASNLookupError,
+            domain_check.ASNParseError,
+            domain_check.ASNRegistryError,
+            domain_check.ASNOriginLookupError,
+            domain_check.IPDefinedError,
+        ),
+    )
+    def test_asn_from_ip_fails_gracefully_with_bad_asn_lookup(
+        self, checker, caplog, error_type
+    ):
         """
         Sometimes calling lookup() on an IP address raises a ASNParseError.
         Do we catch this exception and log it?
         """
 
-        checker.asn_from_ip = mock.MagicMock(side_effect=domain_check.ASNParseError)
+        checker.asn_from_ip = mock.MagicMock(side_effect=error_type)
         with caplog.at_level(logging.WARNING):
             res = checker.check_for_matching_asn("23.32.24.203")
 
         assert res is False
         logged_error = caplog.text
-        assert "ASNParseError" in logged_error
+
+        assert error_type.__name__ in logged_error
 
     def test_with_green_domain_by_non_resolving_asn(self, green_asn, checker):
         """


### PR DESCRIPTION
This pull request includes updates to the `apps/greencheck` module to handle additional ASN-related exceptions and improve the robustness of the domain checker. The most important changes include expanding the list of exceptions handled in the `check_for_matching_asn` method and updating the corresponding tests to ensure all new exceptions are properly caught and logged.

### Exception Handling Improvements:

* [`apps/greencheck/domain_check.py`](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154L26-R32): Added new ASN-related exceptions (`ASNRegistryError`, `ASNOriginLookupError`, `ASNLookupError`) to the import list and updated the `check_for_matching_asn` method to handle these exceptions. [[1]](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154L26-R32) [[2]](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154L312-R325)

### Test Enhancements:

* [`apps/greencheck/tests/test_domain_checker.py`](diffhunk://#diff-7aaeab869d28717169fc0578f9c18bf920deb7ebeb1634677f2b1690552b3addL107-R132): Modified the `test_asn_from_ip_fails_gracefully_with_bad_asn_lookup` test to use `pytest.mark.parametrize` for testing multiple exception types, ensuring that all new exceptions are properly caught and logged.