### PR TITLE
Add domain claim support for #638 

### DIFF
--- a/apps/greencheck/api/views.py
+++ b/apps/greencheck/api/views.py
@@ -8,7 +8,7 @@ from rest_framework import permissions, views
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.response import Response
 
-from apps.accounts.models import DomainHash
+from apps.accounts.models import DomainHash, Hostingprovider
 from apps.greencheck.models.checks import CO2Intensity, GreenDomain
 
 from ..serializers import (
@@ -205,8 +205,12 @@ class DomainClaimView(views.APIView):
     def post(self, request, format=None):
         domain = request.data.get("domain")
 
+        provider_id = request.data.get("provider")
+
+        provider = Hostingprovider.objects.get(id=provider_id)
+
         # try to claim the domain, and raise the exception if not
-        result = GreenDomain.claim_via_carbon_txt(domain)
+        result = GreenDomain.claim_via_carbon_txt(domain, provider)
 
         # our serializer serves the 'claimed' result if we have
         # GreenDomain entry, otherwise 'unclaimed'

--- a/apps/greencheck/api/views.py
+++ b/apps/greencheck/api/views.py
@@ -8,17 +8,16 @@ from rest_framework import permissions, views
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.response import Response
 
-from apps.accounts.models import Hostingprovider, DomainHash
+from apps.accounts.models import DomainHash
 from apps.greencheck.models.checks import CO2Intensity, GreenDomain
 
 from ..serializers import (
     CO2IntensitySerializer,
-    ProviderSharedSecretSerializer,
-    DomainHashSerializer,
     DomainClaimSerializer,
+    DomainHashSerializer,
+    ProviderSharedSecretSerializer,
 )
 from . import exceptions
-from .permissions import UserManagesHostingProvider
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +199,6 @@ class DomainClaimView(views.APIView):
     """
 
     permission_classes = [permissions.IsAuthenticated]
-
     serializer_class = DomainClaimSerializer
 
     @swagger_auto_schema(tags=["Domain Claim"])
@@ -210,8 +208,8 @@ class DomainClaimView(views.APIView):
         # try to claim the domain, and raise the exception if not
         result = GreenDomain.claim_via_carbon_txt(domain)
 
-        # our serializer serves the 'claimed' result if
-        # we have GreenDomain entry otherwise 'not'
+        # our serializer serves the 'claimed' result if we have
+        # GreenDomain entry, otherwise 'unclaimed'
         if not result:
             # for historical reasons, the domain is listed as url in
             # the GreenDomain model

--- a/apps/greencheck/domain_check.py
+++ b/apps/greencheck/domain_check.py
@@ -430,8 +430,17 @@ class GreenDomainChecker:
                     # exit the function as soon as we see our first valid via header
                     if "carbon.txt" in via_header:
                         return via_header
-            except httpx.TimeoutException:
-                pass
+            except httpx.TimeoutException as ex:
+                logger.warning(f"Timeout fetching: {uri.geturl()}. Error was: {ex}")
+            except httpx.ConnectError as ex:
+                logger.warning(
+                    f"Connection error fetching: {uri.geturl()}. Error was: {ex}"
+                )
+            # lay down the 'tarp' for any other errors
+            except Exception as ex:
+                logger.exception(
+                    f"Unexpected error fetching: {uri.geturl()}. Error was: {ex}"
+                )
 
         return False
 

--- a/apps/greencheck/exceptions.py
+++ b/apps/greencheck/exceptions.py
@@ -13,3 +13,10 @@ class NoSharedSecret(NotFound):
 
 class CarbonTxtFileNotFound(Exception):
     pass
+
+
+class NoMatchingDomainHash(NotFound):
+    """
+    An exception raised when we try to fetch a shared secret for a provider
+    but no shared secret has been set.
+    """

--- a/apps/greencheck/models/checks.py
+++ b/apps/greencheck/models/checks.py
@@ -571,7 +571,7 @@ class GreenDomain(models.Model):
             )
         except ac_models.Hostingprovider.DoesNotExist:
             logger.warning(
-                ("We expected to find a provider for this sitecheck, " "But didn't. ")
+                ("We expected to find a provider for this sitecheck, But didn't. ")
             )
             return cls.grey_result(domain=sitecheck.url)
 
@@ -586,7 +586,7 @@ class GreenDomain(models.Model):
         )
 
     @classmethod
-    def claim_via_carbon_txt(cls, domain):
+    def claim_via_carbon_txt(cls, domain, provider: ac_models.Hostingprovider):
         """
         Accept a domain, and try verifying it with the carbon.txt validator.
 
@@ -603,7 +603,10 @@ class GreenDomain(models.Model):
 
         checker = GreenDomainChecker()
 
-        domain_hash = ac_models.DomainHash.objects.filter(domain=domain)
+        domain_hash = ac_models.DomainHash.objects.filter(
+            domain=domain, provider=provider
+        )
+
         from ..exceptions import NoMatchingDomainHash
 
         if not domain_hash:

--- a/apps/greencheck/models/checks.py
+++ b/apps/greencheck/models/checks.py
@@ -197,7 +197,7 @@ class GreencheckIp(mu_models.TimeStampedModel):
 
     def archive(self) -> "GreencheckIp":
         """
-        Mark a GreencheckIp as inactive, as a softer alternative to deletion, 
+        Mark a GreencheckIp as inactive, as a softer alternative to deletion,
         returning the Greencheck IP for further processing.
         """
         self.active = False
@@ -206,7 +206,7 @@ class GreencheckIp(mu_models.TimeStampedModel):
 
     def unarchive(self) -> "GreencheckIp":
         """
-        Mark a GreencheckIp as inactive, as a softer alternative to deletion, 
+        Mark a GreencheckIp as inactive, as a softer alternative to deletion,
         returning the Greencheck IP for further processing.
         """
         self.active = True
@@ -398,7 +398,7 @@ class GreencheckASN(mu_models.TimeStampedModel):
 
     def archive(self) -> "GreencheckASN":
         """
-        Mark a GreencheckASN as inactive, as a softer alternative to deletion, 
+        Mark a GreencheckASN as inactive, as a softer alternative to deletion,
         returning the Greencheck ASN for further processing.
         """
         self.active = False
@@ -407,7 +407,7 @@ class GreencheckASN(mu_models.TimeStampedModel):
 
     def unarchive(self) -> "GreencheckASN":
         """
-        Mark a GreencheckASN as inactive, as a softer alternative to deletion, 
+        Mark a GreencheckASN as inactive, as a softer alternative to deletion,
         returning the Greencheck ASN for further processing.
         """
         self.active = True
@@ -578,6 +578,26 @@ class GreenDomain(models.Model):
             modified=timezone.now(),
             green=True,
         )
