### PR TITLE
Add a cron job to clear archived domains

### DIFF
--- a/ansible/setup_cronjobs.yml
+++ b/ansible/setup_cronjobs.yml
@@ -26,6 +26,13 @@
         mode: "0755"
       tags: [ip-importers]
 
+    - name: Upload archived domain pruning script
+      ansible.builtin.template:
+        src: clear_archived_domains.sh.j2
+        dest: /home/deploy/cronjobs/clear_archived_domains.sh
+        mode: "0755"
+      tags: [green-domains-exporter]
+
     - name: Upload green domain export script
       ansible.builtin.template:
         src: export_green_domains.sh.j2
@@ -57,6 +64,14 @@
             name: "green domains export STDERR",
             path: "/var/log/export_green_domains.error.log",
           }
+        - {
+            name: "clear archived domains STDOUT",
+            path: "/var/log/clear_archived_domains.log",
+          }
+        - {
+            name: "clear archived domains STDERR",
+            path: "/var/log/clear_archived_domains.error.log",
+          }
       tags: [ip-importers, green-domains-exporter]
 
     - name: Ensure job to run IP hyperscaler importers is present
@@ -68,9 +83,23 @@
         minute: "30"
         user: deploy
         job: >
-          bash /home/deploy/cronjobs/import_ips_for_large_providers.sh 
-          >> /var/log/import_ips_for_large_providers.log 
+          bash /home/deploy/cronjobs/import_ips_for_large_providers.sh
+          >> /var/log/import_ips_for_large_providers.log
           2>> /var/log/import_ips_for_large_providers.error.log
+      tags: [crontab]
+
+    - name: Ensure job to clear archived domains is present
+      ansible.builtin.cron:
+        name: "every day at 1:00 clear all archived domains"
+        state: present
+        weekday: "*"
+        hour: "1"
+        minute: "00"
+        user: deploy
+        job: >
+          bash /home/deploy/cronjobs/clear_archived_domains.sh
+          >> /var/log/clear_archived_domains.log
+          2>> /var/log/clear_archived_domains.error.log
       tags: [crontab]
 
     - name: Ensure job to export green domains is present
@@ -82,7 +111,7 @@
         minute: "30"
         user: deploy
         job: >
-          bash /home/deploy/cronjobs/export_green_domains.sh 
-          >> /var/log/export_green_domains.log 
+          bash /home/deploy/cronjobs/export_green_domains.sh
+          >> /var/log/export_green_domains.log
           2>> /var/log/export_green_domains.error.log
       tags: [crontab]

--- a/ansible/templates/clear_archived_domains.sh.j2
+++ b/ansible/templates/clear_archived_domains.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# {{ ansible_managed }}
+# Last run: {{ template_run_date }}
+
+# make sure we fail on any error
+set -euo pipefail
+
+# make sure we are in the right directory
+cd {{ project_root }}/current/
+
+# run the domains export and upload to object storage
+source .venv/bin/activate
+dotenv run -- python ./manage.py clear_archived_greendomains


### PR DESCRIPTION
one missing piece of the jigsaw in #658 was a cronjob to actually run the "archived greendomain purger" task periodically. This corrects that oversight :-)

