### PR TITLE
Add ability to filter provider / verification requests via search

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1409,6 +1409,7 @@ class ProviderRequest(ActionInChangeFormMixin, admin.ModelAdmin):
         ProviderRequestIPRangeInline,
         ProviderRequestASNInline,
     ]
+    search_fields = ("name", "website")
     formfield_overrides = {TaggableManager: {"widget": LabelWidget(model=Service)}}
     empty_value_display = "(empty)"
     list_filter = ("status",)


### PR DESCRIPTION
One thing I realised when looking at verification requests in the a django admin was that it's not too easy to see all the requests made by a provider.

This introduces the ability to filter by the either the provider name, or the website.

The former make it easier to match a given provider, and the latter allows for cases when you have two providers with similar names, or when want to see all the providers who use the same tld, like `.nl` or `.com`