### PR TITLE
Update support email

### DIFF
--- a/.devcontainer/codespaces-compose.yaml
+++ b/.devcontainer/codespaces-compose.yaml
@@ -2,7 +2,7 @@ services:
   main:
     # we use the default codespaces image. this likely requires an x86
     # processor, so might not work on arm machines
-    image: "mcr.microsoft.com/devcontainers/universal:2"
+    image: "mcr.microsoft.com/devcontainers/universal:3"
   
     volumes:
       - ../..:/workspaces:cached

--- a/apps/accounts/models/hosting/provider.py
+++ b/apps/accounts/models/hosting/provider.py
@@ -518,7 +518,7 @@ class Hostingprovider(models.Model, DirtyFieldsMixin):
         msg = AnymailMessage(
             subject=subject,
             body=email_txt,
-            to=["support@thegreenwebfoundation.org"],
+            to=["support@greenweb.org"],
         )
 
         if email_html:

--- a/apps/accounts/templates/emails/migration_email.txt
+++ b/apps/accounts/templates/emails/migration_email.txt
@@ -4,7 +4,7 @@ Thank you for the contributions that you've made in the past to our hosting data
 
 Resetting your password for the Green Web Foundation hosting database will only take one minute. Please follow this secure link: https://admin.thegreenwebfoundation.org and follow the instructions there.
 
-Feel free to contact us at support@thegreenwebfoundation.org at any time if you have any questions.
+Feel free to contact us at support@greenweb.org at any time if you have any questions.
 
 Thanks in advance for your help!
 With best regards,

--- a/apps/accounts/templates/emails/new-linked-domain-notify.html
+++ b/apps/accounts/templates/emails/new-linked-domain-notify.html
@@ -5,7 +5,7 @@ What happens next?
 </p><p>
 We review new linked domains on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
 </p><p>
-If you have further questions, please contact <a href="mailto:support@thegreenwebfoundation.org">support@thegreenwebfoundation.org</a>.
+If you have further questions, please contact <a href="mailto:support@greenweb.org">support@greenweb.org</a>.
 </p><p>
 Many thanks,
 </p><p>

--- a/apps/accounts/templates/emails/new-linked-domain-notify.txt
+++ b/apps/accounts/templates/emails/new-linked-domain-notify.txt
@@ -2,6 +2,6 @@ Hello
 Thank you for taking the time to link the domain {{domain}} for {{ provider.name }} in the Green Web Dataset.
 What happens next?
 We review new linked domains on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
-If you have further questions, please contact support@thegreenwebfoundation.org.
+If you have further questions, please contact support@greenweb.org.
 Many thanks,
 Green Web Foundation

--- a/apps/accounts/templates/emails/verification-request-notify.html
+++ b/apps/accounts/templates/emails/verification-request-notify.html
@@ -30,7 +30,7 @@
     on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
 </p>
 <p>
-    If you have further questions, or need to edit your verification request,  please contact <a href="mailto:support@thegreenwebfoundation.org">support@thegreenwebfoundation.org</a>.
+    If you have further questions, or need to edit your verification request,  please contact <a href="mailto:support@greenweb.org">support@greenweb.org</a>.
 </p>
 <p>
     Many thanks,

--- a/apps/accounts/templates/emails/verification-request-notify.txt
+++ b/apps/accounts/templates/emails/verification-request-notify.txt
@@ -10,6 +10,6 @@ Thank you for taking the time to {% if provider %}update the listing for {{ prov
 {{ link_to_verification_request }}
 What happens next?
 We review {% if provider %}provider updates{% else %}new verification requests{% endif %} on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
-If you have further questions, or need to edit your verification request,  please contact support@thegreenwebfoundation.org.
+If you have further questions, or need to edit your verification request,  please contact support@greenweb.org.
 Many thanks,
 Green Web Foundation

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -417,7 +417,7 @@ def test_wizard_sends_email_on_submission(
 
     # then: and our email is addressed to the people we expect it to be
     assert user.email in eml.to
-    assert "support@thegreenwebfoundation.org" in eml.cc
+    assert "support@greenweb.org" in eml.cc
 
     # then: and our email has the subject and copy we were expecting
     assert "Your Green Web Dataset verification request:" in eml.subject

--- a/apps/accounts/utils.py
+++ b/apps/accounts/utils.py
@@ -54,7 +54,7 @@ def send_email(address, subject, context, template_txt, template_html=None, bcc=
         subject=subject,
         body=email_body,
         to=[address],
-        cc=["support@thegreenwebfoundation.org"],
+        cc=["support@greenweb.org"],
     )
 
     if bcc:

--- a/apps/greencheck/swagger.py
+++ b/apps/greencheck/swagger.py
@@ -26,7 +26,7 @@ schema_view = get_schema_view(
         ),
         default_version="v3",
         terms_of_service="https://www.thegreenwebfoundation.org/privacy-statement/",
-        contact=openapi.Contact(email="support@thegreenwebfoundation.org"),
+        contact=openapi.Contact(email="support@greenweb.org"),
         license=openapi.License(name="License: Apache 2.0. "),
         x_logo={
             "url": "https://www.thegreenwebfoundation.org/wp-content/themes/tgwf2015/img/top-logo-greenweb.png",  # noqa

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -281,7 +281,7 @@ TIME_ZONE = "UTC"
 USE_I18N = True
 
 # Email settings
-DEFAULT_FROM_EMAIL = "support@thegreenwebfoundation.org"
+DEFAULT_FROM_EMAIL = "support@greenweb.org"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/dev/howto/static-files/

--- a/templates/partials/nav_menu.html
+++ b/templates/partials/nav_menu.html
@@ -18,7 +18,7 @@
           <a href="{% url 'schema-swagger-ui' %}">API Documentation</a>
         </li>
         <li class="nav-item">
-          <a href="mailto:support@thegreenwebfoundation.org">Contact</a>
+          <a href="mailto:support@greenweb.org">Contact</a>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
Updates the support mailbox address to the new `@greenweb` domain.

The change applies to:
- Email templates
- Email sending functions
- Some page partials

This PR also includes a small update to the GitHub Workspaces compose file:

- Updates the image version to `universal:3`

This change was made because the initial build using `universal:2` was failing. Using `universal:3` the Codespace gets created successfully, however it does take around 8 minutes for this complete!