### PR TITLE
Switch flag handling to enable individual activation of flags

### DIFF
--- a/src/apps/accounts/forms/provider_request_wizard.py
+++ b/src/apps/accounts/forms/provider_request_wizard.py
@@ -371,11 +371,11 @@ class CredentialForm(AlwaysChangedModelFormMixin, forms.ModelForm):
     """
     Per-row form used inside the green evidence formset.
 
-    Accepts an optional ``request`` kwarg so the ``verification_basis_v2``
-    waffle flag can be consulted to decide whether to show the
-    ``fossil_free_energy_matching`` and ``claim_coverage_percentage``
-    fields. When the flag is off, both fields are popped so the flag-OFF
-    rendering is byte-identical to the legacy form.
+    Accepts an optional ``request`` kwarg so the
+    ``verification_basis_v2_hourly_annual`` waffle flag can be consulted to
+    decide whether to show the ``fossil_free_energy_matching`` and
+    ``claim_coverage_percentage`` fields. When the flag is off, both fields
+    are popped so the flag-OFF rendering is byte-identical to the legacy form.
     """
 
     fossil_free_energy_matching = forms.ChoiceField(
@@ -441,7 +441,7 @@ class CredentialForm(AlwaysChangedModelFormMixin, forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         show_matching_fields = request is not None and flag_is_active(
-            request, "verification_basis_v2"
+            request, "verification_basis_v2_hourly_annual"
         )
         if not show_matching_fields:
             self.fields.pop("fossil_free_energy_matching", None)
@@ -813,10 +813,11 @@ class OrgDetailsForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         """
-        Accepts an optional ``request`` kwarg so the ``verification_basis_v2``
-        waffle flag can be consulted to decide whether to show the
-        ``public_2030_target_url`` field. When the flag is off, the field is
-        popped so flag-OFF rendering stays byte-identical to the legacy form.
+        Accepts an optional ``request`` kwarg so the
+        ``verification_basis_v2_fossil_free_2030`` waffle flag can be
+        consulted to decide whether to show the ``public_2030_target_url``
+        field. When the flag is off, the field is popped so flag-OFF rendering
+        stays byte-identical to the legacy form.
         """
         from waffle import flag_is_active
 
@@ -824,7 +825,7 @@ class OrgDetailsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         show_field = request is not None and flag_is_active(
-            request, "verification_basis_v2"
+            request, "verification_basis_v2_fossil_free_2030"
         )
         if not show_field:
             self.fields.pop("public_2030_target_url", None)

--- a/src/apps/accounts/migrations/0104_create_verification_basis_v2_flag.py
+++ b/src/apps/accounts/migrations/0104_create_verification_basis_v2_flag.py
@@ -24,8 +24,14 @@ def create_verification_basis_v2_flag(apps, schema_editor):
             "authenticated": False,
             "note": (
                 "Controls visibility of October 2026 verification basis criteria "
-                "in request forms. Set everyone=None (default) for per-user/per-group "
-                "rollout; flip everyone=True for the global October 2026 switchover."
+                "in request forms (get_active_version, upstream_providers field, "
+                "legacy slug conversion, upstream_section_enabled template tag, "
+                "and the evidence intro text swap). Note: the fossil-free 2030 "
+                "target URL and the hourly/annual disclosure fields now have "
+                "their own flags (verification_basis_v2_fossil_free_2030 and "
+                "verification_basis_v2_hourly_annual respectively). Set "
+                "everyone=None (default) for per-user/per-group rollout; flip "
+                "everyone=True for the global October 2026 switchover."
             ),
         },
     )

