### PR TITLE
Fix 500's when visiting pages guarded by is_admin

### DIFF
--- a/apps/accounts/apps.py
+++ b/apps/accounts/apps.py
@@ -3,3 +3,10 @@ from django.apps import AppConfig
 
 class AccountsConfig(AppConfig):
     name = "apps.accounts"
+
+    def ready(self):
+        # Patch AnonymousUser so that code accessing `request.user.is_admin`
+        # does not raise AttributeError for unauthenticated users.
+        from django.contrib.auth.models import AnonymousUser
+
+        AnonymousUser.is_admin = property(lambda self: False)

--- a/apps/accounts/tests/test_autocomplete.py
+++ b/apps/accounts/tests/test_autocomplete.py
@@ -101,3 +101,33 @@ class TestLinkedProviderAutocompleteView:
         texts = [r["text"] for r in results]
         assert "Green Web" in texts
         assert "Grey Web" not in texts
+
+
+@pytest.mark.django_db
+class TestProviderAutocompleteView:
+    def test_unauthenticated_user_gets_empty_results(self, client):
+        """
+        Given an unauthenticated user,
+        when they hit the provider autocomplete endpoint,
+        then they get an empty result set and no 500 error is raised.
+        """
+        url = reverse("provider-autocomplete")
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+
+
+@pytest.mark.django_db
+class TestLabelAutocompleteView:
+    def test_unauthenticated_user_gets_empty_results(self, client):
+        """
+        Given an unauthenticated user,
+        when they hit the label autocomplete endpoint,
+        then they get an empty result set and no 500 error is raised.
+        """
+        url = reverse("label-autocomplete")
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.json()["results"] == []

--- a/apps/accounts/tests/test_explorer.py
+++ b/apps/accounts/tests/test_explorer.py
@@ -31,3 +31,19 @@ def test_explorer_staff_user_can_access(greenweb_staff_user, client):
     assert response.status_code == 200
     # we can't just rely on having a 200, as described before
     assert "not authorized to access this page" not in response.content.decode("utf8")
+
+
+@pytest.mark.django_db
+def test_explorer_anonymous_user_does_not_500(client):
+    """
+    Given an anonymous user, when they access the explorer index,
+    then they are presented with the admin login page and no 500 error is raised.
+    The EXPLORER_PERMISSION_VIEW lambda calls request.user.is_admin, which
+    would previously raise AttributeError on AnonymousUser.
+    """
+    explorer_url = urls.reverse("explorer_index")
+    response = client.get(explorer_url)
+
+    content = response.content.decode("utf8")
+    assert response.status_code == 200
+    assert "Log in | Django site admin" in content

--- a/apps/accounts/tests/test_models.py
+++ b/apps/accounts/tests/test_models.py
@@ -17,6 +17,7 @@ from storages.backends.s3 import S3Storage
 #  or form level.
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 
 User = get_user_model()
 
@@ -435,6 +436,17 @@ class TestHostingProviderEvidence:
         object_storage_bucket_mock.assert_called_with(bucket_name)
         bucket.Object.assert_called_with(evidence.attachment.name)
         bucket.Object.return_value.Acl.return_value.put.assert_called_with(ACL="private")
+
+
+class TestAnonymousUser:
+    def test_anonymous_user_is_admin_returns_false(self):
+        """
+        Given an AnonymousUser instance,
+        when accessing the is_admin property,
+        then it returns False without raising an AttributeError.
+        """
+        anon = AnonymousUser()
+        assert anon.is_admin is False
 
 
 class TestUser:

--- a/apps/accounts/tests/test_provider_request.py
+++ b/apps/accounts/tests/test_provider_request.py
@@ -2673,3 +2673,19 @@ def test_request_detail_shows_upstream_providers_when_flag_is_on(
     content = response.content.decode()
     assert "Linked providers" in content
     assert "Upstream Provider" in content
+
+
+@pytest.mark.django_db
+def test_provider_edit_anonymous_user_does_not_500(client, hosting_provider_factory):
+    """
+    Given an anonymous user and an existing hosting provider,
+    when they access the provider edit URL,
+    then they are redirected to the login page and no 500 error is raised.
+    The dispatch method accesses request.user.is_admin,
+    which would previously raise AttributeError on AnonymousUser.
+    """
+    provider = hosting_provider_factory.create()
+    edit_url = urls.reverse("provider_edit", args=[provider.id])
+    response = client.get(edit_url)
+
+    assert response.status_code == 302


### PR DESCRIPTION
At the moment, visiting some paths like the SQL explorer path used by our staff , and Some user facing paths like the provide a request update wizard ones can trigger 500 errors, because we often check for `is_admin` when we do some of our access checks. 

The default anonymous user does not have this method, and trying to call it raises an exception, triggering the 500. 

This change introduces a more graceful fallback, and verifies that the pages that were throwing errors no longer throw errors. 

Machine generated summary below

----


This pull request addresses issues where code was assuming the presence of an is_admin property on Django's AnonymousUser, which previously caused AttributeError exceptions for unauthenticated users. The main change is a patch to AnonymousUser to ensure is_admin always exists and returns False, preventing errors across the application. Additional tests have been added to verify that unauthenticated users do not trigger server errors when accessing certain endpoints.

Key changes:

**AnonymousUser patching:**
* Added a patch in `apps/accounts/apps.py` so that `AnonymousUser.is_admin` always returns `False`, preventing AttributeError when code checks `request.user.is_admin` for unauthenticated users.

**Testing improvements:**
* Added a test in `apps/accounts/tests/test_models.py` to confirm that `AnonymousUser.is_admin` returns `False` and does not raise an error.
* Added tests for provider and label autocomplete endpoints to ensure unauthenticated users receive empty results and no 500 errors are raised.
* Added a test to ensure that an anonymous user accessing the explorer index page is shown the login page without a 500 error.
* Added a test to verify that anonymous users attempting to access the provider edit URL are redirected to login and do not cause a 500 error.

**Test setup:**
* Imported `AnonymousUser` in `apps/accounts/tests/test_models.py` for use in new tests.