+
+    @classmethod
+    def claim_via_carbon_txt(cls, domain):
+        """
+        Accept a domain, and try verifying it with the carbon.txt validator.
+
+        We use the carbon.txt validator library to look up the domain, and
+        if there is the matching
+        domain we were expecting, we create the domain as "green domain" associated
+        with the provider that initially requested the domain hash.
+        """
+
+        # first of all, if there is no domain hash for the domain exit early - there is no
+        # point in trying to claim a domain hash for a domain that no provider has requested
+        # a domain hash for.
+        domain_hash = ac_models.DomainHash.objects.filter(domain=domain)
+        from ..exceptions import NoMatchingDomainHash
+
+        if not domain_hash:
+            raise NoMatchingDomainHash
 
     # Queries
     @property

--- a/apps/greencheck/models/checks.py
+++ b/apps/greencheck/models/checks.py
@@ -4,8 +4,6 @@ import logging
 import typing
 from dataclasses import dataclass
 
-import httpx
-
 from dateutil.relativedelta import relativedelta
 from django import forms
 from django.core import exceptions, validators
@@ -17,6 +15,7 @@ from django.utils.text import capfirst
 from django_mysql import models as dj_mysql_models
 from django_mysql import models as mysql_models
 from model_utils import models as mu_models
+
 from apps.greencheck.validators import validate_ip_range
 
 from ...accounts import models as ac_models

--- a/apps/greencheck/serializers.py
+++ b/apps/greencheck/serializers.py
@@ -5,10 +5,10 @@ from rest_framework.validators import UniqueValidator
 from taggit import serializers as tag_serializers
 
 from apps.accounts.models import (
+    DomainHash,
     Hostingprovider,
     HostingProviderSupportingDocument,
     ProviderSharedSecret,
-    DomainHash,
 )
 from apps.greencheck.models.checks import CO2Intensity
 