--- a/src/apps/accounts/migrations/0110_create_split_verification_basis_v2_flags.py
+++ b/src/apps/accounts/migrations/0110_create_split_verification_basis_v2_flags.py
@@ -1,0 +1,99 @@
+# Generated manually on 2026-07-15
+
+from django.db import migrations
+
+
+FOSSIL_FREE_2030_NOTE = (
+    "Controls the visibility of the fossil-free 2030 target URL field "
+    "(public_2030_target_url) in the provider request wizard org-details step "
+    "and the provider-portal request detail view. Set everyone=None (default) "
+    "for per-user/per-group rollout; flip everyone=True for the global October "
+    "2026 switchover."
+)
+
+HOURLY_ANNUAL_NOTE = (
+    "Controls the visibility of the hourly/annual fossil-free energy matching "
+    "fields (fossil_free_energy_matching and, in conjunction with "
+    "verification_basis_v2_claimed_percentage, claim_coverage_percentage) on "
+    "the evidence step of the provider request wizard. Set everyone=None "
+    "(default) for per-user/per-group rollout; flip everyone=True for the "
+    "global October 2026 switchover."
+)
+
+VERIFICATION_BASIS_V2_UPDATED_NOTE = (
+    "Controls visibility of October 2026 verification basis criteria in "
+    "request forms (get_active_version, upstream_providers field, legacy slug "
+    "conversion, upstream_section_enabled template tag, and the evidence intro "
+    "text swap). Note: the fossil-free 2030 target URL and the hourly/annual "
+    "disclosure fields now have their own flags "
+    "(verification_basis_v2_fossil_free_2030 and "
+    "verification_basis_v2_hourly_annual respectively). Set everyone=None "
+    "(default) for per-user/per-group rollout; flip everyone=True for the "
+    "global October 2026 switchover."
+)
+
+
+def create_split_flags_and_update_note(apps, schema_editor):
+    """
+    Create the two new split waffle flags and update the note on the
+    existing ``verification_basis_v2`` flag to reflect its narrowed scope.
+
+    ``everyone=None`` (rather than ``False``) is required so that waffle's
+    ``Flag.is_active`` falls through from the ``everyone`` short-circuit to
+    the per-user / per-group checks. With ``everyone=False``, waffle returns
+    False immediately and never consults the ``users`` / ``groups`` M2M
+    relations, which would make the planned per-user rollout a no-op.
+    Superusers/staff/authenticated are also left unset for the same reason.
+    """
+    Flag = apps.get_model("waffle", "Flag")
+
+    Flag.objects.get_or_create(
+        name="verification_basis_v2_fossil_free_2030",
+        defaults={
+            "everyone": None,
+            "superusers": False,
+            "staff": False,
+            "authenticated": False,
+            "note": FOSSIL_FREE_2030_NOTE,
+        },
+    )
+
+    Flag.objects.get_or_create(
+        name="verification_basis_v2_hourly_annual",
+        defaults={
+            "everyone": None,
+            "superusers": False,
+            "staff": False,
+            "authenticated": False,
+            "note": HOURLY_ANNUAL_NOTE,
+        },
+    )
+
+    Flag.objects.filter(name="verification_basis_v2").update(
+        note=VERIFICATION_BASIS_V2_UPDATED_NOTE,
+    )
+
+
+def remove_split_flags_and_restore_note(apps, schema_editor):
+    Flag = apps.get_model("waffle", "Flag")
+    Flag.objects.filter(
+        name__in=[
+            "verification_basis_v2_fossil_free_2030",
+            "verification_basis_v2_hourly_annual",
+        ]
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0109_create_claim_percentage_flag"),
+        ("waffle", "0004_update_everyone_nullbooleanfield"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_split_flags_and_update_note,
+            reverse_code=remove_split_flags_and_restore_note,
+        ),
+    ]

--- a/src/apps/accounts/models/hosting/provider.py
+++ b/src/apps/accounts/models/hosting/provider.py
@@ -55,6 +55,13 @@ class VerificationBasisVersion(models.TextChoices):
     while pre-existing records are backfilled to ``JUNE_2026``. Which
     version is surfaced to end users is controlled by the
     ``verification_basis_v2`` waffle flag via :func:`get_active_version`.
