### PR TITLE
Add test to catch importing for archived providers

### DIFF
--- a/ansible/templates/import_ips_for_large_providers.sh.j2
+++ b/ansible/templates/import_ips_for_large_providers.sh.j2
@@ -11,6 +11,6 @@ cd {{ project_root }}/current/
 
 # run our ip imports
 source .venv/bin/activate
-#dotenv run -- ./manage.py update_networks_in_db_amazon
+dotenv run -- ./manage.py update_networks_in_db_amazon
 dotenv run -- ./manage.py update_networks_in_db_google
 dotenv run -- ./manage.py update_networks_in_db_microsoft

--- a/apps/greencheck/exceptions.py
+++ b/apps/greencheck/exceptions.py
@@ -20,3 +20,15 @@ class NoMatchingDomainHash(NotFound):
     An exception raised when we try to fetch a shared secret for a provider
     but no shared secret has been set.
     """
+
+
+class ImportingForArchivedProvider(Exception):
+    """
+    An exception raised when we try to import data for a provider
+    that has been archived.
+    """
+
+    default_detail = (
+        "This provider has been archived. Please unarchive it before importing data."
+    )
+    default_code = "archived_provider"

--- a/apps/greencheck/importers/network_importer.py
+++ b/apps/greencheck/importers/network_importer.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from apps.accounts.models import Hostingprovider
 from apps.greencheck.models import GreencheckASN, GreencheckIp
+from apps.greencheck import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -166,11 +167,19 @@ class NetworkImporter:
         created_green_ips = []
         created_asns = []
 
+        if self.hosting_provider.archived:
+            logger.warning(
+                f"Hosting provider {self.hosting_provider} is archived. "
+                f"Not importing any IPs or ASNs"
+            )
+            raise exceptions.ImportingForArchivedProvider(
+                f"{self.hosting_provider} is archived. To import IPs for this provider, unarchive it first."
+            )
+
         # Determine the type of address (IPv4, IPv6 or ASN) for
         # address in list_of_addresses:
         try:
             for address in list_of_addresses:
-
                 if is_ip_range(address):
                     # address looks like an IPv4 or IPv6 range
                     green_ip, created = self.save_ip(address)

--- a/apps/greencheck/management/commands/update_networks_in_db_amazon.py
+++ b/apps/greencheck/management/commands/update_networks_in_db_amazon.py
@@ -1,4 +1,5 @@
 from apps.greencheck.importers.importer_amazon import AmazonImporter
+from ...exceptions import ImportingForArchivedProvider
 from django.core.management.base import BaseCommand
 
 
@@ -7,7 +8,14 @@ class Command(BaseCommand):
         importer = AmazonImporter()
         data = importer.fetch_data_from_source()
         parsed_data = importer.parse_to_list(data)
-        result = importer.process(parsed_data)
+
+        try:
+            result = importer.process(parsed_data)
+        except ImportingForArchivedProvider:
+            self.stdout.write(
+                "The provider is archived. Skipping any further changes to this provider"
+            )
+            return None
 
         update_message = (
             f"Processing complete. Created {len(result['created_asns'])} ASNs,"

--- a/apps/greencheck/management/commands/update_networks_in_db_amazon.py
+++ b/apps/greencheck/management/commands/update_networks_in_db_amazon.py
@@ -1,6 +1,7 @@
-from apps.greencheck.importers.importer_amazon import AmazonImporter
-from ...exceptions import ImportingForArchivedProvider
 from django.core.management.base import BaseCommand
+
+from ...exceptions import ImportingForArchivedProvider
+from ...importers.importer_amazon import AmazonImporter
 
 
 class Command(BaseCommand):

--- a/apps/greencheck/management/commands/update_networks_in_db_google.py
+++ b/apps/greencheck/management/commands/update_networks_in_db_google.py
@@ -1,10 +1,7 @@
-import logging
-
 from django.core.management.base import BaseCommand
 
-from apps.greencheck.importers.importer_google import GoogleImporter
-
-logger = logging.getLogger(__name__)
+from ...exceptions import ImportingForArchivedProvider
+from ...importers.importer_google import GoogleImporter
 
 
 class Command(BaseCommand):
@@ -15,6 +12,14 @@ class Command(BaseCommand):
         data = importer.fetch_data_from_source()
         parsed_data = importer.parse_to_list(data)
         result = importer.process(parsed_data)
+
+        try:
+            result = importer.process(parsed_data)
+        except ImportingForArchivedProvider:
+            self.stdout.write(
+                "The provider is archived. Skipping any further changes to this provider"
+            )
+            return None
 
         update_message = (
             f"Processing complete. Created {len(result['created_asns'])} ASNs,"

--- a/apps/greencheck/management/commands/update_networks_in_db_microsoft.py
+++ b/apps/greencheck/management/commands/update_networks_in_db_microsoft.py
@@ -1,5 +1,7 @@
-from apps.greencheck.importers.importer_microsoft import MicrosoftImporter
 from django.core.management.base import BaseCommand
+
+from ...exceptions import ImportingForArchivedProvider
+from ...importers.importer_microsoft import MicrosoftImporter
 
 
 class Command(BaseCommand):
@@ -7,7 +9,14 @@ class Command(BaseCommand):
         importer = MicrosoftImporter()
         data = importer.fetch_data_from_source()
         parsed_data = importer.parse_to_list(data)
-        result = importer.process(parsed_data)
+
+        try:
+            result = importer.process(parsed_data)
+        except ImportingForArchivedProvider:
+            self.stdout.write(
+                "The provider is archived. Skipping any further changes to this provider"
+            )
+            return None
 
         update_message = (
             f"Processing complete. Created {len(result['created_asns'])} ASNs,"

--- a/apps/greencheck/tests/test_importer_amazon.py
+++ b/apps/greencheck/tests/test_importer_amazon.py
@@ -181,6 +181,6 @@ class TestAmazonImportCommand:
         call_command("update_networks_in_db_amazon", stdout=stdout)
 
         assert (
-            "The provider is archived. Skipping any further changes to ths provider"
+            "The provider is archived. Skipping any further changes to this provider"
             in stdout.getvalue()
         )


### PR DESCRIPTION
This pull request introduces a new exception to handle cases where data import is attempted for an archived hosting provider, along with the necessary updates to enforce this behavior and tests to validate it. The changes ensure better error handling and maintain data integrity by preventing imports for archived providers.

### New exception for archived providers:
* Added `ImportingForArchivedProvider` exception in `apps/greencheck/exceptions.py` to handle cases where data import is attempted for an archived provider. This includes a default error message and code.

### Updates to data import logic:
* Modified `process_addresses` in `apps/greencheck/importers/network_importer.py` to check if the hosting provider is archived. If archived, it logs a warning and raises the new `ImportingForArchivedProvider` exception.
* Imported the new exception in `apps/greencheck/importers/network_importer.py`.

### Tests for archived provider handling:
* Added a new test, `test_handle_with_archived_provider`, in `apps/greencheck/tests/test_importer_amazon.py` to ensure that attempting to import data for an archived provider raises the `ImportingForArchivedProvider` exception.
* Added necessary imports for testing in `apps/greencheck/tests/test_importer_amazon.py`.