### PR TITLE
Remove away message - April 2026

### DIFF
--- a/apps/accounts/templates/emails/verification-request-notify.html
+++ b/apps/accounts/templates/emails/verification-request-notify.html
@@ -29,7 +29,6 @@
     {% endif %}
     on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
 </p>
-<p><strong>Note: Members of our team are currently on leave. As a result, it will take longer than normal to for verification requests to be processed. You should hear back from us regarding any verification requests or updates by April 29th, 2026.</strong></p>
 <p>
     If you have further questions, or need to edit your verification request,  please contact <a href="mailto:support@greenweb.org">support@greenweb.org</a>.
 </p>

--- a/apps/accounts/templates/emails/verification-request-notify.txt
+++ b/apps/accounts/templates/emails/verification-request-notify.txt
@@ -10,7 +10,6 @@ Thank you for taking the time to {% if provider %}update the listing for {{ prov
 {{ link_to_verification_request }}
 What happens next?
 We review {% if provider %}provider updates{% else %}new verification requests{% endif %} on Tuesday each week. Once we have reviewed the request, we will contact you by email to let you know that it is approved, or that we need more information from you.
-Note: Members of our team are currently on leave. As a result, it will take longer than normal to for verification requests to be processed. You should hear back from us regarding any verification requests or updates by April 29th, 2026.
 If you have further questions, or need to edit your verification request,  please contact support@greenweb.org.
 Many thanks,
 Green Web Foundation

--- a/apps/accounts/templates/provider_portal/before_starting.html
+++ b/apps/accounts/templates/provider_portal/before_starting.html
@@ -31,13 +31,8 @@
 			<p class="text-neutral-600">The same applies to submitting IP/ASN ranges via api.</p> 
 		</section>
 		
-		{% comment %} <h3 class="font-bold text-xl uppercase mt-12">Ready?</h3>
-		<p>After submission of your request, you can expect to hear from us within a week.</p> {% endcomment %}
-
-		<div class="alert__warning">
-            <p>We'll get back to you soon</p>
-            <p>Members of our team are currently on leave. As a result, it will take longer than normal to for verification requests to be processed. You should hear back from us regarding any verification requests or updates by April 29th, 2026. </p>
-          </div>
+		<h3 class="font-bold text-xl uppercase mt-12">Ready?</h3>
+		<p>After submission of your request, you can expect to hear from us within a week.</p>
 
 
 		<a href="{% url 'provider_registration' %}" class="btn font-bold">Begin form</a>

--- a/apps/accounts/templates/provider_registration/preview.html
+++ b/apps/accounts/templates/provider_registration/preview.html
@@ -104,12 +104,7 @@
         </section>
       </div>
 
-      <div class="alert__warning">
-            <p>We'll get back to you soon</p>
-            <p>Members of our team are currently on leave. As a result, it will take longer than normal to for verification requests to be processed. You should hear back from us regarding any verification requests or updates by April 29th, 2026. </p>
-          </div>
-
-      <input class="btn" type="submit" value="{% trans " submit" %}" />
+            <input class="btn" type="submit" value="{% trans " submit" %}" />
 
       {% if wizard.steps.prev %}
         <div>


### PR DESCRIPTION
Removes a message to the first and last pages of the verification flow, as well as to the verification review email to notify users that their request will take longer than normal to be reviewed.