+
+    Note: the ``verification_basis_v2`` flag now controls only October 2026
+    verification bases / upstream providers / intro text. The fossil-free 2030
+    target URL and the hourly/annual disclosure fields have been split out
+    into their own flags (``verification_basis_v2_fossil_free_2030`` and
+    ``verification_basis_v2_hourly_annual`` respectively) and are no longer
+    tied to this flag.
     """
 
     JUNE_2026 = "2026-06", "Current (June 2026)"
@@ -71,6 +78,10 @@ def get_active_version(request=None) -> str:
     cannot be safely evaluated, so the June 2026 version is returned as a
     conservative fallback. This avoids hitting ``request.GET`` /
     ``request.user`` on a ``None`` request inside waffle.
+
+    Note: this flag controls only the October 2026 verification bases. The
+    fossil-free 2030 target URL and the hourly/annual disclosure fields have
+    their own flags and are consulted independently in their respective forms.
     """
     if request is None:
         return VerificationBasisVersion.JUNE_2026

--- a/src/apps/accounts/templates/provider_portal/request_detail.html
+++ b/src/apps/accounts/templates/provider_portal/request_detail.html
@@ -75,7 +75,7 @@
             <td>Description</td>
             <td>{{ object.description }}</td>
           </tr>
-          {% flag "verification_basis_v2" %}
+          {% flag "verification_basis_v2_fossil_free_2030" %}
           <tr>
             <td>Public 2030 target</td>
             <td>

--- a/src/apps/accounts/tests/test_provider_request.py
+++ b/src/apps/accounts/tests/test_provider_request.py
@@ -3414,11 +3414,11 @@ def test_credential_form_hides_matching_fields_when_request_is_none():
 
 
 @pytest.mark.django_db
-@override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 @override_flag("verification_basis_v2_claimed_percentage", active=True)
 def test_credential_form_shows_matching_fields_when_flag_on(user):
     """
-    With verification_basis_v2 and verification_basis_v2_claimed_percentage ON,
+    With verification_basis_v2_hourly_annual and verification_basis_v2_claimed_percentage ON,
     both new fields appear. claim_coverage_percentage is optional.
     both sit immediately before ``description``.
     """
@@ -3445,7 +3445,7 @@ def test_credential_form_shows_matching_fields_when_flag_on(user):
 
 
 @pytest.mark.django_db
-@override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 def test_credential_form_coverage_percentage_optional_when_flag_on(user):
     """
     With the flag ON, claim_coverage_percentage remains optional: a form
@@ -3470,7 +3470,7 @@ def test_credential_form_coverage_percentage_optional_when_flag_on(user):
     assert form.is_valid(), form.errors
 
 @pytest.mark.django_db
-@override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 def test_evidence_form_defaults_to_annual_when_matching_field_not_set(user):
     from apps.accounts.forms.provider_request_wizard import CredentialForm
 
@@ -3495,7 +3495,7 @@ def test_evidence_form_defaults_to_annual_when_matching_field_not_set(user):
 
 
 @pytest.mark.django_db
-@override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 @pytest.mark.parametrize(
     "value,should_be_valid",
     [
@@ -3547,6 +3547,7 @@ def _walk_to_evidence_step(client, user, org_details, org_location, services):
 
 @pytest.mark.django_db
 @override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 @override_flag("verification_basis_v2_claimed_percentage", active=True)
 def test_wizard_evidence_step_renders_new_fields_when_flag_on(
     user,
@@ -3557,10 +3558,11 @@ def test_wizard_evidence_step_renders_new_fields_when_flag_on(
     wizard_form_verification_bases_data,
 ):
     """
