### PR TITLE
Refactor accounts models

### DIFF
--- a/apps/accounts/models/hosting/__init__.py
+++ b/apps/accounts/models/hosting/__init__.py
@@ -1,0 +1,69 @@
+from django.db import models
+from model_utils.models import TimeStampedModel
+
+from .abstract import EvidenceType, Label
+from .datacenter import (
+    Datacenter,
+    DatacenterCertificate,
+    DatacenterClassification,
+    DatacenterCooling,
+    DataCenterLocation,
+    DatacenterNote,
+    DatacenterSupportingDocument,
+)
+from .provider import (
+    Hostingprovider,
+    HostingproviderCertificate,
+    HostingProviderNote,
+    HostingProviderSupportingDocument,
+    HostingCommunication,
+    DomainHash,
+    Service,
+    PartnerChoice,
+    ProviderSharedSecret,
+    DOMAIN_HASH_ISSUER_ID,
+    GREEN_VIA_CARBON_TXT,
+)
+
+class SupportMessage(TimeStampedModel):
+
+    """
+    A model to represent the different kind of support messages we use when
+    corresponding with providers and end users.
+    """
+
+    category = models.CharField(
+        max_length=255,
+        help_text="A category for this kind of message. For internal use",
+    )
+    subject = models.CharField(
+        max_length=255,
+        help_text=(
+            "The default subject of the email message. This is what "
+            "the user sees in their inbox"
+        ),
+    )
+    body = models.TextField(
+        help_text=(
+            "The default content of the message sent to the user. Supports markdown."
+        ),
+    )
+
+    def __str__(self):
+        return self.category
+
+class HostingproviderDatacenter(models.Model):
+    """Intermediary table between Datacenter and Hostingprovider"""
+
+    approved = models.BooleanField(default=False)
+    approved_at = models.DateTimeField(null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    datacenter = models.ForeignKey(Datacenter, null=True, on_delete=models.CASCADE)
+    hostingprovider = models.ForeignKey(
+        Hostingprovider, null=True, on_delete=models.CASCADE
+    )
+
+    class Meta:
+        db_table = "datacenters_hostingproviders"
+        # managed = False
+

--- a/apps/accounts/models/hosting/abstract.py
+++ b/apps/accounts/models/hosting/abstract.py
@@ -1,0 +1,118 @@
+from django.conf import settings
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+from taggit import models as tag_models
+from model_utils.models import TimeStampedModel
+from ..choices import EnergyType
+
+class Label(tag_models.TagBase):
+    """
+    The base tag class we need in order to create a separate set of
+    tags to use as internal labels
+    """
+
+    class Meta:
+        verbose_name = _("Label")
+        verbose_name_plural = _("Labels")
+
+
+class AbstractNote(TimeStampedModel):
+    """
+    Notes around domain objects, to allow admin
+    staff to add unstructured data, and links, and commentary
+    add commentary or link to other information relating to
+    """
+
+    added_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.PROTECT, null=True
+    )
+    body_text = models.TextField(blank=True)
+
+    def __str__(self):
+        added_at = self.created.strftime("%Y-%m-%d, %H:%M")
+        return f"Note, added by {self.added_by} at {added_at}"
+
+    class Meta:
+        abstract = True
+
+class EvidenceType(models.TextChoices):
+    """
+    Type of the supporting evidence, that certifies that green energy is used
+    """
+
+    ANNUAL_REPORT = "Annual report"
+    WEB_PAGE = "Web page"
+    CERTIFICATE = "Certificate"
+    OTHER = "Other"
+
+class AbstractSupportingDocument(models.Model):
+    """
+    When a hosting provider makes claims about running on green energy,
+    offsetting their emissions, and so on want to them to upload the
+    evidence.
+    We subclass this
+
+    """
+
+    title = models.CharField(
+        max_length=255,
+        help_text="Describe what you are listing, as you would to a user or customer.",
+    )
+    attachment = models.FileField(
+        upload_to="uploads/",
+        blank=True,
+        help_text=(
+            "If you have a sustainability report, or bill from a energy provider"
+            " provider, or similar certificate of supply from a green tariff add it"
+            " here."
+        ),
+    )
+    url = models.URLField(
+        blank=True,
+        help_text=(
+            "Alternatively, if you add a link, we'll fetch a copy at the URL you list,"
+            " so we can point to the version when you listed it"
+        ),
+    )
+    description = models.TextField(
+        blank=True,
+    )
+    valid_from = models.DateField()
+    valid_to = models.DateField()
+    type = models.CharField(choices=EvidenceType.choices, max_length=255, null=True)
+    public = models.BooleanField(
+        default=True,
+        help_text=(
+            "If this is checked, we'll add a link to this "
+            "document/page in your entry in the green web directory."
+        ),
+    )
+    archived = models.BooleanField(
+        default=False,
+        editable=False,
+        help_text=(
+            "If this is checked, this document will not show up in any queries. "
+            "Should not be editable via the admin interface by non-staff users."
+        ),
+    )
+
+    def __str__(self):
+        return f"{self.valid_from} - {self.title}"
+
+    class Meta:
+        abstract = True
+        verbose_name = "Supporting Document"
+
+class Certificate(models.Model):
+    energyprovider = models.CharField(max_length=255)
+    mainenergy_type = models.CharField(
+        max_length=255, db_column="mainenergytype", choices=EnergyType.choices
+    )
+    url = models.CharField(max_length=255)
+    valid_from = models.DateField()
+    valid_to = models.DateField()
+
+    class Meta:
+        abstract = True
+
+

