### PR TITLE
Remove old deprecated API token code

### DIFF
--- a/apps/greencheck/tests/test_api.py
+++ b/apps/greencheck/tests/test_api.py
@@ -4,7 +4,6 @@ import pytest
 from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from rest_framework.authtoken import models, views
 from rest_framework.test import APIRequestFactory
 
 from ...accounts import models as ac_models
@@ -16,36 +15,6 @@ pytestmark = pytest.mark.django_db
 logger = logging.getLogger(__name__)
 
 rf = APIRequestFactory()
-
-
-class TestUsingAuthToken:
-    def test_fetching_auth_token(
-        self,
-        hosting_provider: ac_models.Hostingprovider,
-        sample_hoster_user: User,
-    ):
-        """
-        Anyone who is able to update an organisation is able to
-        generate an API token.
-        """
-        hosting_provider.save()
-
-        # set up our views, request factories and paths
-        rf = APIRequestFactory()
-        url_path = reverse("api-obtain-token")
-        view = views.ObtainAuthToken.as_view()
-
-        # create our request
-        credentials = {"username": sample_hoster_user.username, "password": "topSekrit"}
-        request = rf.post(url_path, credentials)
-
-        response = view(request)
-        token = models.Token.objects.get(user=sample_hoster_user)
-
-        # check contents, is the token the right token?
-        assert response.status_code == 200
-        assert response.data["token"] == token.key
-
 
 class TestCORSforAPI:
     def test_requests_have_permissive_cors_enabled_for_api(

--- a/greenweb/settings/common.py
+++ b/greenweb/settings/common.py
@@ -102,7 +102,6 @@ INSTALLED_APPS = [
     "django_mysql",
     "django_registration",
     "rest_framework",
-    "rest_framework.authtoken",
     "rest_framework_api_key",
     "drf_yasg",
     "corsheaders",

--- a/greenweb/urls.py
+++ b/greenweb/urls.py
@@ -37,7 +37,6 @@ from apps.greencheck.api import image_views
 from apps.greencheck.api import views as api_views
 from apps.accounts.views import LabelAutocompleteView
 from apps.accounts import urls as accounts_urls
-from rest_framework.authtoken import views
 
 from apps.greencheck import urls as greencheck_urls, directory_urls
 from apps.theme.views import style_guide
@@ -126,7 +125,6 @@ urlpatterns += [
         image_views.legacy_greencheck_image,
         name="greencheck-image-legacy",
     ),
-    path("api-token-auth/", views.obtain_auth_token, name="api-obtain-token"),
     path(
         "api-docs/",
         TGWFSwaggerView.with_ui("swagger", cache_timeout=0),


### PR DESCRIPTION
This removes the old apitokens support (not actually used for auth anywhere).

Some users have tokens, see [this database table](https://admin.thegreenwebfoundation.org/explorer/41/), and we get very infrequent requests to the api-token-auth endpoint (see [grafana](https://grafana.greenweb.org/explore?schemaVersion=1&panes=%7B%22wjq%22:%7B%22datasource%22:%22H0yiLpF7z%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bunit%3D%5C%22web_prod.service%5C%22%7D%20%7C%3D%20%60api-token-auth%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22H0yiLpF7z%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now%2Fy%22,%22to%22:%22now%2Fy%22%7D%7D%7D&orgId=1)). Therefore we should contact these users before merging to advise them that this is going away. 