-    Given the verification_basis_v2 and verification_basis_v2_claimed_percentage flags
-    are ON, the green-evidence step surfaces the fossil_free_energy_matching and
-    claim_coverage_percentage form fields immediately above the description textarea,
-    and hides the legacy "avoid, reduce, or offset" intro sentence (superseded by the
+    Given the verification_basis_v2, verification_basis_v2_hourly_annual and
+    verification_basis_v2_claimed_percentage flags are ON, the green-evidence
+    step surfaces the fossil_free_energy_matching and claim_coverage_percentage
+    form fields immediately above the description textarea, and hides the
+    legacy "avoid, reduce, or offset" intro sentence (superseded by the
     October 2026 criteria wording).
     """
     _walk_to_evidence_step(
@@ -3648,6 +3650,7 @@ def test_wizard_evidence_step_hides_new_fields_when_flag_off(
 
 @pytest.mark.django_db
 @override_flag("verification_basis_v2", active=True)
+@override_flag("verification_basis_v2_hourly_annual", active=True)
 def test_wizard_preview_renders_new_fields_when_flag_on(
     user,
     client,
@@ -3798,3 +3801,70 @@ def test_provider_request_evidence_inline_includes_new_fields():
     }
     assert "fossil_free_energy_matching" in inline_field_names
     assert "claim_coverage_percentage" in inline_field_names
+
+
+# --- Flag independence tests ---
+#
+# These guard against future regressions where someone re-couples the three
+# features (fossil-free 2030 link, hourly/annual disclosures, October 2026
+# verification bases) to a single flag. Each test enables exactly ONE of the
+# three flags and asserts only its own feature surfaces.
+
+
+@pytest.mark.django_db
+@override_flag("verification_basis_v2_hourly_annual", active=True)
+def test_credential_form_shows_matching_fields_with_only_hourly_annual_flag(user):
+    """
+    With ONLY ``verification_basis_v2_hourly_annual`` ON (and
+    ``verification_basis_v2`` OFF), the matching and coverage fields appear
+    on ``CredentialForm``. This proves the hourly/annual feature is decoupled
+    from the October 2026 verification bases flag.
+    """
+    from apps.accounts.forms.provider_request_wizard import CredentialForm
+
+    request = RequestFactory().get("/")
+    request.user = user
+
+    form = CredentialForm(request=request)
+
+    assert "fossil_free_energy_matching" in form.fields
+    assert "claim_coverage_percentage" in form.fields
+
+
+@pytest.mark.django_db
+@override_flag("verification_basis_v2_fossil_free_2030", active=True)
+def test_org_details_form_shows_2030_field_with_only_fossil_free_flag(user):
+    """
+    With ONLY ``verification_basis_v2_fossil_free_2030`` ON (and
+    ``verification_basis_v2`` OFF), the ``public_2030_target_url`` field
+    appears on ``OrgDetailsForm``. This proves the fossil-free 2030 feature
+    is decoupled from the October 2026 verification bases flag.
+    """
+    from apps.accounts.forms.provider_request_wizard import OrgDetailsForm
+
+    request = RequestFactory().get("/")
+    request.user = user
+
+    form = OrgDetailsForm(request=request)
+
+    assert "public_2030_target_url" in form.fields
+
+
+@pytest.mark.django_db
+@override_flag("verification_basis_v2", active=True)
+def test_verification_bases_return_october_with_only_v2_flag(user):
+    """
+    With ONLY ``verification_basis_v2`` ON (and the other two flags OFF),
+    ``get_active_version`` returns the October 2026 version. This proves the
+    October 2026 verification bases feature is decoupled from the fossil-free
+    2030 and hourly/annual flags.
+    """
+    from apps.accounts.models.hosting.provider import (
+        VerificationBasisVersion,
+        get_active_version,
+    )
+
+    request = RequestFactory().get("/")
+    request.user = user
+
+    assert get_active_version(request) == VerificationBasisVersion.OCTOBER_2026

--- a/src/apps/accounts/views/provider/request/wizard.py
+++ b/src/apps/accounts/views/provider/request/wizard.py
@@ -401,9 +401,9 @@ class ProviderRequestWizardView(LoginRequiredMixin, SessionWizardView):
             kwargs["request"] = self.request
 
         # The green evidence step is a formset; ``form_kwargs`` is threaded
-        # to each child ``CredentialForm.__init__`` so it can consult the
-        # ``verification_basis_v2`` waffle flag to show/hide the matching
-        # and coverage fields.
+        # to each child ``CredentialForm.__init__``. This allows them to
+        # consult `verification_basis_v2` waffle flags and decide to
+        # show/hide the annual / hourly matching, or fossil free coverage fields.
         if step == self.Steps.GREEN_EVIDENCE.value:
             kwargs["form_kwargs"] = {"request": self.request}
 


### PR DESCRIPTION
This PR decomposes the earlier verification_v2 flag behaviour which couple together three different things we intend introduce in October:

1. allowing providers to list where the 2030 target is. 
2. allowing providers to mark any disclosure as evidence of annual or hourly matching for fossil free energy
3. Switching on the different kinds of verification basis we will be adopting in October

Machine generated summary below

---

This pull request splits the previous single `verification_basis_v2` waffle flag into three independent flags, each controlling a distinct feature in the provider request wizard and related forms. This decoupling allows for granular, per-feature rollouts and ensures that enabling/disabling one feature does not affect the others. The changes include new migration logic, updates to forms, templates, and tests to reference the new flags, as well as additional tests to guarantee the features remain independent.

**Feature flag decoupling and migration:**

* Added a new migration (`0110_create_split_verification_basis_v2_flags.py`) to create two new flags: `verification_basis_v2_fossil_free_2030` (controls the fossil-free 2030 target URL field) and `verification_basis_v2_hourly_annual` (controls the hourly/annual disclosure fields), and updated the note on the original `verification_basis_v2` flag to clarify its narrowed scope.
* Updated existing migration (`0104_create_verification_basis_v2_flag.py`) to clarify in the flag note that the 2030 target URL and hourly/annual fields now have their own flags.

**Form and template updates:**

* Updated `CredentialForm` and `OrgDetailsForm` to consult the new, more specific flags (`verification_basis_v2_hourly_annual` and `verification_basis_v2_fossil_free_2030`) rather than the general `verification_basis_v2` flag, ensuring each field is shown/hidden independently. [[1]](diffhunk://#diff-7ebd7721bb14b99a273992bbdc6d03230342977a6c1be0df06d5c4b7892f46e3L374-R378) [[2]](diffhunk://#diff-7ebd7721bb14b99a273992bbdc6d03230342977a6c1be0df06d5c4b7892f46e3L444-R444) [[3]](diffhunk://#diff-7ebd7721bb14b99a273992bbdc6d03230342977a6c1be0df06d5c4b7892f46e3L816-R828)
* Updated the provider portal request detail template to use the new `verification_basis_v2_fossil_free_2030` flag for the 2030 target URL field.

**Model and documentation updates:**

* Updated docstrings and comments in `VerificationBasisVersion` and `get_active_version()` to clarify the new scope and independence of each flag. [[1]](diffhunk://#diff-d98fb6f818ab8efb831929b26cfea35b86602efe46a5e0ce4d8940cf81786300R58-R64) [[2]](diffhunk://#diff-d98fb6f818ab8efb831929b26cfea35b86602efe46a5e0ce4d8940cf81786300R81-R84)

**Test suite improvements:**

* Updated and expanded tests to use the correct, feature-specific flags, and added new tests to ensure that each feature surfaces only when its corresponding flag is enabled, confirming the decoupling. [[1]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89L3417-R3421) [[2]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89L3448-R3448) [[3]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89L3473-R3473) [[4]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89L3498-R3498) [[5]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89R3550) [[6]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89L3560-R3565) [[7]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89R3653) [[8]](diffhunk://#diff-5fe38747bca480e3cc2746cc2431f6beafc90497a22c410f8c73d3b077ad8c89R3804-R3870)

**View logic clarification:**

* Updated comments in the wizard view to reflect the new flag structure and clarify how form kwargs are used to control field visibility.