### PR TITLE
Don't run the AWS network importer

### DIFF
--- a/ansible/templates/import_ips_for_large_providers.sh.j2
+++ b/ansible/templates/import_ips_for_large_providers.sh.j2
@@ -11,6 +11,6 @@ cd {{ project_root }}/current/
 
 # run our ip imports
 source .venv/bin/activate
-dotenv run -- ./manage.py update_networks_in_db_amazon
+#dotenv run -- ./manage.py update_networks_in_db_amazon
 dotenv run -- ./manage.py update_networks_in_db_google
 dotenv run -- ./manage.py update_networks_in_db_microsoft


### PR DESCRIPTION
Now we have archived the AWS provider, we don't want to update its IP ranges, as newly imported IPs are set as "active" leading to false positive "green" results.

See [this trello ticket](https://trello.com/c/0HcANMXF/555-aws-ip-ranges-still-active-returning-green-results-in-check?search_id=abcc8eb9-3ce2-4c61-bb30-c00253ca621f) for more details.