--- a/apps/greencheck/serializers.py
+++ b/apps/greencheck/serializers.py
@@ -235,7 +235,8 @@ class ProviderSharedSecretSerializer(serializers.ModelSerializer):
 
 
 class DomainHashSerializer(serializers.ModelSerializer):
-    domain_hash = serializers.CharField(source="hash")  # Map 'hash' to 'domain_hash'
+    # Map 'hash' to 'domain_hash'
+    domain_hash = serializers.CharField(source="hash")
 
     class Meta:
         model = DomainHash
@@ -243,4 +244,39 @@ class DomainHashSerializer(serializers.ModelSerializer):
             "domain_hash",
             "domain",
             "created",
+        ]
+
+
+class DomainClaimSerializer(serializers.ModelSerializer):
+    """
+    A Domain Claims represents a domain that has been ver
+    """
+
+    domain = serializers.CharField(source="url")
+    provider = serializers.CharField(source="hosted_by")
+    provider_id = serializers.IntegerField(source="hosted_by_id")
+    provider_website = serializers.CharField(source="hosted_by_website")
+    # used to determine the status dynamically based on if a GreeenDomain
+    # object is a 'real' one retrieved from the database. If so it counts
+    # as claimed.
+    status = serializers.SerializerMethodField()
+
+    def get_status(self, obj):
+        """
+        Determine the status of the domain claim.
+        If the object is a valid GreenDomain instance, return 'claimed'.
+        Otherwise, return 'unclaimed'.
+        """
+        return "claimed" if obj.pk else "unclaimed"
+
+    class Meta:
+        model = GreenDomain
+        fields = [
+            "domain",
+            "provider",
+            "provider_id",
+            "provider_website",
+            "status",
+            # TODO serve "created_at" field so people can see
+            # when a domain was created
         ]

--- a/apps/greencheck/tests/test_domain_claim.py
+++ b/apps/greencheck/tests/test_domain_claim.py
@@ -51,3 +51,35 @@ class TestGreenDomainClaim:
             resp = GreenDomain.claim_via_carbon_txt(hosted_site)
 
             assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
+
+        def test_claim_domain_with_dns_txt_record(self, user_with_provider, mocker):
+            """
+            Test that claiming a domain with a valid domain hash as a TXT record in DNS
+            is successful.
+            """
+
+            # Given: a hosted service that operates multiple domains
+            managed_service = "managed-service.com"
+
+            # Given: a website operated by the managing service above
+            hosted_site = "delegating-with-txt-record.carbontxt.org"
+
+            provider = user_with_provider.hosting_providers.first()
+            provider.refresh_shared_secret()
+
+            # And: the website has been associated with the provider
+            domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
+
+            # And DNS record has been set up for the domain with the correct hash added
+            # as a TXT record, and pointing to the managing service's carbon.txt file
+            mocker.patch(
+                "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
+                return_value=f"managed-service.com/carbon.txt {domain_hash.hash}",
+            )
+
+            # When: the managing service posts a request to verify the domain hash
+            # has been added to the domain's DNS record
+            resp = GreenDomain.claim_via_carbon_txt(hosted_site)
+
+            # Then: the domain show up as associated with the managed service provider
+            assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)

--- a/apps/greencheck/tests/test_domain_claim.py
+++ b/apps/greencheck/tests/test_domain_claim.py
@@ -1,81 +1,120 @@
 import pytest
+from guardian.shortcuts import assign_perm
 
+from apps.accounts.permissions import manage_provider
 from apps.greencheck.exceptions import NoMatchingDomainHash
 from apps.greencheck.models import GreenDomain
 
 
+@pytest.mark.django_db
 class TestGreenDomainClaim:
     """
     This code exercises the "domain claim" functionality in the platform, for
     carrying out a carbon.txt domain validation.
     """
 
-    @pytest.mark.django_db
-    class TestGreenDomainClaim:
+    def test_claim_domain_with_no_domain_hash(self):
         """
-        This code exercises the "domain claim" functionality in the platform, for
-        carrying out a carbon.txt domain validation.
+        Test that attempting to claim a domain without a corresponding domain hash
+        raises a NoMatchingDomainHash exception.
+        """
+        domain_name = "example.com"
+
+        with pytest.raises(NoMatchingDomainHash):
+            GreenDomain.claim_via_carbon_txt(domain_name, provider=None)
+
+    def test_claim_domain_with_via_header(self, user_with_provider, httpx_mock):
+        """
+        Test that claiming a domain with a valid domain hash in the 'via header'
+        is successful.
         """
 
