### PR TITLE
Fix docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 
 # ignore everything beginning with dot by default
 .*
+!.env.docker
 
 ansible*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11 as production
+FROM python:3.11 AS production
 
 # Update the package listing, so we know what packages exist
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN python -m pip install uv wheel --upgrade
 COPY --chown=deploy . .
 
 # Install dependencies via uv
-RUN uv pip install -r requirements/requirements.linux.generated.txt 
+RUN uv sync
 
 # Set up front end pipeline
 RUN python ./manage.py tailwind install

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,8 @@ COPY --chown=deploy . .
 COPY --chown=deploy .env.docker .env
 
 # Set up front end pipeline
-RUN python ./manage.py tailwind install
-RUN python ./manage.py tailwind build
+RUN dotenv run -- python ./manage.py tailwind install
+RUN dotenv run -- python ./manage.py tailwind build
 
 # Install the other node dependencies
 # TODO: we might not need node in production *at all* if we can generate 
@@ -69,7 +69,7 @@ RUN cd ./apps/theme/static_src/ && \
     npx rollup --config
 
 # Collect static files
-RUN python ./manage.py collectstatic --noinput --clear
+RUN dotenv run -- python ./manage.py collectstatic --noinput --clear
 
 # Use the shell form of CMD, so we have access to our environment variables
 # $GUNICORN_CMD_ARGS allows us to add additional arguments to the gunicorn command

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,12 +42,17 @@ RUN python -m venv $VIRTUAL_ENV
 # Add our python libraries for managing dependencies
 RUN python -m pip install uv wheel --upgrade
 
+# Copy just the pyproject.toml for uv sync.
+# That way, the next step can be cached until pyproject.toml changes.
+COPY --chown=deploy ./pyproject.toml ./pyproject.toml
+
+# Install dependencies via uv
+RUN uv sync
+
 # Copy application code, with dockerignore filtering out the stuff we don't want
 # from our final build artefact
 COPY --chown=deploy . .
 
-# Install dependencies via uv
-RUN uv sync
 
 # Set up front end pipeline
 RUN python ./manage.py tailwind install

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN uv sync
 # from our final build artefact
 COPY --chown=deploy . .
 
+# Copy envfile to the correct location.
+COPY --chown=deploy .env.docker .env
 
 # Set up front end pipeline
 RUN python ./manage.py tailwind install

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ USER deploy
 RUN python -m venv $VIRTUAL_ENV
 
 # Add our python libraries for managing dependencies
-uv 0.1.43 is triggering bad certificate errors, so we pin to 0.1.39
-RUN python -m pip install uv==0.1.39 wheel --upgrade
+RUN python -m pip install uv wheel --upgrade
 
 # Copy application code, with dockerignore filtering out the stuff we don't want
 # from our final build artefact


### PR DESCRIPTION
Fixes #173, #632

One thing this doesn't do yet is migrate, unlike the gitpod script. The reason for this is that we'd need the `db` container to be running already at that point.

Given that the docker container never did that, I decided to consider that out of scope.

I also made an optimization: installing dependencies after copying only the `pyproject.toml`, then copying the rest of the tree. This means that the installation step gets cached until the `pyproject.toml` is changed. This should significantly increase build speeds in most cases.