### PR TITLE
Don't look up domains twice when skipping cache

### DIFF
--- a/apps/greencheck/viewsets.py
+++ b/apps/greencheck/viewsets.py
@@ -197,15 +197,12 @@ class GreenDomainViewset(viewsets.ReadOnlyModelViewSet):
 
             if not via_carbon_txt:
                 self.clear_from_caches(domain)
-
-            if http_response := self.build_response_from_full_network_lookup(domain):
+        else:
+            # Try the database green domain cache table first:
+            if http_response := self.build_response_from_database_lookup(domain):
                 return http_response
 
-        # Try the database green domain cache table first:
-        if http_response := self.build_response_from_database_lookup(domain):
-            return http_response
-
-        # not in cache table cache, try full lookup using network
+        # not in cache table cache (or skipped), try full lookup using network
         if http_response := self.build_response_from_full_network_lookup(domain):
             return http_response
 


### PR DESCRIPTION
Found this while working on #275 . It's a straightforward fix, and unrelated to the rest of the issue, so I thought I'd make a separate PR.

Currently, when the cache is skipped for the legacy API view, a full lookup will be done twice: once in the `if skip_cache:` block, and once after the database lookup fails. This PR also no longer unnecessarily does that lookup if the cache is skipped.