-        def test_claim_domain_with_no_domain_hash(self):
-            """
-            Test that attempting to claim a domain without a corresponding domain hash
-            raises a NoMatchingDomainHash exception.
-            """
-            domain_name = "example.com"
+        managed_service = "managed-service.com"
+        hosted_site = "example.com"
 
-            with pytest.raises(NoMatchingDomainHash):
-                GreenDomain.claim_via_carbon_txt(domain_name, provider=None)
+        provider = user_with_provider.hosting_providers.first()
+        provider.refresh_shared_secret()
 
-        def test_claim_domain_with_via_header(self, user_with_provider, httpx_mock):
-            """
-            Test that claiming a domain with a valid domain hash in the 'via header'
-            is successful.
-            """
+        domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
 
-            managed_service = "managed-service.com"
-            hosted_site = "example.com"
+        httpx_mock.add_response(
+            url="https://example.com/carbon.txt",
+            headers={"Via": f"{managed_service}/carbon.txt {domain_hash.hash}"},
+        )
 
-            provider = user_with_provider.hosting_providers.first()
-            provider.refresh_shared_secret()
+        resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
 
-            domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
+        assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
 
-            httpx_mock.add_response(
-                url="https://example.com/carbon.txt",
-                headers={"Via": f"{managed_service}/carbon.txt {domain_hash.hash}"},
-            )
+    def test_claim_domain_with_dns_txt_record(self, user_with_provider, mocker):
+        """
+        Test that claiming a domain with a valid domain hash as a TXT record in DNS
+        is successful.
+        """
 
-            resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
+        # Given: a managed service that operates multiple domains
+        provider = user_with_provider.hosting_providers.first()
+        provider.refresh_shared_secret()
 
-            assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
+        # Given: a website operated by the managing service above
+        hosted_site = "delegating-with-txt-record.carbontxt.org"
 
-        def test_claim_domain_with_dns_txt_record(self, user_with_provider, mocker):
-            """
-            Test that claiming a domain with a valid domain hash as a TXT record in DNS
-            is successful.
-            """
+        # And: the website has been associated with the provider
+        domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
 
-            # Given: a managed service that operates multiple domains
-            provider = user_with_provider.hosting_providers.first()
-            provider.refresh_shared_secret()
+        # And DNS record has been set up for the domain with the correct hash added
+        # as a TXT record, and pointing to the managing service's carbon.txt file
+        mocker.patch(
+            "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
+            return_value=f"managed-service.com/carbon.txt {domain_hash.hash}",
+        )
 
-            # Given: a website operated by the managing service above
-            hosted_site = "delegating-with-txt-record.carbontxt.org"
+        # When: the managing service posts a request to verify the domain hash
+        # has been added to the domain's DNS record
+        resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
 
-            # And: the website has been associated with the provider
-            domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
+        # Then: the domain show up as associated with the managed service provider
+        assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
 
-            # And DNS record has been set up for the domain with the correct hash added
-            # as a TXT record, and pointing to the managing service's carbon.txt file
-            mocker.patch(
-                "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
-                return_value=f"managed-service.com/carbon.txt {domain_hash.hash}",
-            )
+    def test_claim_domain_with_two_competing_providers(
+        self, user_with_provider, hosting_provider_factory, user_factory, mocker
+    ):
+        """
+        We want to make sure that when we have two providers both trying to claim a
+        domain, we allocate the domain to the correct provider, based on the
+        domain hash found, not just the most recent provider to request.
+        """
 
-            # When: the managing service posts a request to verify the domain hash
-            # has been added to the domain's DNS record
-            resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
+        # Given: one 'correct' hosting provider
+        correct_provider = user_with_provider.hosting_providers.first()
+        correct_provider.refresh_shared_secret()
 