--- a/apps/accounts/models/hosting/datacenter.py
+++ b/apps/accounts/models/hosting/datacenter.py
@@ -1,0 +1,219 @@
+from django.conf import settings
+from django.db import models
+from django.urls import reverse
+from django_countries.fields import CountryField
+from guardian.shortcuts import get_users_with_perms
+from ...permissions import manage_datacenter
+from ..choices import (
+    ClassificationChoice,
+    CoolingChoice,
+    ModelType,
+    TempType
+)
+from .abstract import AbstractNote, AbstractSupportingDocument, Certificate
+
+class Datacenter(models.Model):
+    country = CountryField(db_column="countrydomain")
+    dc12v = models.BooleanField()
+    greengrid = models.BooleanField()
+    mja3 = models.BooleanField(null=True, verbose_name="meerjaren plan energie 3")
+    model = models.CharField(max_length=255, choices=ModelType.choices)
+    name = models.CharField(max_length=255, db_column="naam")
+    pue = models.FloatField(verbose_name="Power usage effectiveness")
+    residualheat = models.BooleanField(null=True)
+    showonwebsite = models.BooleanField(verbose_name="Show on website", default=False)
+    temperature = models.IntegerField(null=True)
+    temperature_type = models.CharField(
+        max_length=255, choices=TempType.choices, db_column="temperaturetype"
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True
+    )
+    virtual = models.BooleanField()
+    website = models.CharField(max_length=255)
+
+    @property
+    def users(self) -> models.QuerySet["User"]:
+        """
+        Returns a QuerySet of Users who have permissions for a given Datacenter
+        """
+        return get_users_with_perms(
+            self, only_with_perms_in=(manage_datacenter.codename,)
+        )
+
+    @property
+    def users_explicit_perms(self) -> models.QuerySet["User"]:
+        """
+        Returns a QuerySet of all Users that have *explicit* permissions to manage this Datacenter,
+        not taking into consideration:
+            - group membership
+            - superuser status
+        """
+        return get_users_with_perms(
+            self,
+            only_with_perms_in=(manage_datacenter.codename,),
+            with_superusers=False,
+            with_group_users=False,
+        )
+
+    @property
+    def admin_url(self) -> str:
+        return reverse("greenweb_admin:accounts_datacenter_change", args=[str(self.id)])
+
+    @property
+    def city(self):
+        """
+        Return the city this datacentre is
+        placed in.
+        """
+        location = self.datacenterlocation_set.first()
+        if location:
+            return location.city
+        else:
+            return None
+
+    def legacy_representation(self):
+        """
+        Return a dictionary representation of datacentre,
+        suitable for serving in the older directory
+        API.
+        """
+
+        certificates = [
+            cert.legacy_representation() for cert in self.datacenter_certificates.all()
+        ]
+
+        return {
+            "id": self.id,
+            "naam": self.name,
+            "website": self.website,
+            "countrydomain": str(self.country),
+            "model": self.model,
+            "pue": self.pue,
+            "mja3": self.mja3,
+            # this needs a new table we don't have
+            "city": self.city,
+            "country": self.country.name,
+            # this lists through DatacenterCertificate
+            "certificates": certificates,
+            # the options below are deprecated
+            "classification": "DEPRECATED",
+            # this lists through DatacenterClassification
+            "classifications": ["DEPRECATED"],
+        }
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        db_table = "datacenters"
+        indexes = [
+            models.Index(fields=["name"], name="dc_name"),
+        ]
+        permissions = (manage_datacenter.astuple(),)
+
+
+class DatacenterClassification(models.Model):
+    # TODO if this is used to some extent, this should be m2m
+    classification = models.CharField(
+        max_length=255, choices=ClassificationChoice.choices
+    )
+    datacenter = models.ForeignKey(
+        Datacenter,
+        db_column="id_dc",
+        on_delete=models.CASCADE,
+        related_name="classifications",
+    )
+
+    def __str__(self):
+        return f"{self.classification} - related id: {self.datacenter_id}"
+
+    class Meta:
+        db_table = "datacenters_classifications"
+        # managed = False
+
+
+class DatacenterCooling(models.Model):
+    # TODO if this is used to some extent, this should ideally be m2m
+    cooling = models.CharField(max_length=255, choices=CoolingChoice.choices)
+    datacenter = models.ForeignKey(
+        Datacenter, db_column="id_dc", on_delete=models.CASCADE
+    )
+
+    def __str__(self):
+        return self.cooling
+
+    class Meta:
+        db_table = "datacenters_coolings"
+        # managed = False
+
+class DatacenterCertificate(Certificate):
+    datacenter = models.ForeignKey(
+        Datacenter,
+        db_column="id_dc",
+        null=True,
+        on_delete=models.CASCADE,
+        related_name="datacenter_certificates",
+    )
+
+    def legacy_representation(self):
+        """
+        Return the JSON representation
+        """
+        return {
+            "cert_valid_from": self.valid_from,
+            "cert_valid_to": self.valid_to,
+            "cert_url": self.url,
+        }
+
+    class Meta:
+        db_table = "datacenter_certificates"
+        # managed = False
+
+class DatacenterNote(AbstractNote):
+    """
+    A note model for information about a datacentre - like the hosting note,
+    but for annotating datacenters in the admin.
+    """
+
+    provider = models.ForeignKey(
+        Datacenter, null=True, on_delete=models.PROTECT, db_column="id_dc"
+    )
+
+class DatacenterSupportingDocument(AbstractSupportingDocument):
+    """
+    The concrete class for datacentre providers.
+    """
+
+    datacenter = models.ForeignKey(
+        Datacenter,
+        db_column="id_dc",
+        null=True,
+        on_delete=models.CASCADE,
+        related_name="datacenter_evidence",
+    )
+
+    @property
+    def parent(self):
+        return self.datacentre
+
+
+class DataCenterLocation(models.Model):
+    """
+    A join table linking datacentre cities
+    to the country.
+    """
+
+    city = models.CharField(max_length=255)
+    country = models.CharField(max_length=255)
+    datacenter = models.ForeignKey(
+        Datacenter, null=True, on_delete=models.CASCADE, db_column="id_dc"
+    )
+
+    def __str__(self):
+        return f"{self.city}, {self.country}"
+
+    class Meta:
+        verbose_name = "Datacentre Location"
+        db_table = "datacenters_locations"
+


### PR DESCRIPTION
That `hosting.py[ was getting quite unwieldy at over 1100 LOC, so i've had
a go at splitting it up: the external interface stays the same (as we
reexport everything used elsewhere in the codebase), but now the
"hosting" models are divided into a "datacentres" sub-package, a
"providers" sub-package, and an "abstract" sub-package for abstract
base classes shared by both. The "providers" package is still pretty
huge, at 700 LOC, but I think this makes things a little more
manageable, with room for further improvement.

@mrchrisadams, what do you think? This is meant as a bit of a
conversation-starter as much as anything - would you like to see some of
the larger files split up, or are you happy with everything in one
place?