### PR TITLE
Eco ci update

### DIFF
--- a/.github/workflows/run-deploy-staging.yml
+++ b/.github/workflows/run-deploy-staging.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Eco CI Energy Estimation - Initialize
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: start-measurement
+        continue-on-error: true
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -69,3 +76,18 @@ jobs:
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
           API_URL: ${{ secrets.API_URL }}
           TRELLO_REGISTRATION_EMAIL_TO_BOARD_ADDRESS: ${{ secrets.TRELLO_REGISTRATION_EMAIL_TO_BOARD_ADDRESS }}
+
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: get-measurement
+          label: "ansible deploy staging"
+        continue-on-error: true
+
+      - name: Eco CI Energy Estimation - End Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: display-results
+          pr-comment: true
+          send-data: true
+        continue-on-error: true

--- a/.github/workflows/run-deploy.yml
+++ b/.github/workflows/run-deploy.yml
@@ -17,6 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Eco CI Energy Estimation - Initialize
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: start-measurement
+        continue-on-error: true
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -66,3 +73,18 @@ jobs:
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
           API_URL: ${{ secrets.API_URL }}
           TRELLO_REGISTRATION_EMAIL_TO_BOARD_ADDRESS: ${{ secrets.TRELLO_REGISTRATION_EMAIL_TO_BOARD_ADDRESS }}
+
+      - name: Eco CI Energy Estimation - Get Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: get-measurement
+          label: "ansible deploy"
+        continue-on-error: true
+
+      - name: Eco CI Energy Estimation - End Measurement
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
+        with:
+          task: display-results
+          pr-comment: true
+          send-data: true
+        continue-on-error: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,17 +46,14 @@ jobs:
 
     steps:
       - name: Eco CI Energy Estimation - Initialize
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: start-measurement
-          company-uuid: "7f1d34f0-7666-4378-8d8f-d37cced7ccb0"
-          project-uuid: "a9946d61-149b-4757-99e5-aaac24acf289"
-          machine-uuid: "90a9ec92-0884-43bc-8b98-9a7885864307"
         continue-on-error: true
 
       - uses: actions/checkout@v4
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: get-measurement
           label: "checkout"
@@ -68,7 +65,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: get-measurement
           label: "setup-python"
@@ -78,7 +75,7 @@ jobs:
         run: |
           python -m pip install --upgrade uv wheel
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: get-measurement
           label: "pip install uv wheel"
@@ -99,7 +96,7 @@ jobs:
           uv venv
           uv sync
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: get-measurement
           label: "pip install requirements"
@@ -125,15 +122,16 @@ jobs:
           EQUINIX_REMOTE_API_ENDPOINT: ${{ secrets.EQUINIX_REMOTE_API_ENDPOINT }}
           AWS_SHARED_CREDENTIALS_FILE: ${{ secrets.AWS_SHARED_CREDENTIALS_FILE }}
           AWS_CONFIG_FILE: ${{ secrets.AWS_CONFIG_FILE }}
+
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: get-measurement
           label: "pytest"
         continue-on-error: true
 
       - name: Eco CI Energy Estimation - End Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v4
         with:
           task: display-results
           pr-comment: true


### PR DESCRIPTION
Eco CI, which was used in the `run-tests.yml` workflow was quite outdated.

This PR:
- Moved Eco CI in the `run-tests.yml` workflow to `@v4`. This will also auto-update.
  - In case dependabot is active on the repo and auto-updating is not wanted the version can also be pinned to `@a2305b330063eddbf6fd758bb5a335a87c65d804` which is the lastest version as of now
  - Dependabot will then open a PR in case we release a new version
- Also this PR introcuced Eco CI to the other workflows. Since they only have one signifcant step only one Eco CI step was integrated.

Note: 
In the current implementation Eco CI cannot derive CO2 values. An Electricitymaps-token is needed for that.
In case you either have a paid mult-zone-token or still have an "old" Electricitymaps token from the time where it was still called `CO2-Signal` you can use it. Newer "free" tokens will sadly not work as they are zone restricted :/  

A sample integration would look like this:
```
      - name: Eco CI Energy Estimation - Initialize
        uses: green-coding-solutions/eco-ci-energy-estimation@v4
        with:
          task: start-measurement
          electricitymaps-api-token: ${{ secrets.ELECTRICITYMAPS_TOKEN }}
```

=> A secret should be used for the token and must be accessible for the workflow