-            # Then: the domain show up as associated with the managed service provider
-            assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
+        # And: a 'sneaky' provider with a different user
+        sneaky_user = user_factory()
+        sneaky_provider = hosting_provider_factory(created_by=sneaky_user)
+        sneaky_provider.refresh_shared_secret()
+        assign_perm(manage_provider.codename, sneaky_user, sneaky_provider)
+
+        # And: a website that both providers want to claim
+        hosted_site = "site-with-competing-claims.example.com"
+
+        # And: both providers created domain hashes for the site
+        correct_domain_hash = correct_provider.create_domain_hash(
+            hosted_site, user_with_provider
+        )
+        domain_hash_2 = sneaky_provider.create_domain_hash(hosted_site, sneaky_user)
+
+        # When: the DNS record contains correct_provider's domain_hash
+        mocker.patch(
+            "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
+            return_value=f"correct_provider.example.com/carbon.txt {correct_domain_hash.hash}",
+        )
+
+        # Then: even when both providers try to claim the domain
+        resp = GreenDomain.claim_via_carbon_txt(hosted_site, correct_provider)
+        resp2 = GreenDomain.claim_via_carbon_txt(hosted_site, sneaky_provider)
+
+        # The domain should be associated with just the correct provider,
+        # as its hash was found
+        assert resp in GreenDomain.objects.filter(hosted_by_id=correct_provider.id)
+        assert resp not in GreenDomain.objects.filter(hosted_by_id=sneaky_provider.id)

--- a/apps/greencheck/tests/test_domain_claim.py
+++ b/apps/greencheck/tests/test_domain_claim.py
@@ -1,0 +1,36 @@
+import pytest
+
+from apps.greencheck.exceptions import NoMatchingDomainHash
+from apps.greencheck.models import GreenDomain
+
+
+class TestGreenDomainClaim:
+    """
+    This code exercises the "domain claim" functionality in the platform, for
+    carrying out a carbon.txt domain validation.
+    """
+
+    @pytest.mark.django_db
+    class TestGreenDomainClaim:
+        """
+        This code exercises the "domain claim" functionality in the platform, for
+        carrying out a carbon.txt domain validation.
+        """
+
+        def test_claim_domain_with_no_domain_hash(self):
+            """
+            Test that attempting to claim a domain without a corresponding domain hash
+            raises a NoMatchingDomainHash exception.
+            """
+            domain_name = "example.com"
+
+            with pytest.raises(NoMatchingDomainHash):
+                GreenDomain.claim_via_carbon_txt(domain_name)
+
+        def test_claim_domain_with_via_header(self):
+            """
+            Test that claiming a domain with a valid domain hash in the 'via header'
+            is successful.
+            """
+
+            pass

--- a/apps/greencheck/tests/test_domain_claim.py
+++ b/apps/greencheck/tests/test_domain_claim.py
@@ -25,7 +25,7 @@ class TestGreenDomainClaim:
             domain_name = "example.com"
 
             with pytest.raises(NoMatchingDomainHash):
-                GreenDomain.claim_via_carbon_txt(domain_name)
+                GreenDomain.claim_via_carbon_txt(domain_name, provider=None)
 
         def test_claim_domain_with_via_header(self, user_with_provider, httpx_mock):
             """
@@ -46,7 +46,7 @@ class TestGreenDomainClaim:
                 headers={"Via": f"{managed_service}/carbon.txt {domain_hash.hash}"},
             )
 
-            resp = GreenDomain.claim_via_carbon_txt(hosted_site)
+            resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
 
             assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)
 
@@ -75,7 +75,7 @@ class TestGreenDomainClaim:
 
             # When: the managing service posts a request to verify the domain hash
             # has been added to the domain's DNS record
-            resp = GreenDomain.claim_via_carbon_txt(hosted_site)
+            resp = GreenDomain.claim_via_carbon_txt(hosted_site, provider)
 
             # Then: the domain show up as associated with the managed service provider
             assert resp in GreenDomain.objects.filter(hosted_by_id=provider.id)

--- a/apps/greencheck/tests/test_domain_claim.py
+++ b/apps/greencheck/tests/test_domain_claim.py
@@ -2,8 +2,6 @@ import pytest
 
 from apps.greencheck.exceptions import NoMatchingDomainHash
 from apps.greencheck.models import GreenDomain
-from apps.accounts.models import DomainHash
-from pytest_httpx import HTTPXMock
 
 
 class TestGreenDomainClaim:
@@ -44,7 +42,7 @@ class TestGreenDomainClaim:
             domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)
 
             httpx_mock.add_response(
-                url=f"https://example.com/carbon.txt",
+                url="https://example.com/carbon.txt",
                 headers={"Via": f"{managed_service}/carbon.txt {domain_hash.hash}"},
             )
 
@@ -58,14 +56,12 @@ class TestGreenDomainClaim:
             is successful.
             """
 
-            # Given: a hosted service that operates multiple domains
-            managed_service = "managed-service.com"
+            # Given: a managed service that operates multiple domains
+            provider = user_with_provider.hosting_providers.first()
+            provider.refresh_shared_secret()
 
             # Given: a website operated by the managing service above
             hosted_site = "delegating-with-txt-record.carbontxt.org"
-
-            provider = user_with_provider.hosting_providers.first()
-            provider.refresh_shared_secret()
 
             # And: the website has been associated with the provider
             domain_hash = provider.create_domain_hash(hosted_site, user_with_provider)

--- a/apps/greencheck/tests/views/test_api_domain_claim.py
+++ b/apps/greencheck/tests/views/test_api_domain_claim.py
@@ -1,5 +1,5 @@
 import pytest
-from apps.accounts.models import DomainHash
+
 from apps.greencheck.models import GreenDomain
 
 

--- a/apps/greencheck/tests/views/test_api_domain_claim.py
+++ b/apps/greencheck/tests/views/test_api_domain_claim.py
@@ -25,7 +25,7 @@ class TestDomainclaimForProvider:
 
         domain_hash = provider.create_domain_hash(domain, user_with_provider)
 
-        payload = {"domain": domain}
+        payload = {"domain": domain, "provider": provider.id}
 
         mocker.patch(
             "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",

--- a/apps/greencheck/tests/views/test_api_domain_claim.py
+++ b/apps/greencheck/tests/views/test_api_domain_claim.py
@@ -1,0 +1,101 @@
+import pytest
+from apps.accounts.models import DomainHash
+from apps.greencheck.models import GreenDomain
+
+
+class TestDomainclaimForProvider:
+    """
+    Tests fo the domain claim APOI endpoint, to allow a domain to be 'claimed'
+    by a Provider that has already created a domain hash.
+    """
+
+    @pytest.mark.django_db
+    def test_successful_domain_claim_by_provider(
+        self, client, user_with_provider, mocker
+    ):
+        """
+        The happy path for claiming domain once a domain hash has
+        been created by a given provider.
+        """
+        # Given: A logged-in user associated with a hosting provider
+        client.force_login(user_with_provider)
+        provider = user_with_provider.hosting_providers.first()
+        provider.refresh_shared_secret()
+        domain = "example.com"
+
+        domain_hash = provider.create_domain_hash(domain, user_with_provider)
+
+        payload = {"domain": domain}
+
+        mocker.patch(
+            "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
+            return_value=f"managed-service.com/carbon.txt {domain_hash.hash}",
+        )
+
+        # When: The user sends a POST request to /api/v3/domain_claim/ for the domain
+        response = client.post(
+            "/api/v3/domain_claim/", payload, content_type="application/json"
+        )
+
+        # Then: The response should contain a domain, provider and meaningful status
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["domain"] == domain
+        assert response_data["provider"] == provider.name
+        assert response_data["provider_id"] == provider.id
+        assert response_data["provider_website"] == provider.website
+        assert response_data["status"] == "claimed"
+
+    @pytest.mark.django_db
+    def test_domain_claim_for_an_already_claimed_domain_by_a_provider(
+        self, client, user_with_provider, mocker
+    ):
+        """
+        If a domain already exists for that provider it should not be claimed again.
+        """
+        # Given: A logged-in user associated with a hosting provider
+        client.force_login(user_with_provider)
+        provider = user_with_provider.hosting_providers.first()
+        provider.refresh_shared_secret()
+        domain = "example.com"
+
+        domain_hash = provider.create_domain_hash(domain, user_with_provider)
+
+        payload = {"domain": domain}
+
+        mocker.patch(
+            "apps.greencheck.domain_check.GreenDomainChecker._lookup_domain_hash_with_dns",
+            return_value=f"managed-service.com/carbon.txt {domain_hash.hash}",
+        )
+
+        # When: The user sends a POST request to /api/v3/domain_claim/ for the domain
+        first_response = client.post(
+            "/api/v3/domain_claim/", payload, content_type="application/json"
+        )
+        # And: a second request is made for the same domain by the same provider
+        repeat_response = client.post(
+            "/api/v3/domain_claim/", payload, content_type="application/json"
+        )
+
+        # Then: Both responses should contain a domain, provider and meaningful status
+        for resp in [first_response, repeat_response]:
+            assert resp.status_code == 200
+            resp_data = resp.json()
+            assert resp_data["domain"] == domain
+            assert resp_data["provider"] == provider.name
+            assert resp_data["provider_id"] == provider.id
+            assert resp_data["provider_website"] == provider.website
+            assert resp_data["status"] == "claimed"
+
+        assert GreenDomain.objects.filter(hosted_by_id=provider.id).count() == 1
+
+    @pytest.mark.skip(reason="Not implemented")
+    @pytest.mark.django_db
+    def test_domain_claim_for_an_already_claimed_domain_by_a_provider(
+        self, client, user_with_provider, mocker
+    ):
+        """
+        When a different provider is able to demonstrate control over a domain
+        we reallocate the domain to them.
+        """
+        pass

--- a/apps/greencheck/tests/views/test_api_domain_claim.py
+++ b/apps/greencheck/tests/views/test_api_domain_claim.py
@@ -5,7 +5,7 @@ from apps.greencheck.models import GreenDomain
 
 class TestDomainclaimForProvider:
     """
-    Tests fo the domain claim APOI endpoint, to allow a domain to be 'claimed'
+    Tests for the domain claim API endpoint, to allow a domain to be 'claimed'
     by a Provider that has already created a domain hash.
     """
 
@@ -87,6 +87,7 @@ class TestDomainclaimForProvider:
             assert resp_data["provider_website"] == provider.website
             assert resp_data["status"] == "claimed"
 
+        # And: we should not have any duplicate domains created in our table
         assert GreenDomain.objects.filter(hosted_by_id=provider.id).count() == 1
 
     @pytest.mark.skip(reason="Not implemented")
@@ -98,4 +99,8 @@ class TestDomainclaimForProvider:
         When a different provider is able to demonstrate control over a domain
         we reallocate the domain to them.
         """
+
+        # Ideally this would rely on us being able to order green domains by
+        # created date. That would leave us with an audit trail of claimed domains
+        # rather than overwiting them with the most recent claim.
         pass

--- a/greenweb/urls.py
+++ b/greenweb/urls.py
@@ -119,11 +119,11 @@ urlpatterns += [
         api_views.DomainHashView.as_view(),
         name="carbon-txt-domain-hash",
     ),
-    # path(
-    #     "api/v3/domain_claim/",
-    #     api_views.DomainClaimView.as_view(),
-    #     name="carbon-txt-shared-secret",
-    # ),
+    path(
+        "api/v3/domain_claim/",
+        api_views.DomainClaimView.as_view(),
+        name="carbon-txt-domain-claim",
+    ),
     path(
         "api/v3/greencheckimage/<url>",
         image_views.greencheck_image,

--- a/justfile
+++ b/justfile
@@ -67,8 +67,13 @@ data_marimo_starter *options: _data_analysis_repo
 	# set up our start notebook with django initialised ready for queries
 	uv run marimo edit data-analysis/starter-notebook.py {{ options }}
 
+<<<<<<< Updated upstream
 # Run Marimo notebook session. This will not work inside a Github Codespace
 data_marimo *options: _data_analysis_repo
+=======
+# Run Marimo notebook session
+data_marimo *options: data_analysis_repo
+>>>>>>> Stashed changes
     uv run marimo {{ options }}
 
 # Run the django tests (with pytest), creating a test database using the `testing` settings.

--- a/justfile
+++ b/justfile
@@ -67,13 +67,8 @@ data_marimo_starter *options: _data_analysis_repo
 	# set up our start notebook with django initialised ready for queries
 	uv run marimo edit data-analysis/starter-notebook.py {{ options }}
 
-<<<<<<< Updated upstream
 # Run Marimo notebook session. This will not work inside a Github Codespace
 data_marimo *options: _data_analysis_repo
-=======
-# Run Marimo notebook session
-data_marimo *options: data_analysis_repo
->>>>>>> Stashed changes
     uv run marimo {{ options }}
 
 # Run the django tests (with pytest), creating a test database using the `testing` settings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ dependencies = [
     "django-guardian>=2.4.0",
     "drf-api-logger>=1.1.16",
     "urllib3>=2.2.3",
+    "httpx>=0.28.1",
+    "pytest-httpx>=0.35.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -55,12 +55,14 @@ dependencies = [
     { name = "freezegun" },
     { name = "geoip2" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "ipwhois" },
     { name = "iso3166" },
     { name = "markdown" },
     { name = "mysqlclient" },
     { name = "phpserialize" },
     { name = "pillow" },
+    { name = "pytest-httpx" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -156,12 +158,14 @@ requires-dist = [
     { name = "freezegun", specifier = ">=1.5.1" },
     { name = "geoip2", specifier = ">=4.8.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipwhois", specifier = ">=1.3.0" },
     { name = "iso3166", specifier = ">=2.1.1" },
     { name = "markdown", specifier = ">=3.7" },
     { name = "mysqlclient", specifier = "==2.1.1" },
     { name = "phpserialize", specifier = ">=1.3" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -1679,6 +1683,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.116.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2606,6 +2638,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442 },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2828,6 +2873,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012 },
     { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352 },
     { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344 },
+    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498 },
     { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205 },
     { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185 },
     { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433 },
@@ -2836,6 +2882,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497 },
     { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042 },
     { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831 },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692 },
     { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777 },
     { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523 },
     { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011 },
@@ -2844,6 +2891,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785 },
     { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017 },
     { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270 },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059 },
     { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583 },
     { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190 },
 ]


### PR DESCRIPTION
This PR introduces new _domain claim_ logic where the platform now attempts to verify a domain is associated with a provider by looking for the existence of a domain, and a domain hash derived from a combination of the domain and a secret value already associated with the provider.

This allows for programatically associating domain with a provider by either:

1. adding a special `via` header to the HTTP response headers for requests served at `hosted-website.com`
2. adding a DNS TXT record for the domain being looked up, to associated say... `hosted-website.com` with the provider


The first is intended to cover the case of a managed service provider already registered with the platform wanting to have their platform's sustainability credentials showing up when `hosted-website.com` is looked up, giving a 'green' result, rather than showing up as 'grey'.

The second allows for multiple domains controlled by a single organisation (in our case a hosting provider) to be associated with that provider, without needing to create carbon.txt files on every single domain.
Auto generated summary below:


---

This pull request introduces several changes across multiple files to enhance domain claim functionality, improve error handling, and add new tests. The most important changes include the addition of domain claim verification methods, new serializers, and related tests.

### Enhancements to domain claim functionality:

* [`apps/greencheck/api/views.py`](diffhunk://#diff-1509052d177b4feeced011bc5b0c2a26c9837bf7f33abfb09beb26f6b2272640L11-L20): Added `DomainClaimSerializer` and updated `DomainClaimView` to include a new `post` method for domain claims. [[1]](diffhunk://#diff-1509052d177b4feeced011bc5b0c2a26c9837bf7f33abfb09beb26f6b2272640L11-L20) [[2]](diffhunk://#diff-1509052d177b4feeced011bc5b0c2a26c9837bf7f33abfb09beb26f6b2272640L198-R224)
* [`apps/greencheck/models/checks.py`](diffhunk://#diff-61e01f39d103b1d71d9615b541b86bca72945c9f7c8d923aa450ac81a518eb64R589-R635): Added `claim_via_carbon_txt` method to `GreenDomain` for domain claim verification using carbon.txt.

### Improved error handling:

* [`apps/greencheck/exceptions.py`](diffhunk://#diff-5e10846abdb1db3ff4e8f3a740ce11d7a2b76df3267d94e334e573713b62ae60R16-R22): Added `NoMatchingDomainHash` exception for handling cases where no matching domain hash is found.
* [`apps/greencheck/api/views.py`](diffhunk://#diff-1509052d177b4feeced011bc5b0c2a26c9837bf7f33abfb09beb26f6b2272640L171-R174): Updated error handling in `post` method to raise `BadRequest` when a domain is not provided.

### New serializers:

* [`apps/greencheck/serializers.py`](diffhunk://#diff-ff853e2ba7b1ce8a3750b222ccc020e7b29b08ff79a22f443fc1a250e9af83bbR248-R282): Added `DomainClaimSerializer` to handle domain claim responses.

### New tests:

* [`apps/greencheck/tests/test_domain_claim.py`](diffhunk://#diff-11f454e7c29e132a3e477bf035ba074c1d4113665114506a2d9563549bd7b0ecR1-R120): Added tests for domain claim functionality, including cases with no domain hash, via header, DNS TXT record, and competing providers.

### Other changes:

* [`apps/greencheck/domain_check.py`](diffhunk://#diff-962c7da672ccda34a8739839ced1c68a0a9123743e584e2af98cbcc9a6c30154R398-R474): Added methods for verifying domain hash via DNS and HTTP headers.